### PR TITLE
Upgraded SDK version to fix HCS_E_HYPERV_NOT_INSTALLED undeclared

### DIFF
--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{BA627106-E5F7-46EE-B8D7-2D5A760F2FB2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DistroLauncher</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <ProjectName>launcher</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu</TargetName>

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu1804</TargetName>

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu2004</TargetName>

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu2204</TargetName>

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntupreview</TargetName>


### PR DESCRIPTION
Per conversation on https://github.com/microsoft/WSL-DistroLauncher/issues/103 the recommendation is to upgrade to the latest SDK version. The other option would be define the constant in our sources.

```cpp
#define HCS_E_HYPERV_NOT_INSTALLED _HRESULT_TYPEDEF_(0x80370102L)
```

Since GitHub documentation says this version of the SDK is supported on the Windows runners, I opted in for the first option. Should the upstream implement any other fix I'll revisit this topic, but for now this is enough our CI. 