### PR TITLE
Misinterpreted distributionInfo var in WSLInfo.cpp

### DIFF
--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -85,7 +85,8 @@ namespace Helpers {
         // One indication that the distro has graphical support enabled.
         bool isX11UnixSocketMounted() {
             const std::array cmds = {
-                L"ls -l /tmp/.X11-unix",
+                L"ls -l /mnt/wslg",
+                L"ls -l /tmp/.X11-unix | grep wslg",
                 L"ss -lx | grep \"/tmp/.X11-unix/X0\"",
             };
             // I'm sure is better to read this way than with the algorithm.

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -85,10 +85,11 @@ namespace Helpers {
         // One indication that the distro has graphical support enabled.
         bool isX11UnixSocketMounted() {
             const std::array cmds = {
-                L"ls -l /mnt/wslg",
-                L"ls -l /tmp/.X11-unix | grep wslg",
-                L"ss -lx | grep \"/tmp/.X11-unix/X0\"",
+                L"ls -l /tmp/.X11-unix | grep wslg", // symlink points to wslg.
+                L"ls -l /tmp/.X11-unix/", // symlink resolves correctly.
+                L"ss -lx | grep \"/tmp/.X11-unix/X0\"", // socket is listening.
             };
+
             // I'm sure is better to read this way than with the algorithm.
             // NOLINTNEXTLINE(readability-use-anyofallof)
             for (const auto *const cmd : cmds) {

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -60,8 +60,12 @@ namespace Helpers {
         for (int64_t i = defaultEnvironmentVariableCount-1; i >= 0; --i) {
             CoTaskMemFree(static_cast<LPVOID>(defaultEnvironmentVariables[i]));
         }
-
-        return distributionVersion;
+        
+        // Per conversation at https://github.com/microsoft/WSL-DistroLauncher/issues/96
+        // distributionVersion is not what I thought.
+        // The actual information is on the 4th bit of the distro flags, which is not 
+        // currently referrenced by the API nor docs. The `1+` is just to ensure we return 1 or two.
+        return (1+((wslDistributionFlags & 0x08)>>3));
     }
 
     inline bool isWslgEnabled() {


### PR DESCRIPTION
Learned from Microsoft that the proper way to detect WSL1 or WSL2 is by inspecting the 4th bit of distribution flags variable written by the function `WslGetDistributionConfiguration()`.
The expression `(1+((wslDistributionFlags & 0x08)>>3))` in the return statement is just a way to evaluate that bit and return 1 or 2.