### PR TITLE
Created an abstraction for the Win32 named pipe.

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -67,6 +67,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ExitStatusParserTests.cpp" />
+    <ClCompile Include="LocalNamedPipeTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -68,6 +68,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ExitStatusParserTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests.cpp" />
+    <ClCompile Include="LocalNamedPipeTests2.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
@@ -1,0 +1,42 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+#include "local_named_pipe.cpp"
+
+namespace Win32Utils
+{
+    TEST(LocalNamedPipeTests, PipeNameBusinessRule)
+    {
+        auto pipe = LocalNamedPipe(false, false, L"test-pipe");
+        ASSERT_PRED1([](const std::wstring& name) { return name._Starts_with(L"\\\\.\\pipe\\"); }, pipe.pipeName());
+    }
+    TEST(LocalNamedPipeTests, FromAnyStringLikeArg)
+    {
+        std::wstring suffix{L"test-pipe"};
+        auto view = std::wstring_view{suffix};
+        auto pipe = LocalNamedPipe(false, false, view);
+        ASSERT_PRED1([](const HANDLE& read) { return read != INVALID_HANDLE_VALUE; }, pipe.readHandle());
+        ASSERT_PRED1([](const std::wstring& name) { return name._Starts_with(L"\\\\.\\pipe\\"); }, pipe.pipeName());
+    }
+    TEST(LocalNamedPipeTests, NeverReturnClosedHandles)
+    {
+        auto pipe = LocalNamedPipe(false, false, L"test-pipe");
+        auto fd = pipe.writeFileDescriptor();
+        auto handle = pipe.writeHandle();
+        ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+        // After this, both fd and handle are closed.
+        pipe.closeWriteHandles();
+        DWORD dFlags;
+        auto handleResult = GetHandleInformation(handle, &dFlags); // must fail.
+        ASSERT_EQ(handleResult, 0);                                // this means failure.
+    }
+    TEST(LocalNamedPipeTests, AskingForWriteHandlesGiveNewOnes)
+    {
+        auto pipe = LocalNamedPipe(false, false, L"test-pipe");
+        auto fd = pipe.writeFileDescriptor();
+        auto handle = pipe.writeHandle();
+        ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+        pipe.closeWriteHandles();
+        ASSERT_NE(handle, pipe.writeHandle());
+        ASSERT_NE(fd, pipe.writeFileDescriptor());
+    }
+}

--- a/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
@@ -4,6 +4,23 @@
 
 namespace Win32Utils
 {
+    TEST(PipeNameValidation, RemovesBackslash)
+    {
+        auto name = pipeNameFrom(L"tes\\t-\\pipe");
+        ASSERT_EQ(std::wstring(L"\\\\.\\pipe\\test-pipe"), name);
+    }
+    TEST(PipeNameValidation, ReturnsDefaultIfEmpty)
+    {
+        auto name = pipeNameFrom(L"");
+        ASSERT_EQ(std::wstring(L"\\\\.\\pipe\\LOCAL"), name);
+        name = pipeNameFrom(L"\\");
+        ASSERT_EQ(std::wstring(L"\\\\.\\pipe\\LOCAL"), name);
+    }
+    TEST(PipeNameValidation, TrimsToMaxLength)
+    {
+        auto name = pipeNameFrom(static_cast<size_t>(300), L't');
+        ASSERT_EQ(name.length(), 256);
+    }
     TEST(LocalNamedPipeTests, PipeNameBusinessRule)
     {
         auto pipe = LocalNamedPipe(false, false, L"test-pipe");
@@ -38,5 +55,43 @@ namespace Win32Utils
         pipe.closeWriteHandles();
         ASSERT_NE(handle, pipe.writeHandle());
         ASSERT_NE(fd, pipe.writeFileDescriptor());
+    }
+    TEST(MakeNamedPipeTests, TestFailedPipeCreation)
+    {
+        using namespace std::string_literals;
+        // The trick below shows the benefit of using templates for passing dependences.
+        struct FakePipe
+        {
+            std::wstring pipeName()
+            {
+                return L"FakePipe";
+            }
+            HANDLE readHandle()
+            {
+                return nullptr;
+            }
+            explicit FakePipe(bool inheritRead, bool inheritWrite, const wchar_t* name)
+            { }
+        };
+
+        auto failure = makeNamedPipe<FakePipe>(false, false, L"GoodPipe");
+        ASSERT_EQ(failure.has_value(), false);
+        ASSERT_PRED1([](const std::wstring& value) { return value.find(L"FakePipe") != std::wstring::npos; },
+                     failure.error());
+    }
+    TEST(MakeNamedPipeTests, PipeBehaviorShouldNotChange)
+    { // The environment should never fail, but if it does this test should still pass if the error handling is
+      // consistent with the original design.
+        auto pipe = makeNamedPipe(false, false, L"test-pipe");
+        if (pipe.has_value()) {
+            ASSERT_PRED1([](const std::wstring& name) { return name._Starts_with(L"\\\\.\\pipe\\"); },
+                         pipe.value().pipeName());
+        } else {
+            // Just in case that ever happens we'll have something different to notice.
+            std::wcerr << pipe.error() << L'\n';
+            ASSERT_PRED1(
+              [](const std::wstring& value) { return value.find(L"\\\\.\\pipe\\test-pipe") != std::wstring::npos; },
+              pipe.error());
+        }
     }
 }

