### PR TITLE
Fallback OOBE into text mode if graphics are not supported

### DIFF
--- a/DistroLauncher/.clang-tidy
+++ b/DistroLauncher/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: 'bugprone-*,readability-*,google-readability-casting'
+HeaderFilterRegex: '.*'

--- a/DistroLauncher/.clang-tidy
+++ b/DistroLauncher/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: 'bugprone-*,readability-*,google-readability-casting'
-HeaderFilterRegex: '.*'
+Checks: 'bugprone-*,performance-*,readability-*,google-readability-casting'
+HeaderFilterRegex: .*

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="WslApiLoader.h" />
+    <ClInclude Include="WSLInfo.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DistributionInfo.cpp" />
@@ -158,6 +159,7 @@
     </ClCompile>
     <ClCompile Include="WindowsUserInfo.cpp" />
     <ClCompile Include="WslApiLoader.cpp" />
+    <ClCompile Include="WSLInfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="DistroLauncher.rc" />

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -242,7 +242,6 @@ namespace DistributionInfo {
 			switch (value[0]) {
 			case L'1': // forced text mode.
 				return true;
-				break;
 			case L'2': // forced GUI mode, no autodetection.
 				return false;
 			case L'0':

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -23,19 +23,19 @@ namespace DistributionInfo {
 		std::wstring PreparePrefillInfo();
 		HRESULT OOBEStatusHandling(std::wstring_view status);
 		bool EnsureStopped(unsigned int maxNoOfRetries);
-		static TCHAR* OOBE_NAME = L"/usr/libexec/wsl-setup";
+		const TCHAR* OOBE_NAME = L"/usr/libexec/wsl-setup";
 	}
 
-	bool DistributionInfo::isOOBEAvailable(){
+	bool isOOBEAvailable(){
 		DWORD exitCode=-1;
 		std::wstring whichCdm{ L"which " };
 		whichCdm.append(DistributionInfo::OOBE_NAME);
-		HRESULT hr = g_wslApi.WslLaunchInteractive(whichCdm.c_str(), true, &exitCode);
+		HRESULT hr = g_wslApi.WslLaunchInteractive(whichCdm.c_str(), TRUE, &exitCode);
 		// true if launching the process succeeds and `which` command returns 0.
 		return ((SUCCEEDED(hr)) && (exitCode == 0));
 	}
 
-	HRESULT DistributionInfo::OOBESetup()
+	HRESULT OOBESetup()
 	{
 		// Prepare prefill information to send to the OOBE.
 		std::wstring prefillCLIPostFix = DistributionInfo::PreparePrefillInfo();
@@ -46,12 +46,12 @@ namespace DistributionInfo {
 		}
 		// calling the OOBE.
 		DWORD exitCode=-1;
-		HRESULT hr = g_wslApi.WslLaunchInteractive(commandLine.c_str(), true, &exitCode);
+		HRESULT hr = g_wslApi.WslLaunchInteractive(commandLine.c_str(), TRUE, &exitCode);
 		if ((FAILED(hr)) || (exitCode != 0)) {
 			return hr;
 		}
 
-		hr = g_wslApi.WslLaunchInteractive(L"clear", true, &exitCode);
+		hr = g_wslApi.WslLaunchInteractive(L"clear", TRUE, &exitCode);
 		if (FAILED(hr)) {
 			return hr;
 		}

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -1,20 +1,19 @@
-//
-//    Copyright: 2021, Canonical Ltd.
-//  License: GPL-3
-//  This program is free software : you can redistribute itand /or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License.
-//  .
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
-//  GNU General Public License for more details.
-//  .
-//  You should have received a copy of the GNU General Public License
-//  along with this program.If not, see < https://www.gnu.org/licenses/>.
-//  .
-//  On Debian systems, the complete text of the GNU General
-//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #include "stdafx.h"
 

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -41,6 +41,10 @@ namespace DistributionInfo {
 		// Prepare prefill information to send to the OOBE.
 		std::wstring prefillCLIPostFix = DistributionInfo::PreparePrefillInfo();
 		std::wstring commandLine = DistributionInfo::OOBE_NAME + prefillCLIPostFix;
+		// Fallback OOBE to text mode if graphics are not supported.
+		if (!Helpers::WslGraphicsSupported()) {
+			commandLine.append(L" --text");
+		}
 		// calling the OOBE.
 		DWORD exitCode=-1;
 		HRESULT hr = g_wslApi.WslLaunchInteractive(commandLine.c_str(), true, &exitCode);

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -169,7 +169,7 @@ namespace DistributionInfo {
 
 			// Before relaunching, give WSL some time to make sure 
 			// distro is stopped.
-			bool stopSuccess = EnsureStopped(30u);
+			bool stopSuccess = EnsureStopped(30);
 			if (!stopSuccess) {
 				// We could try again, but who knows why
 				// we failed to stop the distro in the first time.
@@ -210,7 +210,7 @@ namespace DistributionInfo {
 				}
 
 				// We don't need to be hard real time precise.
-				Sleep(997u);
+				Sleep(997);
 			}
 			return false;
 		}

--- a/DistroLauncher/OOBE.h
+++ b/DistroLauncher/OOBE.h
@@ -1,20 +1,19 @@
-//
-//    Copyright: 2021, Canonical Ltd.
-//  License: GPL-3
-//  This program is free software : you can redistribute itand /or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License.
-//  .
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
-//  GNU General Public License for more details.
-//  .
-//  You should have received a copy of the GNU General Public License
-//  along with this program.If not, see < https://www.gnu.org/licenses/>.
-//  .
-//  On Debian systems, the complete text of the GNU General
-//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #pragma once
 

--- a/DistroLauncher/ProcessRunner.cpp
+++ b/DistroLauncher/ProcessRunner.cpp
@@ -1,3 +1,22 @@
+//
+//    Copyright: 2021, Canonical Ltd.
+//  License: GPL-3
+//  This program is free software : you can redistribute itand /or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License.
+//  .
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+//  GNU General Public License for more details.
+//  .
+//  You should have received a copy of the GNU General Public License
+//  along with this program.If not, see < https://www.gnu.org/licenses/>.
+//  .
+//  On Debian systems, the complete text of the GNU General
+//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+//
+
 #include "stdafx.h"
 
 namespace Helpers {

--- a/DistroLauncher/ProcessRunner.cpp
+++ b/DistroLauncher/ProcessRunner.cpp
@@ -1,21 +1,19 @@
-//
-//    Copyright: 2021, Canonical Ltd.
-//  License: GPL-3
-//  This program is free software : you can redistribute itand /or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License.
-//  .
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
-//  GNU General Public License for more details.
-//  .
-//  You should have received a copy of the GNU General Public License
-//  along with this program.If not, see < https://www.gnu.org/licenses/>.
-//  .
-//  On Debian systems, the complete text of the GNU General
-//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-//
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #include "stdafx.h"
 

--- a/DistroLauncher/ProcessRunner.cpp
+++ b/DistroLauncher/ProcessRunner.cpp
@@ -45,7 +45,7 @@ namespace Helpers {
 
     }
 
-    bool ProcessRunner::isDefunct() {
+    bool ProcessRunner::isDefunct() const {
         return defunct;
     }
 
@@ -55,15 +55,15 @@ namespace Helpers {
         exit_code = ERROR_PROCESS_ABORTED;
     }
 
-    std::wstring_view ProcessRunner::getStdErr() {
+    std::wstring_view ProcessRunner::getStdErr() const {
         return stdErr;
     }
 
-    std::wstring_view ProcessRunner::getStdOut() {
+    std::wstring_view ProcessRunner::getStdOut() const {
         return stdOut;
     }
 
-    DWORD ProcessRunner::getExitCode() {
+    DWORD ProcessRunner::getExitCode() const {
         return exit_code;
     }
 
@@ -111,7 +111,7 @@ namespace Helpers {
         DWORD dwRead;
         const size_t BUFSIZE = 80;
         TCHAR chBuf[BUFSIZE];
-        bool bSuccess = FALSE;
+        BOOL bSuccess = FALSE;
         for (;;) {
             bSuccess = ReadFile(g_hChildStd_OUT_Rd, chBuf, BUFSIZE, &dwRead, NULL);
             if (!bSuccess || dwRead == 0) {

--- a/DistroLauncher/ProcessRunner.cpp
+++ b/DistroLauncher/ProcessRunner.cpp
@@ -92,8 +92,8 @@ namespace Helpers {
         }
 
         read_pipes();
-        WaitForSingleObject(_piProcInfo.hProcess, 1000u);
-        auto iDontKnow = GetExitCodeProcess(_piProcInfo.hProcess, &exit_code);
+        WaitForSingleObject(_piProcInfo.hProcess, 1000);
+        GetExitCodeProcess(_piProcInfo.hProcess, &exit_code);
         alreadyRun = true;
         return exit_code;
     }
@@ -109,7 +109,7 @@ namespace Helpers {
 
     void ProcessRunner::read_pipes() {
         DWORD dwRead;
-        const size_t BUFSIZE = 80u;
+        const size_t BUFSIZE = 80;
         TCHAR chBuf[BUFSIZE];
         bool bSuccess = FALSE;
         for (;;) {

--- a/DistroLauncher/ProcessRunner.h
+++ b/DistroLauncher/ProcessRunner.h
@@ -60,7 +60,7 @@ namespace Helpers {
         // The runner is considered defunct if it fails to construct the pipe
         // which will conduct the standard streams.
         // This is a way to avoid the need for exceptions.
-        bool isDefunct();
+        bool isDefunct() const;
 
         // Runs the CLI given to constructor and returns it's exit code.
         // If called more than once, returns the cached exit code.
@@ -68,13 +68,13 @@ namespace Helpers {
         DWORD run();
 
         // Returns the cached exit code.
-        DWORD getExitCode();
+        DWORD getExitCode() const;
 
         // Returns a view of the process standard output stream.
-        std::wstring_view getStdOut();
+        std::wstring_view getStdOut() const;
 
         // Returns a view of the process standard error stream.
-        std::wstring_view getStdErr();
+        std::wstring_view getStdErr() const;
 
         ~ProcessRunner();
     };

--- a/DistroLauncher/ProcessRunner.h
+++ b/DistroLauncher/ProcessRunner.h
@@ -1,4 +1,24 @@
+//
+//    Copyright: 2021, Canonical Ltd.
+//  License: GPL-3
+//  This program is free software : you can redistribute itand /or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License.
+//  .
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+//  GNU General Public License for more details.
+//  .
+//  You should have received a copy of the GNU General Public License
+//  along with this program.If not, see < https://www.gnu.org/licenses/>.
+//  .
+//  On Debian systems, the complete text of the GNU General
+//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+//
+
 #pragma once
+
 // Wraps up Win32 API's into an run-once-and-discard object
 // to launch an external process and capture its outputs.
 // Once created it cannot be reassigned, nor reused,

--- a/DistroLauncher/ProcessRunner.h
+++ b/DistroLauncher/ProcessRunner.h
@@ -1,21 +1,19 @@
-//
-//    Copyright: 2021, Canonical Ltd.
-//  License: GPL-3
-//  This program is free software : you can redistribute itand /or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License.
-//  .
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
-//  GNU General Public License for more details.
-//  .
-//  You should have received a copy of the GNU General Public License
-//  along with this program.If not, see < https://www.gnu.org/licenses/>.
-//  .
-//  On Debian systems, the complete text of the GNU General
-//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-//
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #pragma once
 

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -1,0 +1,133 @@
+//
+//    Copyright: 2021, Canonical Ltd.
+//  License: GPL-3
+//  This program is free software : you can redistribute itand /or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License.
+//  .
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+//  GNU General Public License for more details.
+//  .
+//  You should have received a copy of the GNU General Public License
+//  along with this program.If not, see < https://www.gnu.org/licenses/>.
+//  .
+//  On Debian systems, the complete text of the GNU General
+//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+//
+
+#include "stdafx.h"
+
+namespace Helpers {
+    namespace {
+        bool isX11UnixSocketMounted();
+        bool isWSLVDCPluginRegistered();
+    }
+
+    // Altough currently only used in this translation unit,
+    // this function has a lot of potential to not be exported.
+    bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds) {
+        DWORD exitCode;
+        HANDLE child;
+        HRESULT hr = g_wslApi.WslLaunch(command, false, NULL, NULL, NULL, &child);
+        if (child == NULL || FAILED(hr)) {
+            return false;
+        }
+
+        WaitForSingleObject(child, dwMilisseconds);
+        auto success = GetExitCodeProcess(child, &exitCode);
+        CloseHandle(child);
+        if (success == FALSE || exitCode != 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // Retrieves subsystem version from the WSL API.
+    DWORD WslGetDistroSubsystemVersion() {
+        ULONG distributionVersion;
+        ULONG defaultUID;
+        WSL_DISTRIBUTION_FLAGS wslDistributionFlags;
+        PSTR* defaultEnvironmentVariables;
+        ULONG defaultEnvironmentVariableCount;
+
+        HRESULT hr = g_wslApi.WslGetDistributionConfiguration(&distributionVersion,
+                                                              &defaultUID,
+                                                              &wslDistributionFlags,
+                                                              &defaultEnvironmentVariables,
+                                                              &defaultEnvironmentVariableCount);
+        if (FAILED(hr) || distributionVersion == 0) {
+            Helpers::PrintErrorMessage(hr);
+            return 0;
+        }
+
+        // discards the env variable string array otherwise they will leak.
+        for (int i = defaultEnvironmentVariableCount-1; i >= 0; --i) {
+            CoTaskMemFree((LPVOID)(defaultEnvironmentVariables[i]));
+        }
+
+        return distributionVersion;
+    }
+
+    bool isWslgEnabled() {
+        return isX11UnixSocketMounted() && isWSLVDCPluginRegistered();
+    }
+
+    bool WslGraphicsSupported() {
+        // Could WSL 3 or greater exist in the future?
+        if(Helpers::isWslgEnabled() &&
+            Helpers::WslGetDistroSubsystemVersion() > 1u) {
+            return true;
+        }
+
+        return false;
+    }
+     
+/* =========================== INTERNALS ================================== */
+    namespace {
+        // Returns true if the WSLDVCPlugin.dll is found.
+        // That is an indication that WSLg is installed.
+        // Search paths are empirical and subject to change.
+        bool isWSLVDCPluginRegistered() {
+            //TODO: if this hack survives, find more possible locations
+            // from other versions of Windows and different locales,
+            // since default search paths couldn't find that plugin.
+            std::array searchPaths = {
+                L"C:\\ProgramData\\Microsoft\\WSL\\WSLDVCPlugin.dll",
+                L"C:\\Windows\\System32\\WSLDVCPlugin.dll",
+            };
+            for (auto sp : searchPaths) {
+                auto wsldvc = LoadLibraryEx(sp, nullptr, 
+                                            LOAD_WITH_ALTERED_SEARCH_PATH |
+                                              LOAD_LIBRARY_AS_IMAGE_RESOURCE);
+                if (wsldvc != nullptr) {
+                    FreeLibrary(wsldvc);
+                    return true;
+                }
+            }
+            
+            PrintMessage(MSG_ERROR_CODE, HRESULT_FROM_WIN32(GetLastError()),
+                        L"Failed to stat WSLDVCPlugin.dll");
+            return false;
+        }
+
+        // Returns true if the WSL successfully launches a list
+        // of commands to ensure X11 socket is properly mounted.
+        // One indication that the distro has graphical support enabled.
+        bool isX11UnixSocketMounted() {
+            const std::array cmds = {
+                L"ls -l /tmp/.X11-unix",
+                L"ss -lx | grep \"/tmp/.X11-unix/X0\"",
+            };
+            for (auto cmd : cmds) {
+                if (!WslLaunchSuccess(cmd, 500u)) {
+                    wprintf(L"Command %s failed.\n", cmd);
+                    return false;
+                }
+            }
+            return true;
+        } 
+    } // namespace.
+} // namespace Helpers.

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -20,7 +20,6 @@
 namespace Helpers {
     namespace {
         bool isX11UnixSocketMounted();
-        bool isWSLVDCPluginRegistered();
     }
 
     // Altough currently only used in this translation unit,
@@ -58,8 +57,8 @@ namespace Helpers {
         }
 
         // discards the env variable string array otherwise they will leak.
-        for (int i = defaultEnvironmentVariableCount-1; i >= 0; --i) {
-            CoTaskMemFree((LPVOID)(defaultEnvironmentVariables[i]));
+        for (int64_t i = defaultEnvironmentVariableCount-1; i >= 0; --i) {
+            CoTaskMemFree(static_cast<LPVOID>(defaultEnvironmentVariables[i]));
         }
 
         return distributionVersion;
@@ -71,12 +70,8 @@ namespace Helpers {
 
     bool WslGraphicsSupported() {
         // Could WSL 3 or greater exist in the future?
-        if(Helpers::isWslgEnabled() &&
-            Helpers::WslGetDistroSubsystemVersion() > 1) {
-            return true;
-        }
-
-        return false;
+        return (Helpers::isWslgEnabled() &&
+                Helpers::WslGetDistroSubsystemVersion() > 1);
     }
      
 /* =========================== INTERNALS ================================== */
@@ -89,12 +84,15 @@ namespace Helpers {
                 L"ls -l /tmp/.X11-unix",
                 L"ss -lx | grep \"/tmp/.X11-unix/X0\"",
             };
-            for (auto cmd : cmds) {
-                if (!WslLaunchSuccess(cmd, 500)) {
+            // I'm sure is better to read this way than with the algorithm.
+            // NOLINTNEXTLINE(readability-use-anyofallof)
+            for (const auto *const cmd : cmds) {
+                if (!WslLaunchSuccess(cmd)) {
                     wprintf(L"Command %s failed.\n", cmd);
                     return false;
                 }
             }
+
             return true;
         } 
     } // namespace.

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -1,21 +1,19 @@
-//
-//    Copyright: 2021, Canonical Ltd.
-//  License: GPL-3
-//  This program is free software : you can redistribute itand /or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License.
-//  .
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
-//  GNU General Public License for more details.
-//  .
-//  You should have received a copy of the GNU General Public License
-//  along with this program.If not, see < https://www.gnu.org/licenses/>.
-//  .
-//  On Debian systems, the complete text of the GNU General
-//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-//
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #include "stdafx.h"
 

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -28,7 +28,7 @@ namespace Helpers {
     bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds) {
         DWORD exitCode;
         HANDLE child;
-        HRESULT hr = g_wslApi.WslLaunch(command, false, NULL, NULL, NULL, &child);
+        HRESULT hr = g_wslApi.WslLaunch(command, FALSE, NULL, NULL, NULL, &child);
         if (child == NULL || FAILED(hr)) {
             return false;
         }
@@ -36,11 +36,7 @@ namespace Helpers {
         WaitForSingleObject(child, dwMilisseconds);
         auto success = GetExitCodeProcess(child, &exitCode);
         CloseHandle(child);
-        if (success == FALSE || exitCode != 0) {
-            return false;
-        }
-
-        return true;
+        return (success == TRUE && exitCode == 0);
     }
 
     // Retrieves subsystem version from the WSL API.

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -69,14 +69,14 @@ namespace Helpers {
         return distributionVersion;
     }
 
-    bool isWslgEnabled() {
-        return isX11UnixSocketMounted() && isWSLVDCPluginRegistered();
+    inline bool isWslgEnabled() {
+        return isX11UnixSocketMounted();
     }
 
     bool WslGraphicsSupported() {
         // Could WSL 3 or greater exist in the future?
         if(Helpers::isWslgEnabled() &&
-            Helpers::WslGetDistroSubsystemVersion() > 1u) {
+            Helpers::WslGetDistroSubsystemVersion() > 1) {
             return true;
         }
 
@@ -85,32 +85,6 @@ namespace Helpers {
      
 /* =========================== INTERNALS ================================== */
     namespace {
-        // Returns true if the WSLDVCPlugin.dll is found.
-        // That is an indication that WSLg is installed.
-        // Search paths are empirical and subject to change.
-        bool isWSLVDCPluginRegistered() {
-            //TODO: if this hack survives, find more possible locations
-            // from other versions of Windows and different locales,
-            // since default search paths couldn't find that plugin.
-            std::array searchPaths = {
-                L"C:\\ProgramData\\Microsoft\\WSL\\WSLDVCPlugin.dll",
-                L"C:\\Windows\\System32\\WSLDVCPlugin.dll",
-            };
-            for (auto sp : searchPaths) {
-                auto wsldvc = LoadLibraryEx(sp, nullptr, 
-                                            LOAD_WITH_ALTERED_SEARCH_PATH |
-                                              LOAD_LIBRARY_AS_IMAGE_RESOURCE);
-                if (wsldvc != nullptr) {
-                    FreeLibrary(wsldvc);
-                    return true;
-                }
-            }
-            
-            PrintMessage(MSG_ERROR_CODE, HRESULT_FROM_WIN32(GetLastError()),
-                        L"Failed to stat WSLDVCPlugin.dll");
-            return false;
-        }
-
         // Returns true if the WSL successfully launches a list
         // of commands to ensure X11 socket is properly mounted.
         // One indication that the distro has graphical support enabled.
@@ -120,7 +94,7 @@ namespace Helpers {
                 L"ss -lx | grep \"/tmp/.X11-unix/X0\"",
             };
             for (auto cmd : cmds) {
-                if (!WslLaunchSuccess(cmd, 500u)) {
+                if (!WslLaunchSuccess(cmd, 500)) {
                     wprintf(L"Command %s failed.\n", cmd);
                     return false;
                 }

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -19,7 +19,7 @@
 
 namespace Helpers {
 	// Returns true if user system has WSLg enabled.
-	bool isWslgEnabled();
+	inline bool isWslgEnabled();
 
 	// Returns the subsystem version for this specific distro or 0 if failed.
 	DWORD WslGetDistroSubsystemVersion();

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -31,5 +31,6 @@ namespace Helpers {
 	// Returns true if all the commands `exit 0`.
 	// Launched command will not be interactive nor show any output,
 	// but it blocks current thread for up to dwMilisseconds.
-	bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds);
+	bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds=500); // NOLINT(readability-magic-numbers):
+	// Magic numbers in default arguments should not be an issue.
 }

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -1,21 +1,19 @@
-//
-//    Copyright: 2021, Canonical Ltd.
-//  License: GPL-3
-//  This program is free software : you can redistribute itand /or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License.
-//  .
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
-//  GNU General Public License for more details.
-//  .
-//  You should have received a copy of the GNU General Public License
-//  along with this program.If not, see < https://www.gnu.org/licenses/>.
-//  .
-//  On Debian systems, the complete text of the GNU General
-//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-//
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #pragma once
 

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -1,0 +1,37 @@
+//
+//    Copyright: 2021, Canonical Ltd.
+//  License: GPL-3
+//  This program is free software : you can redistribute itand /or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License.
+//  .
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+//  GNU General Public License for more details.
+//  .
+//  You should have received a copy of the GNU General Public License
+//  along with this program.If not, see < https://www.gnu.org/licenses/>.
+//  .
+//  On Debian systems, the complete text of the GNU General
+//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+//
+
+#pragma once
+
+namespace Helpers {
+	// Returns true if user system has WSLg enabled.
+	bool isWslgEnabled();
+
+	// Returns the subsystem version for this specific distro or 0 if failed.
+	DWORD WslGetDistroSubsystemVersion();
+
+	// Returns true if WSLg is enabled and distro subsystem versin is > 1.
+	bool WslGraphicsSupported();
+
+	// Runs a Linux command and checks for successfull exit.
+	// Returns true if all the commands `exit 0`.
+	// Launched command will not be interactive nor show any output,
+	// but it blocks current thread for up to dwMilisseconds.
+	bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds);
+}

--- a/DistroLauncher/WindowsUserInfo.cpp
+++ b/DistroLauncher/WindowsUserInfo.cpp
@@ -1,21 +1,19 @@
-//
-//    Copyright: 2021, Canonical Ltd.
-//  License: GPL-3
-//  This program is free software : you can redistribute itand /or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License.
-//  .
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
-//  GNU General Public License for more details.
-//  .
-//  You should have received a copy of the GNU General Public License
-//  along with this program.If not, see < https://www.gnu.org/licenses/>.
-//  .
-//  On Debian systems, the complete text of the GNU General
-//  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-//
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #include "stdafx.h"
 

--- a/DistroLauncher/WindowsUserInfo.cpp
+++ b/DistroLauncher/WindowsUserInfo.cpp
@@ -26,7 +26,7 @@ namespace DistributionInfo {
 			std::wstring realName;
 			std::wstring localeName;
 
-			std::wstring toYaml();
+			std::wstring toYaml() const;
 		};
 
 		// PrintLastError converts the last error code from Win32 API's into
@@ -40,7 +40,7 @@ namespace DistributionInfo {
 		// because of such small feature, which would be an overkill. Shall the need
 		// for more YAML manipulation in the DistroLauncher arise, thus function should
 		// be changed to use a proper YAML manipulation library, such as yaml-cpp.
-		std::wstring WindowsUserInfo::toYaml() {
+		std::wstring WindowsUserInfo::toYaml() const {
 			std::wstring fullYaml;
 
 			if (!localeName.empty()) {

--- a/DistroLauncher/WslApiLoader.cpp
+++ b/DistroLauncher/WslApiLoader.cpp
@@ -14,6 +14,7 @@ WslApiLoader::WslApiLoader(const std::wstring& distributionName) :
         _isDistributionRegistered = (WSL_IS_DISTRIBUTION_REGISTERED)GetProcAddress(_wslApiDll, "WslIsDistributionRegistered");
         _registerDistribution = (WSL_REGISTER_DISTRIBUTION)GetProcAddress(_wslApiDll, "WslRegisterDistribution");
         _configureDistribution = (WSL_CONFIGURE_DISTRIBUTION)GetProcAddress(_wslApiDll, "WslConfigureDistribution");
+        _getDistributionConfiguration = (WSL_GET_DISTRIBUTION_CONFIGURATION)GetProcAddress(_wslApiDll, "WslGetDistributionConfiguration");
         _launchInteractive = (WSL_LAUNCH_INTERACTIVE)GetProcAddress(_wslApiDll, "WslLaunchInteractive");
         _launch = (WSL_LAUNCH)GetProcAddress(_wslApiDll, "WslLaunch");
     }
@@ -32,6 +33,7 @@ BOOL WslApiLoader::WslIsOptionalComponentInstalled()
             (_isDistributionRegistered != nullptr) &&
             (_registerDistribution != nullptr) &&
             (_configureDistribution != nullptr) &&
+            (_getDistributionConfiguration != nullptr) &&
             (_launchInteractive != nullptr) &&
             (_launch != nullptr));
 }
@@ -59,6 +61,20 @@ HRESULT WslApiLoader::WslConfigureDistribution(ULONG defaultUID, WSL_DISTRIBUTIO
     }
 
     return hr;
+}
+
+HRESULT WslApiLoader::WslGetDistributionConfiguration(ULONG* distributionVersion,
+                                                      ULONG* defaultUID,
+                                                      WSL_DISTRIBUTION_FLAGS* wslDistributionFlags, 
+                                                      PSTR** defaultEnvironmentVariables,
+                                                      ULONG* defaultEnvironmentVariableCount)
+{
+    return _getDistributionConfiguration(_distributionName.c_str(),
+                                         distributionVersion,
+                                         defaultUID,
+                                         wslDistributionFlags,
+                                         defaultEnvironmentVariables,
+                                         defaultEnvironmentVariableCount);
 }
 
 HRESULT WslApiLoader::WslLaunchInteractive(PCWSTR command, BOOL useCurrentWorkingDirectory, DWORD *exitCode)

--- a/DistroLauncher/WslApiLoader.h
+++ b/DistroLauncher/WslApiLoader.h
@@ -33,6 +33,13 @@ class WslApiLoader
     HRESULT WslConfigureDistribution(ULONG defaultUID,
                                      WSL_DISTRIBUTION_FLAGS wslDistributionFlags);
 
+    HRESULT WslGetDistributionConfiguration(ULONG* distributionVersion,
+                                            ULONG* defaultUID,
+                                            WSL_DISTRIBUTION_FLAGS* wslDistributionFlags,
+                                            PSTR** defaultEnvironmentVariables,
+                                            ULONG* defaultEnvironmentVariableCount
+                                            );
+
     HRESULT WslLaunchInteractive(PCWSTR command,
                                  BOOL useCurrentWorkingDirectory,
                                  DWORD *exitCode);
@@ -50,6 +57,7 @@ class WslApiLoader
     WSL_IS_DISTRIBUTION_REGISTERED _isDistributionRegistered;
     WSL_REGISTER_DISTRIBUTION _registerDistribution;
     WSL_CONFIGURE_DISTRIBUTION _configureDistribution;
+    WSL_GET_DISTRIBUTION_CONFIGURATION _getDistributionConfiguration;
     WSL_LAUNCH_INTERACTIVE _launchInteractive;
     WSL_LAUNCH _launch;
 };

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <wslapi.h>
 #include <fstream>
+#include <array>
 #define SECURITY_WIN32
 #include <sspi.h>
 #include <secext.h>
@@ -34,6 +35,7 @@
 #include "DistributionInfo.h"
 #include "OOBE.h"
 #include "ProcessRunner.h"
+#include "WSLInfo.h"
 
 // Message strings compiled from .MC file.
 #include "messages.h"

--- a/wsl-builder/lp-distro-info
+++ b/wsl-builder/lp-distro-info
@@ -6,23 +6,22 @@
 #
 """
 
-# Copyright: 2021, Canonical Ltd.
-
-# License: GPL-3
-#  This program is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License.
-#  .
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY;without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#  GNU General Public License for more details.
-#  .
-#  You should have received a copy of the GNU General Public License
-#  along with this program. If not, see <https://www.gnu.org/licenses/>.
-#  .
-#  On Debian systems, the complete text of the GNU General
-#  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ #
+ # Copyright (C) 2021 Canonical Ltd
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License version 3 as
+ # published by the Free Software Foundation.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #
+ #
 
 import argparse
 import logging


### PR DESCRIPTION
There is a --text parameter added to wsl-setup, which starts the TUI instead of the snap GUI. We need to add it dynamically from the launcher:
- if wslg is not installed
- or if current distro is using wsl 1

To achieve that, WSLApiLoader was modified to expose one hidden function `WslGetDistributionConfiguration()`, which can report the recently installed distro subsystem version, default environment variables etc. For this PR the only relevant piece of information is the subsystem version.

There could be other ways to find that information, like querying the Windows registry for the default system version. That idea in particular could lead into crashes if the OOBE is ran in the future in reconfigure mode, for instance, under a distro with the version modified to WSL 1.

The graphics capability in this proposal is detected indirectly by checking if the symlink `/tmp/.X11-unix` is resolved correctly and if the corresponding socket is open and listening. Proof of concept tests proved that the socket is open right after distro registration under WSL 2 with WSLg enabled.