### PR TITLE
Fix WSL build with idempotent artifacts

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -244,14 +244,17 @@ jobs:
         with:
           path: ${{ env.artifactsPath }}
       - name: Copy modified artifacts to base wiki
+        id: modified-artifacts
         if: ${{ github.event.inputs.upload == 'yes' }}
         run: |
           set -eu
           ls -lR ${{ env.artifactsPath }}
+
           mkdir -p build-info/
-          cp -a ${{ env.artifactsPath }}/build-artifacts-*/*.md build-info/
+          cp -a ${{ env.artifactsPath }}/build-artifacts-*/*.md build-info/ || exit 0
+          echo "::set-output name=needs-wiki-update::true"
       - name: Sync wiki to repository documentation
-        if: ${{ github.event.inputs.upload == 'yes' }}
+        if: ${{ steps.modified-artifacts.outputs.needs-wiki-update == 'true' }}
         run: |
           set -eux
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
This fixes the detection of any changes in any directory that we inspect (launcher, build and metadata like images), as multiple builds of the launcher is now not idemnpotent.

There are also some annotations added for build parameters that were passed on and also if there was a build upload.
- Example of a job with one build upload: https://github.com/ubuntu/WSL/actions/runs/1319671750
- Example of a job without any build upload: https://github.com/ubuntu/WSL/actions/runs/1319840969

The format of the fingerprinting changed to be more readable on the wiki: https://github.com/ubuntu/WSL/wiki/UbuntuPreview-fingerprint

Finally, fix UbuntuPreview to publish images automatically.
