### PR TITLE
Console handling enhancements

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/ConsoleServiceTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ConsoleServiceTests.cpp
@@ -25,6 +25,8 @@ namespace Win32Utils
             }
             void closeWriteHandles()
             { }
+            void disconnect()
+            { }
             std::wstring pipeName()
             {
                 return L"FakePipe";
@@ -83,6 +85,8 @@ namespace Win32Utils
             {
                 return hFile;
             }
+            void disconnect()
+            { }
             explicit FakePipe(bool inheritRead, bool inheritWrite, const wchar_t* name)
             {
                 auto now = std::chrono::system_clock::now().time_since_epoch();

--- a/DistroLauncher/console_service.h
+++ b/DistroLauncher/console_service.h
@@ -11,12 +11,12 @@ namespace Win32Utils
         HANDLE stdErrHandle = nullptr;
         // The identity of this state is embedded into the values of the handles.
         // File descriptor values will most likely be always new since they are created by calling _dup().
-        friend constexpr bool operator==(const ConsoleState& lhs, const ConsoleState& rhs);
+        friend bool operator==(const ConsoleState& lhs, const ConsoleState& rhs)
+        {
+            return lhs.stdErrHandle == rhs.stdErrHandle && lhs.stdOutHandle == rhs.stdOutHandle;
+        }
     };
-    constexpr bool operator==(const ConsoleState& lhs, const ConsoleState& rhs)
-    {
-        return lhs.stdErrHandle == rhs.stdErrHandle && lhs.stdOutHandle == rhs.stdOutHandle;
-    }
+
     /**
      * Offers the application the capability to redirect the console output and toggle visibitily of the console window.
      * The console redirection is dependent on a class conforming to the same API as the LocalNamedPipe (see

--- a/DistroLauncher/console_service.h
+++ b/DistroLauncher/console_service.h
@@ -11,11 +11,12 @@ namespace Win32Utils
         HANDLE stdErrHandle = nullptr;
         // The identity of this state is embedded into the values of the handles.
         // File descriptor values will most likely be always new since they are created by calling _dup().
-        friend bool operator==(const ConsoleState& lhs, const ConsoleState& rhs)
-        {
-            return lhs.stdErrHandle == rhs.stdErrHandle && lhs.stdOutHandle == rhs.stdOutHandle;
-        }
+        friend constexpr bool operator==(const ConsoleState& lhs, const ConsoleState& rhs);
     };
+    constexpr bool operator==(const ConsoleState& lhs, const ConsoleState& rhs)
+    {
+        return lhs.stdErrHandle == rhs.stdErrHandle && lhs.stdOutHandle == rhs.stdOutHandle;
+    }
     /**
      * Offers the application the capability to redirect the console output and toggle visibitily of the console window.
      * The console redirection is dependent on a class conforming to the same API as the LocalNamedPipe (see
@@ -44,6 +45,7 @@ namespace Win32Utils
         Pipe redirectTo;
         ConsoleState previousConsoleState;
         bool bIsRedirected = false;
+        HWND window_;
 
         ConsoleState consoleState() const
         {
@@ -63,10 +65,12 @@ namespace Win32Utils
             // the consumer side, both stdout and stderr goes to the same file.
             if (state == consoleState())
                 return;
-            auto res2 = _dup2(state.stdErrFileDescriptor, _fileno(stderrStream));
+            fflush(stderrStream);
+            fflush(stdoutStream);
             SetStdHandle(nStderrHandle, state.stdErrHandle);
-            auto res = _dup2(state.stdOutFileDescriptor, _fileno(stdoutStream));
             SetStdHandle(nStdoutHandle, state.stdOutHandle);
+            auto res2 = _dup2(state.stdErrFileDescriptor, _fileno(stderrStream));
+            auto res = _dup2(state.stdOutFileDescriptor, _fileno(stdoutStream));
         }
 
       public:
@@ -74,12 +78,23 @@ namespace Win32Utils
         ConsoleService(Pipe&& pipe) noexcept : redirectTo{std::forward<Pipe>(pipe)}
         {
             assert(redirectTo.readHandle() != nullptr);
+            // Attempting to find the console window is best-effort if it is not the old style console.
+            // This has been tested for the new Windows Terminal. Other terminals out there may not fit.
+            window_ = FindWindow(L"CASCADIA_HOSTING_WINDOW_CLASS", DistributionInfo::WindowTitle.c_str());
+            if (window_ == NULL) {
+                window_ = GetConsoleWindow();
+            }
         }
         ~ConsoleService() = default;
 
         bool isRedirected() const
         {
             return bIsRedirected;
+        }
+
+        HWND window() const
+        {
+            return window_;
         }
 
         // Redirects the application console to the [redirectTo] pipe.
@@ -130,6 +145,7 @@ namespace Win32Utils
             _close(previousConsoleState.stdErrFileDescriptor);
             _close(previousConsoleState.stdOutFileDescriptor);
             std::ios::sync_with_stdio();
+            redirectTo.disconnect();
             bIsRedirected = false;
             // invalidating previous console state, so there is no where to restore to.
             previousConsoleState = ConsoleState{};
@@ -137,12 +153,13 @@ namespace Win32Utils
 
         bool hideConsoleWindow() const
         {
-            return ShowWindow(GetConsoleWindow(), SW_HIDE) == TRUE;
+            return ShowWindow(window_, SW_HIDE) != FALSE;
         }
 
         bool showConsoleWindow() const
         {
-            return ShowWindow(GetConsoleWindow(), SW_SHOW) == TRUE;
+            ShowWindow(window_, SW_RESTORE);
+            return BringWindowToTop(window_) == 0;
         }
     };
 

--- a/DistroLauncher/local_named_pipe.cpp
+++ b/DistroLauncher/local_named_pipe.cpp
@@ -27,9 +27,9 @@ namespace Win32Utils
                 return; // leave the object unmodified.
             }
             hWrite = handle;
-            writeFd = _open_osfhandle(reinterpret_cast<intptr_t>(hWrite), _O_WRONLY | _O_TEXT);
             SetHandleInformation(hWrite, HANDLE_FLAG_INHERIT, static_cast<BOOL>(inheritWrite));
             ConnectNamedPipe(hRead, nullptr); // can only be called when there is a client to connect.
+            writeFd = _open_osfhandle(reinterpret_cast<intptr_t>(hWrite), _O_WRONLY | _O_TEXT);
         }
     }
     HANDLE LocalNamedPipe::writeHandle()
@@ -44,10 +44,16 @@ namespace Win32Utils
         return writeFd;
     }
 
+    void LocalNamedPipe::disconnect()
+    {
+        FlushFileBuffers(hRead);
+        DisconnectNamedPipe(hRead);
+    }
+
     LocalNamedPipe::~LocalNamedPipe()
     {
         if (hRead != nullptr) {
-            DisconnectNamedPipe(hRead);
+            disconnect();
             CloseHandle(hRead);
             hRead = nullptr;
         }

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -116,7 +116,7 @@ namespace Win32Utils
         // To make piping stdout and stderr work, one will need to close the write end of this pipe after assing the
         // standard file descriptors.
         void closeWriteHandles();
-        
+
         // Allows disconnecting the named pipe programmatically.
         void disconnect();
         // Getter to the OS Handle of the write end of the pipe.

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -116,7 +116,9 @@ namespace Win32Utils
         // To make piping stdout and stderr work, one will need to close the write end of this pipe after assing the
         // standard file descriptors.
         void closeWriteHandles();
-
+        
+        // Allows disconnecting the named pipe programmatically.
+        void disconnect();
         // Getter to the OS Handle of the write end of the pipe.
         HANDLE writeHandle();
         // Getter to the OS Handle of the write end of the pipe.


### PR DESCRIPTION
While integrating the console service with the splash controller under development, it was noticed some gaps in the console handling:

- Hiding console wouldn't work in the Windows Terminal
- GetConsoleWindow() misleads if the app is not running in the old console
- The order of assignment of handles and file descriptors was hiding Linux apps stdout and stderr.
- Splash controller will need to know the console window handle at some point.
- Console service sometimes needs to disconnect the pipe before its destruction.
- Fake (test) pipes had to update their API.

This PR fixes all those situations.