### PR TITLE
Upstream updates

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -162,6 +162,9 @@ int wmain(int argc, wchar_t const *argv[])
         if (hr == HRESULT_FROM_WIN32(ERROR_LINUX_SUBSYSTEM_NOT_PRESENT)) {
             Helpers::PrintMessage(MSG_MISSING_OPTIONAL_COMPONENT);
 
+        } else if (hr == HCS_E_HYPERV_NOT_INSTALLED) {
+            Helpers::PrintMessage(MSG_ENABLE_VIRTUALIZATION);
+
         } else {
             Helpers::PrintErrorMessage(hr);
         }

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -89,3 +89,9 @@ Language=English
 The distribution installation has become corrupted.
 Please select Reset from App Settings or uninstall and reinstall the app.
 .
+
+MessageId=1014 SymbolicName=MSG_ENABLE_VIRTUALIZATION
+Language=English
+Please enable the Virtual Machine Platform Windows feature and ensure virtualization is enabled in the BIOS.
+For information please visit https://aka.ms/enablevirtualization
+.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 This is the C++ reference implementation for a Windows Subsystem for Linux (WSL) distribution installer/launcher application. Every distro package must include a launcher app, which is responsible for completing installation & registration of your distro with WSL, and for launching new distro instances atop WSL.
 
 Once you've built your distro launcher, packaged it along with the required art assets, manifest, and distro.tar.gz, and digitally signed the package, you will be able to sideload your distro on your own machine(s).
-  
-## Important! 
-Before publishing your distro to the Windows Store, you must first reach-out to and get approval from the WSL team: wslpartners@microsoft.com. 
-
-Without testing and approval from the WSL team, distros submitted to the store will be rejected. This process is required in order to ensure the quality and integrity of the WSL distro ecosystem, and to safeguard our users.
 
 ## Goals
 The goal of this project is to enable:


### PR DESCRIPTION
Craig Lowen reported having changed the DistroLauncher code to improve the WSL experience, redirecting the user to the docs web page in case of virtualization being disabled. Also, noticed the [README file was updated recently](https://github.com/microsoft/WSL-DistroLauncher/commit/28d908d9605052c0864138ed98e858d0979f73f7). This PR captures both changes and preserves the original authors, as it should be.