--- a/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests2.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests2.cpp
@@ -4,7 +4,7 @@
 
 // This overrides the Win32 CreateFile macro by placing a function with the same signature inside the same namespace as
 // the class will be, thus being favorited by ADT.
-// That's why we don't specify the global namespace when calling the Win32 functions int he application code.
+// That's why we don't specify the global namespace when calling the Win32 functions in the application code.
 #undef CreateFile
 namespace Test::Win32Utils
 {

--- a/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests2.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests2.cpp
@@ -1,0 +1,40 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+// Tests added in a separate file due need to fake win32 APIs.
+
+// This overrides the Win32 CreateFile macro by placing a function with the same signature inside the same namespace as
+// the class will be, thus being favorited by ADT.
+// That's why we don't specify the global namespace when calling the Win32 functions int he application code.
+#undef CreateFile
+namespace Test::Win32Utils
+{
+    HANDLE CreateFile(LPCWSTR lpFileName,
+                      DWORD dwDesiredAccess,
+                      DWORD dwShareMode,
+                      LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                      DWORD dwCreationDisposition,
+                      DWORD dwFlagsAndAttributes,
+                      HANDLE hTemplateFile)
+    {
+        return INVALID_HANDLE_VALUE;
+    }
+}
+
+// This trick makes the linker ignore the object definition in the other test file (LocalNamedPipeTests2.cpp).
+// Effectively it is another class because leaves inside another namespace.
+namespace Test
+{
+#include "local_named_pipe.cpp"
+}
+
+// The actual tests are here.
+namespace Test::Win32Utils
+{
+
+    TEST(LocalNamedPipeTests, FailureToCreateFileWontChangeObject)
+    {
+        auto pipe = LocalNamedPipe(false, false, L"test-pipe");
+        ASSERT_EQ(pipe.writeHandle(), nullptr);
+        ASSERT_EQ(pipe.writeFileDescriptor(), -1);
+    }
+}

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -150,6 +150,7 @@
     <ClInclude Include="WslApiLoader.h" />
     <ClInclude Include="expected.hpp" />
     <ClInclude Include="WSLInfo.h" />
+    <ClInclude Include="local_named_pipe.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DistributionInfo.cpp" />
@@ -157,6 +158,7 @@
     <ClCompile Include="exit_status_parser.cpp" />
     <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="DistroLauncher.cpp" />
+    <ClCompile Include="local_named_pipe.cpp" />
     <ClCompile Include="OOBE.cpp" />
     <ClCompile Include="ProcessRunner.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/DistroLauncher/local_named_pipe.cpp
+++ b/DistroLauncher/local_named_pipe.cpp
@@ -18,9 +18,9 @@ namespace Win32Utils
     void LocalNamedPipe::openWriteEnd()
     {
         if (hWrite == nullptr && writeFd == -1) {
-            auto handle =
+            HANDLE handle =
               CreateFile(szPipeName.c_str(), GENERIC_WRITE, 0, &writeSA, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
-            
+
             // That's the exact value returned by the function call above if it fails.
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
             if (handle == INVALID_HANDLE_VALUE) {

--- a/DistroLauncher/local_named_pipe.cpp
+++ b/DistroLauncher/local_named_pipe.cpp
@@ -1,0 +1,58 @@
+#include "stdafx.h"
+#include "local_named_pipe.h"
+#include <fcntl.h>
+namespace Win32Utils
+{
+    void LocalNamedPipe::closeWriteHandles()
+    {
+        if (writeFd != -1) {
+            // It meands writeFileDescriptor was assigned by means of  _open_osfhandle().
+            _close(writeFd);
+            writeFd = -1;
+        }
+        if (hWrite != INVALID_HANDLE_VALUE) {
+            hWrite = INVALID_HANDLE_VALUE;
+        }
+    }
+
+    void LocalNamedPipe::openWriteEnd()
+    {
+        if (hWrite == INVALID_HANDLE_VALUE && writeFd == -1) {
+            hWrite =
+              CreateFile(szPipeName.c_str(), GENERIC_WRITE, 0, &writeSA, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
+            writeFd = _open_osfhandle(reinterpret_cast<intptr_t>(hWrite), _O_WRONLY | _O_TEXT);
+            SetHandleInformation(hWrite, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritWrite));
+            ConnectNamedPipe(hRead, NULL); // can only be called when there is a client to connect.
+        }
+    }
+    const HANDLE LocalNamedPipe::writeHandle()
+    {
+        openWriteEnd();
+        return hWrite;
+    }
+
+    const int LocalNamedPipe::writeFileDescriptor()
+    {
+        openWriteEnd();
+        return writeFd;
+    }
+
+    LocalNamedPipe::~LocalNamedPipe()
+    {
+        if (hRead != INVALID_HANDLE_VALUE) {
+            DisconnectNamedPipe(hRead);
+            CloseHandle(hRead);
+            hRead = INVALID_HANDLE_VALUE;
+        }
+        // Notice that hWrite is closed during the console redirection.
+        // This should only happen if the console was never redirected but the pipe was created.
+        if (hWrite != INVALID_HANDLE_VALUE) {
+            CloseHandle(hWrite);
+            hWrite = INVALID_HANDLE_VALUE;
+        }
+        if (writeFd != -1) {
+            _close(writeFd);
+            writeFd = -1;
+        }
+    }
+}

--- a/DistroLauncher/local_named_pipe.cpp
+++ b/DistroLauncher/local_named_pipe.cpp
@@ -10,28 +10,28 @@ namespace Win32Utils
             _close(writeFd);
             writeFd = -1;
         }
-        if (hWrite != INVALID_HANDLE_VALUE) {
-            hWrite = INVALID_HANDLE_VALUE;
+        if (hWrite != nullptr) {
+            hWrite = nullptr;
         }
     }
 
     void LocalNamedPipe::openWriteEnd()
     {
-        if (hWrite == INVALID_HANDLE_VALUE && writeFd == -1) {
+        if (hWrite == nullptr && writeFd == -1) {
             hWrite =
-              CreateFile(szPipeName.c_str(), GENERIC_WRITE, 0, &writeSA, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
+              CreateFile(szPipeName.c_str(), GENERIC_WRITE, 0, &writeSA, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
             writeFd = _open_osfhandle(reinterpret_cast<intptr_t>(hWrite), _O_WRONLY | _O_TEXT);
             SetHandleInformation(hWrite, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritWrite));
-            ConnectNamedPipe(hRead, NULL); // can only be called when there is a client to connect.
+            ConnectNamedPipe(hRead, nullptr); // can only be called when there is a client to connect.
         }
     }
-    const HANDLE LocalNamedPipe::writeHandle()
+    HANDLE LocalNamedPipe::writeHandle()
     {
         openWriteEnd();
         return hWrite;
     }
 
-    const int LocalNamedPipe::writeFileDescriptor()
+    int LocalNamedPipe::writeFileDescriptor()
     {
         openWriteEnd();
         return writeFd;
@@ -39,16 +39,16 @@ namespace Win32Utils
 
     LocalNamedPipe::~LocalNamedPipe()
     {
-        if (hRead != INVALID_HANDLE_VALUE) {
+        if (hRead != nullptr) {
             DisconnectNamedPipe(hRead);
             CloseHandle(hRead);
-            hRead = INVALID_HANDLE_VALUE;
+            hRead = nullptr;
         }
         // Notice that hWrite is closed during the console redirection.
         // This should only happen if the console was never redirected but the pipe was created.
-        if (hWrite != INVALID_HANDLE_VALUE) {
+        if (hWrite != nullptr) {
             CloseHandle(hWrite);
-            hWrite = INVALID_HANDLE_VALUE;
+            hWrite = nullptr;
         }
         if (writeFd != -1) {
             _close(writeFd);

--- a/DistroLauncher/local_named_pipe.cpp
+++ b/DistroLauncher/local_named_pipe.cpp
@@ -18,8 +18,15 @@ namespace Win32Utils
     void LocalNamedPipe::openWriteEnd()
     {
         if (hWrite == nullptr && writeFd == -1) {
-            hWrite =
+            auto handle =
               CreateFile(szPipeName.c_str(), GENERIC_WRITE, 0, &writeSA, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
+            
+            // That's the exact value returned by the function call above if it fails.
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            if (handle == INVALID_HANDLE_VALUE) {
+                return; // leave the object unmodified.
+            }
+            hWrite = handle;
             writeFd = _open_osfhandle(reinterpret_cast<intptr_t>(hWrite), _O_WRONLY | _O_TEXT);
             SetHandleInformation(hWrite, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritWrite));
             ConnectNamedPipe(hRead, nullptr); // can only be called when there is a client to connect.

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -4,7 +4,7 @@ namespace Win32Utils
     /**
      * Encapsulates the Win32 named pipe which can be inherited by child processes into an RAII object to simplify
      * its usage. This pipe is said local in the sense that both client and server stays in the same application.
-     * This is useful for situations like logging or console redirection. Server end is inbound access, i.e. it's ment
+     * This is useful for situations like logging or console redirection. Server end is inbound access, i.e. it's meant
      * to be read-only while client is a write-only file. The client handle could be inherited by a child process as
      * it's stdout and the process creating the pipe could read it to display in a text component, for example.
      * The opposite is also viable, the process creating the pipe could redirect it's stdout and stderr to the write

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -45,7 +45,7 @@ namespace Win32Utils
 
             SetHandleInformation(hRead, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritRead));
         }
-        const HANDLE readHandle() const
+        HANDLE readHandle() const
         {
             return hRead;
         }
@@ -60,9 +60,9 @@ namespace Win32Utils
         void closeWriteHandles();
 
         // Getter to the OS Handle of the write end of the pipe.
-        const HANDLE writeHandle();
+        HANDLE writeHandle();
         // Getter to the OS Handle of the write end of the pipe.
-        const int writeFileDescriptor();
+        int writeFileDescriptor();
 
         ~LocalNamedPipe();
 
@@ -70,14 +70,14 @@ namespace Win32Utils
         // Those are delicate to be exposed. Leaving the write end of this pipe fly all over the places could result
         // in application crashes. Thats why the methods writeHandle() and closeWriteHandles() exist.
         void openWriteEnd();
-        HANDLE hWrite = INVALID_HANDLE_VALUE;
+        HANDLE hWrite = nullptr;
         int writeFd = -1;
         bool inheritWrite;
 
         // Nobody will need to access those outside of this class.
         SECURITY_ATTRIBUTES readSA, writeSA;
         // Those could be public, but to keep the API consistent, they are private.
-        HANDLE hRead = INVALID_HANDLE_VALUE;
+        HANDLE hRead = nullptr;
         // This naming convention (\\\\.\\pipe\\) is a business rule of Win32 named pipes.
         std::wstring szPipeName{L"\\\\.\\pipe\\"};
     };

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -1,0 +1,85 @@
+#pragma once
+namespace Win32Utils
+{
+    /**
+     * Encapsulates the Win32 named pipe which can be inherited by child processes into an RAII object to simplify
+     * its usage. This pipe is said local in the sense that both client and server stays in the same application.
+     * This is useful for situations like logging or console redirection. Server end is inbound access, i.e. it's ment
+     * to be read-only while client is a write-only file. The client handle could be inherited by a child process as
+     * it's stdout and the process creating the pipe could read it to display in a text component, for example.
+     * The opposite is also viable, the process creating the pipe could redirect it's stdout and stderr to the write
+     * handle and let a child process inherit the read handle as stdin, implementing a unix shell pipe like
+     * process chain.
+     *
+     * CLASS INVARIANTS
+     *
+     * At any point in time an instance of this class must:
+     *
+     * Have both hWrite and writeFd valid.
+     * Invalidate one of the memebers above must invalidate the other simultaneously.
+     * hRead must stay valid for the whole object lifecycle.
+     * szPipeName must start with \\.\pipe\
+     * write end getters must always return valid handles.
+     *
+     */
+    class LocalNamedPipe
+    {
+      public:
+        // Constructs a named pipe from a pipe name or any combination of arguments that can build a wstring.
+        // Pipe name will be automatically prefixed with pipeNamePrefix per Win32 rules.
+        // Set inheritRead to true if the read handle should be inheritable. The same applies for inheritWrite.
+        template <typename... Args>
+        explicit LocalNamedPipe(bool inheritRead, bool inheritWrite, Args&&... args) :
+            readSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true}, writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
+            inheritWrite{inheritWrite}
+        {
+            szPipeName.append(std::forward<Args>(args)...);
+            hRead = CreateNamedPipe(szPipeName.c_str(),
+                                    PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+                                    PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                                    PIPE_UNLIMITED_INSTANCES,
+                                    0,
+                                    0,
+                                    0,
+                                    &readSA);
+
+            SetHandleInformation(hRead, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritRead));
+        }
+        const HANDLE readHandle() const
+        {
+            return hRead;
+        }
+
+        const std::wstring& pipeName() const
+        {
+            return szPipeName;
+        }
+
+        // To make piping stdout and stderr work, one will need to close the write end of this pipe after assing the
+        // standard file descriptors.
+        void closeWriteHandles();
+
+        // Getter to the OS Handle of the write end of the pipe.
+        const HANDLE writeHandle();
+        // Getter to the OS Handle of the write end of the pipe.
+        const int writeFileDescriptor();
+
+        ~LocalNamedPipe();
+
+      private:
+        // Those are delicate to be exposed. Leaving the write end of this pipe fly all over the places could result
+        // in application crashes. Thats why the methods writeHandle() and closeWriteHandles() exist.
+        void openWriteEnd();
+        HANDLE hWrite = INVALID_HANDLE_VALUE;
+        int writeFd = -1;
+        bool inheritWrite;
+
+        // Nobody will need to access those outside of this class.
+        SECURITY_ATTRIBUTES readSA, writeSA;
+        // Those could be public, but to keep the API consistent, they are private.
+        HANDLE hRead = INVALID_HANDLE_VALUE;
+        // This naming convention (\\\\.\\pipe\\) is a business rule of Win32 named pipes.
+        std::wstring szPipeName{L"\\\\.\\pipe\\"};
+    };
+
+}

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -21,30 +21,88 @@ namespace Win32Utils
      * szPipeName must start with \\.\pipe\
      * write end getters must always return valid handles.
      *
+     * A factory function (makeNamedPipe()) is offered as a good way to create a named pipe as an expected object. Shall
+     * the creation fail, the function will return a message with some context about the failure.
      */
+
+    // Returns an always valid pipe name. The arguments this function accepts must match one std::wstring
+    // constructor and if so will be appended to the prefix demanded by Win32 API (\\.\pipe\). There are more business
+    // rules involving the named pipe names. Win32 Docs says:
+    // _"The pipename part of the name can include any character
+    // other than a backslash, including numbers and special characters. The entire pipe name string can be up to 256
+    // characters long. Pipe names are not case sensitive."_
+    // Consider room for the 9 characters for the prefix (\\.\pipe\) MAX_SUFFIX_SIZE must be: 247.
+    // See: <https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea>
+    template <typename... Args> std::wstring pipeNameFrom(Args&&... args)
+    {
+        constexpr auto MAX_SUFFIX_LENGTH = 247;
+        std::wstring name(std::forward<Args>(args)...);
+        name.erase(std::remove(name.begin(), name.end(), '\\'), name.end());
+        if (name.length() > MAX_SUFFIX_LENGTH) {
+            name.erase(name.begin() + MAX_SUFFIX_LENGTH, name.end()); // erase is [first, last)
+        }
+        assert(name.length() <= MAX_SUFFIX_LENGTH);
+        if (name.empty()) {
+            name.insert(0, L"LOCAL");
+        }
+        name.insert(0, L"\\\\.\\pipe\\");
+        return name;
+    }
+
     class LocalNamedPipe
     {
+      private:
+        void openWriteEnd();
+        // This naming convention (\\\\.\\pipe\\) is a business rule of Win32 named pipes.
+        std::wstring szPipeName;
+        // Nobody will need to access those outside of this class.
+        SECURITY_ATTRIBUTES readSA, writeSA;
+
+        HANDLE hRead = nullptr;
+
+        // Those are delicate to be exposed. Leaving the write end of this pipe fly all over the places could result
+        // in application crashes. Thats why the methods writeHandle() and closeWriteHandles() exist.
+        HANDLE hWrite = nullptr;
+        int writeFd = -1;
+        bool inheritWrite;
+
       public:
-        // Constructs a named pipe from a pipe name or any combination of arguments that can build a wstring.
-        // Pipe name will be automatically prefixed with pipeNamePrefix per Win32 rules.
-        // Set inheritRead to true if the read handle should be inheritable. The same applies for inheritWrite.
+        // Constructs a named pipe from a pipe name string or any combination of arguments that can build a wstring.
+        // Pipe name is validated according to the Win32 API rules.
+        // The boolean flags [inheritRead] and [inheritWrite] dictate whether the respective HANDLE can be inherited by
+        // a child process, since the main usage of named pipes envolves inter process communication.
         template <typename... Args>
         explicit LocalNamedPipe(bool inheritRead, bool inheritWrite, Args&&... args) :
             readSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true}, writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
-            inheritWrite{inheritWrite}
+            inheritWrite{inheritWrite}, szPipeName{pipeNameFrom(std::forward<Args>(args)...)}
         {
-            szPipeName.append(std::forward<Args>(args)...);
-            hRead = CreateNamedPipe(szPipeName.c_str(),
-                                    PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
-                                    PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT,
-                                    PIPE_UNLIMITED_INSTANCES,
-                                    0,
-                                    0,
-                                    0,
-                                    &readSA);
-
-            SetHandleInformation(hRead, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritRead));
+            auto handle = CreateNamedPipe(szPipeName.c_str(),
+                                          PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+                                          PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                                          PIPE_UNLIMITED_INSTANCES,
+                                          0,
+                                          0,
+                                          0,
+                                          &readSA);
+            // That's the exact value returned by the function call above if it fails.
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            if (handle != INVALID_HANDLE_VALUE) {
+                hRead = handle; // only assign if valid. Otherwise, hRead will stay a nullptr.
+                SetHandleInformation(hRead, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritRead));
+            }
         }
+        // Move constructor is necessary for the expected idiom to work correctly with classes that handles resources
+        // (pointers, file descriptors, OS handles...
+        // The moved-from object must be left in a "zeroed-out" state, so when its destructor gets called there is no
+        // risk of closing a handle being used by other objects.
+        LocalNamedPipe(LocalNamedPipe&& other) noexcept :
+            szPipeName{std::exchange(other.szPipeName, std::wstring{})},
+            readSA{std::exchange(other.readSA, {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE})},
+            writeSA{std::exchange(other.writeSA, {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE})}, // zeroing everything.
+            hRead{std::exchange(other.hRead, nullptr)}, hWrite{std::exchange(other.hWrite, nullptr)},
+            writeFd{std::exchange(other.writeFd, -1)}, inheritWrite{std::exchange(other.inheritWrite, false)}
+        { }
+
         HANDLE readHandle() const
         {
             return hRead;
@@ -65,21 +123,36 @@ namespace Win32Utils
         int writeFileDescriptor();
 
         ~LocalNamedPipe();
-
-      private:
-        // Those are delicate to be exposed. Leaving the write end of this pipe fly all over the places could result
-        // in application crashes. Thats why the methods writeHandle() and closeWriteHandles() exist.
-        void openWriteEnd();
-        HANDLE hWrite = nullptr;
-        int writeFd = -1;
-        bool inheritWrite;
-
-        // Nobody will need to access those outside of this class.
-        SECURITY_ATTRIBUTES readSA, writeSA;
-        // Those could be public, but to keep the API consistent, they are private.
-        HANDLE hRead = nullptr;
-        // This naming convention (\\\\.\\pipe\\) is a business rule of Win32 named pipes.
-        std::wstring szPipeName{L"\\\\.\\pipe\\"};
     };
+
+    // Factory which returns valid and healthy named pipes or a unexpected<string> message.
+    // The unusual signature of this function allows extensibility.
+    // The default usage may not even notice there are templates involved:
+    // ```cpp
+    // auto pipe = makeNamedPipe(false, false, L"test-pipe");
+    // if (pipe.has_value()) {
+    //    do_something_with_the_pipe(...);
+    // }
+    //```
+    //
+    // At the same time, it allows extensibility, like:
+    // ```cpp
+    // auto pipe = makeNamedPipe<FakePipe>(false, false, L"GoodPipe");
+    // ASSERT_SOMETHING_ABOUT_THE_FAKE_PIPE(...);
+    //```
+    template <class Pipe = LocalNamedPipe, typename... Args>
+    nonstd::expected<Pipe, std::wstring> makeNamedPipe(bool inheritRead, bool inheritWrite, Args&&... args)
+    {
+        auto pipe = Pipe(inheritRead, inheritWrite, std::forward<Args>(args)...);
+        if (pipe.readHandle() != nullptr) {
+            return pipe;
+        }
+        // if failed:
+        auto msg = pipe.pipeName();
+        msg.insert(0, L"Failed to create a pipe. Pipe name was: ");
+        msg.append(L" . Error code: ");
+        msg.append(std::to_wstring(GetLastError()));
+        return nonstd::make_unexpected(std::move(msg));
+    }
 
 }


### PR DESCRIPTION
Named pipe will be used for console redirection. This pipe technique has been tested with C++ and Dart console apps and Flutter GUI apps to make sure it works. 

A console service will use this class to activate and deactivate redirection according to the state of the launcher application. Handling it thru Win32 API all by itself can become really tricky. This class should facilitate that task.

Tests added assert the logic and invariants of this abstraction, not the pipe functionality.

This component is not yet connected to the launcher application. No change in behavior of the app should be noticed by this addition. Integration will happen after adding all necessary components.

The foreseen usage for this component is like the snippets below:

```cpp
auto console = ConsoleService<LocalNamedPipe>();
```

```cpp
template<class Pipe>
class ConsoleService
{
  private:
    Pipe redirectTo;                                     // Here it is
    ConsoleState previousConsoleState;
    ConsoleState consoleState();

  public:
    const HANDLE redirectConsole();
    bool restoreConsole();
    bool hideConsoleWindow();
    bool showConsoleWindow();
};

const HANDLE ConsoleService::redirectConsole()
  {
      // Saving the standard streams context before redirecting.
      previousConsoleState = consoleState();

      // Overriding the std streams with the handle to the write end of the pipe.
      SetStdHandle(STD_OUTPUT_HANDLE, redirectTo.writeHandle());                  // Here it is
      SetStdHandle(STD_ERROR_HANDLE, redirectTo.writeHandle());                   // Here it is
     
      int fd = redirectTo.writeFileDescriptor();                             // Here it is
      auto res = _dup2(fd, _fileno(stdout));
      auto res2 = _dup2(fd, _fileno(stderr));
      setvbuf(stdout, nullptr, _IONBF, 0);
      setvbuf(stderr, nullptr, _IONBF, 0);
      std::ios::sync_with_stdio();
      redirectTo.closeWriteHandles();                             // Here it is
      return redirectTo.readHandle();                             // Here it is
}
```