### PR TITLE
Prepare-build now can copy a local rootfs file.

### DIFF
--- a/wsl-builder/prepare-build/main.go
+++ b/wsl-builder/prepare-build/main.go
@@ -43,8 +43,9 @@ func main() {
 	prepareBuildCmd := &cobra.Command{
 		Use:   "prepare BUILDID_PATH WSL_ID ROOTFSES",
 		Short: "Prepares the build source before calling msbuild",
-		Long: `This downloads the root file systems and prepares the build before
-		       building the appx bundle`,
+		Long: `This gets the root file systems and prepares the build before building 
+			the appx bundle. ROOTFSES must be a comma separated list of
+			local file paths or urls each followed by ::<arch>`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return prepareBuild(args[0], args[1], args[2], *noChecksum, *buildID)


### PR DESCRIPTION
With the proposed changes one now can `./prepare-build.exe prepare UbuntuPreview build.txt ~/Downloads/impish_exit_0_oobe.tar.gz::amd64` for example. That command will copy the file from that path supplied if valid, instead of downloading from some cloud, which improves testability by enabling developers to customize their images as they wish and ensure the WSL building workflow stays the same.