### PR TITLE
Adjust wsl-setup path

### DIFF
--- a/DistroLauncher/OOBE.h
+++ b/DistroLauncher/OOBE.h
@@ -32,5 +32,5 @@ namespace DistributionInfo {
     std::wstring GetPrefillInfoInYaml();
 
     // OOBE executable name.
-    static TCHAR* OOBE_NAME = L"/usr/lib/libexec/wsl-setup";
+    static TCHAR* OOBE_NAME = L"/usr/libexec/wsl-setup";
 }


### PR DESCRIPTION
It was wrongly shipped in /usr/lib/libexec instead of /usr/libexec.