### PR TITLE
Finally, the splash controller

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -70,6 +70,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="ExitStatusParserTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests2.cpp" />
+    <ClCompile Include="SplashControllerTests.cpp" />
     <ClCompile Include="StateMachineTests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -70,6 +70,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="ExitStatusParserTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests2.cpp" />
+    <ClCompile Include="StateMachineTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "stdafx.h"
 #include "gtest/gtest.h"
 #include "splash_controller.h"

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
@@ -1,33 +1,190 @@
 #include "stdafx.h"
 #include "gtest/gtest.h"
-#include "splash_controller.cpp"
+#include "splash_controller.h"
 
 namespace Oobe
 {
-    // The tests below only exercise the Idle state. Ideas to enhance testability of this controller are welcome.
-    // The whole purpose of adding this state machine technique was to improve overall testability.
+    // Fake strategies to exercise the Splash controller state machine.
+    struct NothingWorksStrategy
+    {
+        static bool do_create_process(const std::filesystem::path& exePath,
+                                      STARTUPINFO& startup,
+                                      PROCESS_INFORMATION& process)
+        {
+            return false;
+        }
 
+        static HWND do_find_window_by_thread_id(DWORD threadId)
+        {
+            return nullptr;
+        }
+        // The other methods will never be called, so there is no need to define them. Otherwise it would not even
+        // compile.
+    }; // struct NothingWorksStrategy
+
+    struct EverythingWorksStrategy
+    {
+        static bool do_create_process(const std::filesystem::path& exePath,
+                                      STARTUPINFO& startup,
+                                      PROCESS_INFORMATION& process)
+        {
+            return true;
+        }
+
+        static HWND do_find_window_by_thread_id(DWORD threadId)
+        {
+            // no risk because this handle will not be used for anything besides passing around.
+            return GetConsoleWindow();
+        }
+        static bool do_show_window(HWND window)
+        {
+            return true;
+        }
+        static bool do_hide_window(HWND window)
+        {
+            return true;
+        }
+        static bool do_place_behind(HWND toBeFront, HWND toBeBehind)
+        {
+            return true;
+        }
+        static void do_forcebly_close(HWND window)
+        { }
+
+        static void do_gracefully_close(HWND window)
+        { }
+        // The other methods will never be called, so there is no need to define them. Otherwise it would not even
+        // compile.
+    }; // struct EverythingWorksStrategy
+
+    // The whole purpose of adding this state machine technique was to improve overall testability.
     TEST(SplashControllerTests, LaunchFailedShouldStayIdle)
     {
-        SplashController controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
-        controller.sm.addEvent(SplashController::Events::Run{&controller}); // This fails but it is a valid transition.
-        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
+        using Controller = SplashController<NothingWorksStrategy>;
+        Controller controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
+        controller.sm.addEvent(Controller::Events::Run{&controller}); // This fails but it is a valid transition.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Idle>());
     }
 
     TEST(SplashControllerTests, FailedToFindWindowShouldStayIdle)
     {
-        SplashController controller{"cmd.exe", GetStdHandle(STD_OUTPUT_HANDLE)};
-        controller.sm.addEvent(SplashController::Events::Run{&controller});
-        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
-        controller.sm.addEvent(SplashController::Events::Close{});
-        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
+        struct CantFindWindowStrategy
+        {
+            static bool do_create_process(const std::filesystem::path& exePath,
+                                          STARTUPINFO& startup,
+                                          PROCESS_INFORMATION& process)
+            {
+                return true;
+            }
+
+            static HWND do_find_window_by_thread_id(DWORD threadId)
+            {
+                return nullptr;
+            }
+            // When we attempt to push the Close event, compiler detects the need for the two methods below.
+            static void do_forcebly_close(HWND window)
+            { }
+
+            static void do_gracefully_close(HWND window)
+            { }
+        }; // struct SplashStrategy
+        using Controller = SplashController<CantFindWindowStrategy>;
+        Controller controller{"cmd.exe", GetStdHandle(STD_OUTPUT_HANDLE)};
+        controller.sm.addEvent(Controller::Events::Run{&controller});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Idle>());
+        controller.sm.addEvent(Controller::Events::Close{});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Idle>());
     }
 
-    TEST(SplashControllerTests, OnlyVisibleOrHiddenAcceptsClose)
+    TEST(SplashControllerTests, AHappySequenceOfEvents)
     {
-        SplashController controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
-        // Only those two states know the window handle to close. Thus this should result in an InvalidTransition.
-        ASSERT_FALSE(controller.sm.addEvent(SplashController::Events::Close{}));
-        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
+        using Controller = SplashController<EverythingWorksStrategy>;
+        Controller controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
+        auto transition = controller.sm.addEvent(Controller::Events::Run{&controller});
+        // Since everything works in this realm, all transitions below should be valid...
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Visible>());
+        transition = controller.sm.addEvent(Controller::Events::ToggleVisibility{});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Hidden>());
+        transition = controller.sm.addEvent(Controller::Events::ToggleVisibility{});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Visible>());
+        transition = controller.sm.addEvent(Controller::Events::ToggleVisibility{});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Hidden>());
+        transition = controller.sm.addEvent(Controller::Events::PlaceBehind{GetConsoleWindow()});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Visible>());
+        transition = controller.sm.addEvent(Controller::Events::Close{});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
+    }
+    // This proves to be impossible to run the splash application more than once after the first success.
+    TEST(SplashControllerTests, OnlyIdleStateAcceptsRunEvent)
+    {
+        using Controller = SplashController<EverythingWorksStrategy>;
+        Controller controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
+        auto transition = controller.sm.addEvent(Controller::Events::Run{&controller});
+        // Since everything works in this realm, all transitions below should be valid...
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Visible>());
+
+        // now comes the interesting part: all other states should refuse the Run event
+
+        // Exercising the Visble State.
+        transition = controller.sm.addEvent(Controller::Events::Run{&controller});
+        ASSERT_FALSE(transition.has_value());
+        // state should remain the previous one.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Visible>());
+
+        transition = controller.sm.addEvent(Controller::Events::ToggleVisibility{});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Hidden>());
+
+        // Exercising the Hidden State.
+        transition = controller.sm.addEvent(Controller::Events::Run{&controller});
+        ASSERT_FALSE(transition.has_value());
+        // state should remain the previous one.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Hidden>());
+
+        transition = controller.sm.addEvent(Controller::Events::Close{});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
+        // Exercising the ShouldBeClosed State. Not even this once accepts re-running the splash. Should we?
+        transition = controller.sm.addEvent(Controller::Events::Run{&controller});
+        ASSERT_FALSE(transition.has_value());
+        // state should remain the previous one.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
+    }
+    // This proves to be impossible to close the window twice.
+    TEST(SplashControllerTests, MustCloseOnlyOnce)
+    {
+        // Remember that in this realm everything just works...
+        using Controller = SplashController<EverythingWorksStrategy>;
+        Controller controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
+        auto transition = controller.sm.addEvent(Controller::Events::Run{&controller});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Visible>());
+        transition = controller.sm.addEvent(Controller::Events::Close{});
+        ASSERT_TRUE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
+        // silly attempts start here.
+        transition = controller.sm.addEvent(Controller::Events::ToggleVisibility{});
+        ASSERT_FALSE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
+        transition = controller.sm.addEvent(Controller::Events::Close{});
+        ASSERT_FALSE(transition.has_value()); // if closing twice worked, this assertion would fail.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
+
+        // since it's not possible to run a second time...
+        transition = controller.sm.addEvent(Controller::Events::Run{&controller});
+        ASSERT_FALSE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
+
+        // and here we make sure the state machine was not fooled by the attempt to run.
+        transition = controller.sm.addEvent(Controller::Events::Close{});
+        ASSERT_FALSE(transition.has_value());
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::ShouldBeClosed>());
     }
 }

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
@@ -1,0 +1,33 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+#include "splash_controller.cpp"
+
+namespace Oobe
+{
+    // The tests below only exercise the Idle state. Ideas to enhance testability of this controller are welcome.
+    // The whole purpose of adding this state machine technique was to improve overall testability.
+
+    TEST(SplashControllerTests, LaunchFailedShouldStayIdle)
+    {
+        SplashController controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
+        controller.sm.addEvent(SplashController::Events::Run{&controller}); // This fails but it is a valid transition.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
+    }
+
+    TEST(SplashControllerTests, FailedToFindWindowShouldStayIdle)
+    {
+        SplashController controller{"cmd.exe", GetStdHandle(STD_OUTPUT_HANDLE)};
+        controller.sm.addEvent(SplashController::Events::Run{&controller});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
+        controller.sm.addEvent(SplashController::Events::Close{});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
+    }
+
+    TEST(SplashControllerTests, OnlyVisibleOrHiddenAcceptsClose)
+    {
+        SplashController controller{"./do_not_exists", GetStdHandle(STD_OUTPUT_HANDLE)};
+        // Only those two states know the window handle to close. Thus this should result in an InvalidTransition.
+        ASSERT_FALSE(controller.sm.addEvent(SplashController::Events::Close{}));
+        ASSERT_TRUE(controller.sm.isCurrentStateA<SplashController::States::Idle>());
+    }
+}

--- a/DistroLauncher-Tests/DistroLauncher-Tests/StateMachineTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/StateMachineTests.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "gtest/gtest.h"
+#include "state_machine.h"
+
+namespace Oobe
+{
+    /// This WindowController admits three states:
+    /// Idle - not running,
+    /// Visible - running and displaying the window and
+    /// Hidden - running but not displaying the window.
+    ///
+    /// And two events, whose names are self explanatory:
+    /// Run and ToggleVisibility.
+    /// (The events could carry data, but for this example they don't.)
+    /// By inspecting the `on_event()` methods of each state class we can draft a state transition table (PlantUML
+    /// syntax):
+    ///
+    /// [*] --> Idle
+    /// Idle --> Visible : Events::Run
+    /// Visible --> Hidden : Events::ToggleVisibility
+    /// Hidden --> Visible : Events::ToggleVisibility
+    ///
+    /// There are no guards to the transitions themselves, but there are some invalid possibilies (left unhandled by the
+    /// state classes):
+    /// * Idle cannot receive Events::ToggleVisibility
+    /// * Neither Hidden or Visible can receive Events::Run
+    ///
+    /// While exercising the API, the subsequent test cases also exercise:
+    /// TEST(StateMachineTests, ValidTransition) -> handling valid state transitions.
+    /// TEST(StateMachineTests, InvalidTransitionShouldBeDiscarded) -> handling invalid transitions.
+    struct WindowController
+    {
+        // controller events;
+        struct Events
+        {
+            struct Run
+            { };
+            struct ToggleVisibility
+            { };
+        };
+        // controller states;
+        struct States
+        {
+            struct Visible;
+
+            struct Idle
+            {
+              private:
+                Visible run()
+                {
+                    std::wcerr << L"[IdleState] Running... visible: yes\n";
+                    return Visible{42};
+                }
+
+              public:
+                Visible on_event(Events::Run event)
+                {
+                    return run();
+                }
+            };
+
+            struct Hidden
+            {
+                int window = -1;
+                Visible toggle()
+                {
+                    std::wcerr << L"[HiddenState] Showing...\n";
+                    return Visible{window};
+                }
+                Visible on_event(Events::ToggleVisibility event)
+                {
+                    return toggle();
+                }
+            };
+
+            struct Visible
+            {
+                int window = -1;
+
+                Hidden on_event(Events::ToggleVisibility event)
+                {
+                    std::wcerr << L"[ShownState] Hiding...\n";
+                    return Hidden{window};
+                }
+            };
+        };
+        using State = std::variant<States::Idle, States::Visible, States::Hidden>;
+        using Event = std::variant<Events::Run, Events::ToggleVisibility>;
+
+        internal::state_machine<WindowController> sm;
+    };
+
+    TEST(StateMachineTests, ValidTransition)
+    {
+        WindowController controller{};
+        // Here we pass the events directly yo the addEvent method.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Idle>());
+        WindowController::Event event = WindowController::Events::Run{};
+        controller.sm.addEvent(event);
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Visible>());
+        controller.sm.addEvent(WindowController::Events::ToggleVisibility{});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Hidden>());
+        controller.sm.addEvent(WindowController::Events::ToggleVisibility{});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Visible>());
+    }
+
+    TEST(StateMachineTests, InvalidTransitionShouldBeDiscarded)
+    {
+        WindowController controller{};
+        // In this example we reuse a Event variant variable and keep reassigning it.
+        WindowController::Event event = WindowController::Events::ToggleVisibility{};
+
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Idle>());
+        ASSERT_FALSE(controller.sm.addEvent(event));
+
+        event = WindowController::Events::Run{};
+        ASSERT_TRUE(controller.sm.addEvent(event));
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Visible>());
+
+        event = WindowController::Events::ToggleVisibility{};
+        ASSERT_TRUE(controller.sm.addEvent(event));
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Hidden>());
+
+        // Since its running, it should not accept a new Run event, state should not change.
+        event = WindowController::Events::Run{};
+        ASSERT_FALSE(controller.sm.addEvent(event));
+        ASSERT_TRUE(controller.sm.isCurrentStateA<WindowController::States::Hidden>());
+    }
+
+}

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -165,7 +165,7 @@
     <ClCompile Include="local_named_pipe.cpp" />
     <ClCompile Include="OOBE.cpp" />
     <ClCompile Include="ProcessRunner.cpp" />
-    <ClCompile Include="splash_controller.cpp" />
+    <ClCompile Include="find_main_thread_window.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="ProcessRunner.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="state_machine.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Win32Utils.h" />

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -140,6 +140,7 @@
   <ItemGroup>
     <ClInclude Include="console_service.h" />
     <ClInclude Include="ExitStatus.h" />
+    <ClInclude Include="not_null.h" />
     <ClInclude Include="OOBE.h" />
     <ClInclude Include="DistributionInfo.h" />
     <ClInclude Include="Helpers.h" />

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="ProcessRunner.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="splash_controller.h" />
     <ClInclude Include="state_machine.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
@@ -164,6 +165,7 @@
     <ClCompile Include="local_named_pipe.cpp" />
     <ClCompile Include="OOBE.cpp" />
     <ClCompile Include="ProcessRunner.cpp" />
+    <ClCompile Include="splash_controller.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/DistroLauncher/find_main_thread_window.cpp
+++ b/DistroLauncher/find_main_thread_window.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/DistroLauncher/not_null.h
+++ b/DistroLauncher/not_null.h
@@ -1,0 +1,93 @@
+#pragma once
+#include <type_traits>
+namespace Oobe
+{
+    /// This section of nullptr checking template type is humbly borrowed from GSL <https://github.com/microsoft/GSL>
+    // Copyright (c) 2015 Microsoft Corporation. All rights reserved. Licensed under the MIT License (MIT).
+    template <typename T, typename = void> struct is_comparable_to_nullptr : std::false_type
+    { };
+
+    template <typename T>
+    struct is_comparable_to_nullptr<
+      T, std::enable_if_t<std::is_convertible<decltype(std::declval<T>() != nullptr), bool>::value>> : std::true_type
+    { };
+
+    //
+    // not_null
+    //
+    // Restricts a pointer or smart pointer to only hold non-null values.
+    //
+    // Has zero size overhead over T.
+    //
+    // If T is a pointer (i.e. T == U*) then
+    // - allow construction from U*
+    // - disallow construction from nullptr_t
+    // - disallow default construction
+    // - ensure construction from null U* fails
+    // - allow implicit conversion to U*
+    //
+    template <class T> class not_null
+    {
+      public:
+        static_assert(is_comparable_to_nullptr<T>::value, "T cannot be compared to nullptr.");
+
+        template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
+        constexpr not_null(U&& u) : ptr_(std::forward<U>(u))
+        {
+            assert(ptr_ != nullptr);
+        }
+
+        template <typename = std::enable_if_t<!std::is_same<std::nullptr_t, T>::value>>
+        constexpr not_null(T u) : ptr_(std::move(u))
+        {
+            assert(ptr_ != nullptr);
+        }
+
+        template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
+        constexpr not_null(const not_null<U>& other) : not_null(other.get())
+        { }
+
+        not_null(const not_null& other) = default;
+        not_null& operator=(const not_null& other) = default;
+        constexpr std::conditional_t<std::is_copy_constructible<T>::value, T, const T&> get() const
+        {
+            assert(ptr_ != nullptr);
+            return ptr_;
+        }
+
+        constexpr operator T() const
+        {
+            return get();
+        }
+        constexpr decltype(auto) operator->() const
+        {
+            return get();
+        }
+        constexpr decltype(auto) operator*() const
+        {
+            return *get();
+        }
+
+        // prevents compilation when someone attempts to assign a null pointer constant
+        not_null(std::nullptr_t) = delete;
+        not_null& operator=(std::nullptr_t) = delete;
+
+        // unwanted operators...pointers only point to single objects!
+        not_null& operator++() = delete;
+        not_null& operator--() = delete;
+        not_null operator++(int) = delete;
+        not_null operator--(int) = delete;
+        not_null& operator+=(std::ptrdiff_t) = delete;
+        not_null& operator-=(std::ptrdiff_t) = delete;
+        void operator[](std::ptrdiff_t) const = delete;
+
+      private:
+        T ptr_;
+    };
+
+    template <class T> auto make_not_null(T&& t) noexcept
+    {
+        return not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
+    }
+    // end of not_null
+}

--- a/DistroLauncher/splash_controller.cpp
+++ b/DistroLauncher/splash_controller.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "stdafx.h"
+#include "splash_controller.h"
+
+namespace Oobe
+{
+
+    namespace internal
+    {
+        // The struct and three functions below work very deeply integrated to implement one Win32 idiom required to
+        // find the splash screen window handle, which the splash controller will need to do the control job. From
+        // bottom up:
+        // 1. find_main_thread_window - uses the Win32 EnumThreadWindows to iterate over all windows created by a
+        //    specific thread, calling enum_windows_callback for each window found, passing the window handle and a
+        //    void* (used to pass arbitrary data to the callback).
+        // 2. enum_windows_callback is called by the OS with the window handle and that void* called lParam to check if
+        //    matches the window we are looking for.
+        //    We use this lParam "channel" as a two way: we pass to the callback the window class name as
+        //    input and receive the Window Handle as an output. That's why the struct window_data was created, to group
+        //    both pieces of information together and allow accessing both thru a single pointer. The return channel of
+        //    that callback is already occupied with the information the OS expects to know whether it must stop the
+        //    iteration or not. Returning FALSE means we found it.
+        // 3. is_main_window - is just an extra sanity check to make sure the window we are looking into is a top one (
+        //    not a child MDI or window control).
+        //
+        // Having this pattern only searching for Windows created by a specific thread, we don't need to search for the
+        // window name, for instance. Matching the window class name suffices. Bear in mind that the Flutter app changes
+        // its window name based on the language, so comparing the window name would be really tricky.
+        //
+        // Also, this idiom only works for windows created by the thread whose ID is informed. Finding a console window
+        // from a child process of the console is not possible with this approach, because the look up behavior goes
+        // from the thread to the window and in the example of the console the window would exist prior to the creation
+        // of the application and its threads.
+        struct window_data
+        {
+            const wchar_t* szClassName;
+            HWND window_handle = nullptr;
+        };
+
+        // Sanity check because everything is a Window on Windows. By everything, I mean controls, buttons etc etc.
+        BOOL is_main_window(HWND handle)
+        {
+            return static_cast<BOOL>(GetWindow(handle, GW_OWNER) == nullptr && (IsWindowVisible(handle) != 0));
+        }
+
+        BOOL CALLBACK enum_windows_callback(HWND handle, LPARAM lParam)
+        {
+            constexpr auto maxSize = 32;
+            // NOLINTNEXTLINE(performance-no-int-to-ptr) - The API doesn't give us options.
+            window_data* data = reinterpret_cast<window_data*>(lParam);
+            wchar_t windowClass[maxSize];
+            GetClassName(handle, windowClass, maxSize);
+            std::wstring_view klass{windowClass};
+            // Sanity check to make sure we found the correct window. It seems very unlikely not to be the correct one,
+            // but this small check decreases quite dramatically chance of mistakes.
+            // If not the window i'm looking for, keep iterating...
+            if ((is_main_window(handle) == 0) || klass.compare(data->szClassName) != 0) {
+                return TRUE;
+            }
+            // else save the handle.
+            data->window_handle = handle;
+            return FALSE;
+        }
+
+        HWND find_main_thread_window(DWORD thread_id)
+        {
+            window_data data{L"FLUTTER_RUNNER_WIN32_WINDOW", nullptr};
+            EnumThreadWindows(thread_id, enum_windows_callback, reinterpret_cast<LPARAM>(&data));
+            return data.window_handle;
+        }
+    }
+
+    // Most likely the exePath will be built on the fly from a string, so there is no sense in creating a temporary and
+    // copy it when we can move.
+    SplashController::SplashController(std::filesystem::path exePath, not_null<HANDLE> stdIn) :
+        exePath{std::move(exePath)}
+    {
+        ZeroMemory(&_piProcInfo, sizeof(PROCESS_INFORMATION));
+        ZeroMemory(&startInfo, sizeof(STARTUPINFO));
+        startInfo.cb = sizeof(STARTUPINFO);
+        startInfo.hStdInput = stdIn;
+        startInfo.dwFlags |= STARTF_USESTDHANDLES;
+        SetHandleInformation(stdIn, HANDLE_FLAG_INHERIT, 1);
+    }
+
+    SplashController::State SplashController::States::Idle::on_event(Events::Run event)
+    {
+        TCHAR szCmdline[MAX_PATH];
+        wcsncpy_s(
+          szCmdline, event.controller_->exePath.wstring().c_str(), event.controller_->exePath.wstring().length());
+        BOOL res = CreateProcess(nullptr,                          // command line
+                                 szCmdline,                        // non-const CLI
+                                 nullptr,                          // process security attributes
+                                 nullptr,                          // primary thread security attributes
+                                 TRUE,                             // handles are inherited
+                                 0,                                // creation flags
+                                 nullptr,                          // use parent's environment
+                                 nullptr,                          // use parent's current directory
+                                 &event.controller_->startInfo,    // STARTUPINFO pointer
+                                 &event.controller_->_piProcInfo); // output: PROCESS_INFORMATION
+        if (res == 0 || event.controller_->_piProcInfo.hProcess == nullptr) {
+            return *this; // return the the same (Idle) state.
+        }
+        // Without implementing more sofisticated IPC, it can be tricky to monitor the Flutter process to determine the
+        // moment in which the window is ready. Yet, Flutter apps are fast to start up on Windows, so sleeping for some
+        // fraction of a second should be enough. The exact amount of time to sleep might be subject to changes after
+        // further testing on situations of heavier workloads or slower machines or VM's. Yet, it's expected to stay
+        // under less than a second.
+        constexpr DWORD flutterWindowToOpenTimeout = 500; // ms.
+        Sleep(flutterWindowToOpenTimeout);
+        HWND window = internal::find_main_thread_window(event.controller_->_piProcInfo.dwThreadId);
+        if (window == nullptr) {
+            return *this;
+        }
+
+        return Visible{window};
+    }
+
+    // The Close event should be used to gracefully destroys the flutter app.
+    // This will just kill the process unconditionally.
+    SplashController::~SplashController()
+    {
+        if (_piProcInfo.hProcess != nullptr) {
+            TerminateProcess(_piProcInfo.hProcess, 0);
+            CloseHandle(_piProcInfo.hThread);
+            CloseHandle(_piProcInfo.hProcess);
+        }
+    }
+
+}

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+#include "state_machine.h"
+#include <filesystem>
+
+namespace Oobe
+{
+    class SplashController
+    {
+      public:
+        /// Initializes the control structures to later run the splash application. Accepts the splash executable
+        /// filesystem
+        /// path and the HANDLE to the device that will act as the splash standard input.
+        SplashController(std::filesystem::path exePath, not_null<HANDLE> stdIn);
+        // controller events;
+        struct Events
+        {
+            // Run event transports a non-owning mutating (i.e. borrowing) pointer to the outer controller. Using the
+            // pointer instead of a reference allows copy assignment, which in turn simplifies passing the event object
+            // around by value. With this pointer the Run event will allow the Idle state to access the internals of the
+            // controller to find the pieces required to launch the splash applicaiton, thus avoiding transferring much
+            // heavier pieces of data. Coupling in this case should not be a concern. They are tightly coupled by
+            // definition, since all states and events are members of the outer class, thus all can access even the
+            // controller's private members.
+            struct Run
+            {
+                not_null<SplashController*> controller_;
+            };
+            struct ToggleVisibility
+            { };
+
+            struct PlaceBehind
+            {
+                HWND front;
+            };
+
+            struct Close
+            { };
+        };
+        using Event = std::variant<Events::ToggleVisibility, Events::Run, Events::PlaceBehind, Events::Close>;
+
+        // controller states;
+        struct States
+        {
+            // Forward-declaring the states enables declaring the variant upfront. Idle::run() needs the variant
+            // already declared.
+            struct Visible;
+            struct Hidden;
+            struct Idle;
+            struct ShouldBeClosed;
+            using StateVariant = std::variant<Idle, Visible, Hidden, ShouldBeClosed>;
+
+            struct Idle
+            {
+                /// Returns a Visible state if it succeeds in:
+                /// - launching the splash application and
+                /// - finding it's window handle.
+                /// Returns itself (i.e. an instance of the Idle state) otherwise.
+                StateVariant on_event(Events::Run event);
+            };
+            // `ShouldBeClosed` because we'll not stop to check whether it really closed when PostMessage returns.
+            struct ShouldBeClosed
+            { };
+            struct Hidden
+            {
+                HWND window = nullptr;
+                Visible on_event(Events::ToggleVisibility /*unused*/)
+                {
+                    ShowWindow(window, SW_SHOWNA);
+                    return Visible{window};
+                }
+
+                /// Brings the splash window visible but changes its Z-order to stay behind a window specified by the
+                /// PlaceBehind event.
+                Visible on_event(Events::PlaceBehind event)
+                {
+                    ShowWindow(window, SW_SHOWNA);
+                    SetWindowPos(window, event.front, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                    return Visible{window};
+                }
+                // In the visible state, closing the window should allow the user to confirm closing or doing some clean
+                // up. That is the semantic difference between WM_CLOSE (enables that behavior) versus WM_QUIT (closes
+                // the window unconditionally). Interestingly, a GUI application that implements that semantics (think
+                // of document editor showing a dialog asking if the user wants to save their changes) will hang forever
+                // if the window receives WM_CLOSE while hidden, because the OS will not bring it back to the light,
+                // thus there is no way the user can hit any of the dialog buttons to let the window rest in piece.
+                ShouldBeClosed on_event(Events::Close event) const
+                {
+                    PostMessage(window, WM_QUIT, 0, 0);
+                    return ShouldBeClosed{};
+                }
+            };
+
+            struct Visible
+            {
+                HWND window = nullptr;
+                Hidden on_event(Events::ToggleVisibility /*unused*/)
+                {
+                    ShowWindow(window, SW_HIDE);
+                    return Hidden{window};
+                }
+
+                ShouldBeClosed on_event(Events::Close event) const
+                {
+                    PostMessage(window, WM_CLOSE, 0, 0);
+                    return ShouldBeClosed{};
+                }
+            };
+        };
+        // The state machine expects the symbol `State` to be visible.
+        using State = States::StateVariant;
+
+        internal::state_machine<SplashController> sm;
+
+        ~SplashController();
+
+      private:
+        const std::filesystem::path exePath;
+        STARTUPINFO startInfo;
+        // this is the only member that requires ownership/resource management since it contains handles to the process
+        // that will be created and its threads and that must be closed at some point.
+        PROCESS_INFORMATION _piProcInfo;
+    };
+
+}

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -21,13 +21,112 @@
 
 namespace Oobe
 {
-    class SplashController
+
+    namespace internal
     {
+        HWND find_main_thread_window(DWORD thread_id, const wchar_t* windowClass);
+    }
+
+    // Groups a set of functions of stateless functions that interact with the OS to create a process and manipulate
+    // windows according to the needs of the SplashController.
+    // Although those functions could be inside the body of the SplashController state transition methods, abstracting
+    // out the strategy benefits separation of the OS interaction with the logic of the states, thus benefits
+    // testability. Without that separation, the splash controller would never leave the Idle state during tests.
+    // Since most of the functions herein implemented are quite small, the class definition is placed in the header
+    // aiming to allow compiler see completely thru it and ensure optimising out funciton calls.
+    struct SplashStrategy
+    {
+        static bool do_create_process(const std::filesystem::path& exePath,
+                                      STARTUPINFO& startup,
+                                      PROCESS_INFORMATION& process)
+        {
+            TCHAR szCmdline[MAX_PATH];
+            wcsncpy_s(szCmdline, exePath.wstring().c_str(), exePath.wstring().length());
+            BOOL res = CreateProcess(nullptr,               // command line
+                                     szCmdline,             // non-const CLI
+                                     nullptr,               // process security attributes
+                                     nullptr,               // primary thread security attributes
+                                     TRUE,                  // handles are inherited
+                                     0,                     // creation flags
+                                     nullptr,               // use parent's environment
+                                     nullptr,               // use parent's current directory
+                                     &startup,              // STARTUPINFO pointer
+                                     &process);             // output: PROCESS_INFORMATION
+            return res != 0 && process.hProcess != nullptr; // success
+        }
+
+        static HWND do_find_window_by_thread_id(DWORD threadId)
+        {
+            // Without implementing more sofisticated IPC, it can be tricky to monitor the Flutter process to
+            // determine the moment in which the window is ready. Yet, Flutter apps are fast to start up on
+            // Windows, so sleeping for some fraction of a second should be enough. The exact amount of time to
+            // sleep might be subject to changes after further testing on situations of heavier workloads or
+            // slower machines or VM's. Yet, it's expected to stay under less than a second.
+            constexpr DWORD flutterWindowToOpenTimeout = 500; // ms.
+            Sleep(flutterWindowToOpenTimeout);
+            return internal::find_main_thread_window(threadId, L"FLUTTER_RUNNER_WIN32_WINDOW");
+        }
+
+        static bool do_show_window(HWND window)
+        {
+            // If the window was previously visible, the return value is nonzero.
+            // If the window was previously hidden, the return value is zero.
+            return ShowWindow(window, SW_SHOWNA) == 0;
+        }
+
+        static bool do_hide_window(HWND window)
+        {
+            return ShowWindow(window, SW_HIDE) != 0;
+        }
+
+        static bool do_place_behind(HWND toBeFront, HWND toBeBehind)
+        {
+            return SetWindowPos(toBeBehind, toBeFront, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE) != 0;
+        }
+        // In the visible state, closing the window should allow the user to confirm closing or doing some clean
+        // up. That is the semantic difference between WM_CLOSE (enables that behavior) versus WM_QUIT (closes
+        // the window unconditionally). Interestingly, a GUI application that implements that semantics (think
+        // of document editor showing a dialog asking if the user wants to save their changes) will hang forever
+        // if the window receives WM_CLOSE while hidden, because the OS will not bring it back to the light,
+        // thus there is no way the user can hit any of the dialog buttons to let the window rest in piece.
+        static void do_forcebly_close(HWND window)
+        {
+            PostMessage(window, WM_QUIT, 0, 0);
+        }
+
+        static void do_gracefully_close(HWND window)
+        {
+            PostMessage(window, WM_CLOSE, 0, 0);
+        }
+    }; // struct SplashStrategy
+
+    /// Implements the states, events and control of the splash application. Most of the actual work that requires
+    /// interacting with the operating system has been moved out to a strategy class, which by default is SplashStrategy
+    /// defined above.
+    template <typename Strategy = SplashStrategy> class SplashController
+    {
+      private:
+        const std::filesystem::path exePath;
+        STARTUPINFO startInfo;
+        // this is the only member that requires ownership/resource management since it contains handles to the process
+        // that will be created and its threads and that must be closed at some point.
+        PROCESS_INFORMATION procInfo;
+
       public:
         /// Initializes the control structures to later run the splash application. Accepts the splash executable
         /// filesystem
         /// path and the HANDLE to the device that will act as the splash standard input.
-        SplashController(std::filesystem::path exePath, not_null<HANDLE> stdIn);
+        SplashController(std::filesystem::path exePath, not_null<HANDLE> stdIn) : exePath{std::move(exePath)}
+        {
+            // Most likely the exePath will be built on the fly from a string, so there is no sense in creating a
+            // temporary and copy it when we can move.
+            ZeroMemory(&procInfo, sizeof(PROCESS_INFORMATION));
+            ZeroMemory(&startInfo, sizeof(STARTUPINFO));
+            startInfo.cb = sizeof(STARTUPINFO);
+            startInfo.hStdInput = stdIn;
+            startInfo.dwFlags |= STARTF_USESTDHANDLES;
+            SetHandleInformation(stdIn, HANDLE_FLAG_INHERIT, 1);
+        }
         // controller events;
         struct Events
         {
@@ -40,7 +139,7 @@ namespace Oobe
             // controller's private members.
             struct Run
             {
-                not_null<SplashController*> controller_;
+                not_null<SplashController<Strategy>*> controller;
             };
             struct ToggleVisibility
             { };
@@ -52,13 +151,13 @@ namespace Oobe
 
             struct Close
             { };
+            using EventVariant = std::variant<ToggleVisibility, Run, PlaceBehind, Close>;
         };
-        using Event = std::variant<Events::ToggleVisibility, Events::Run, Events::PlaceBehind, Events::Close>;
 
         // controller states;
         struct States
         {
-            // Forward-declaring the states enables declaring the variant upfront. Idle::run() needs the variant
+            // Forward-declaring the states enables declaring the variant upfront because Idle::run() needs the variant
             // already declared.
             struct Visible;
             struct Hidden;
@@ -72,37 +171,47 @@ namespace Oobe
                 /// - launching the splash application and
                 /// - finding it's window handle.
                 /// Returns itself (i.e. an instance of the Idle state) otherwise.
-                StateVariant on_event(Events::Run event);
+                StateVariant on_event(typename Events::Run event)
+                {
+                    auto controller = event.controller;
+                    if (!Strategy::do_create_process(
+                          controller->exePath, controller->startInfo, controller->procInfo)) {
+                        return *this; // return the the same (Idle) state.
+                    }
+
+                    HWND window = Strategy::do_find_window_by_thread_id(controller->procInfo.dwThreadId);
+                    if (window == nullptr) {
+                        return *this;
+                    }
+
+                    return Visible{window};
+                }
             };
+
             // `ShouldBeClosed` because we'll not stop to check whether it really closed when PostMessage returns.
             struct ShouldBeClosed
             { };
             struct Hidden
             {
                 HWND window = nullptr;
-                Visible on_event(Events::ToggleVisibility /*unused*/)
+                Visible on_event(typename Events::ToggleVisibility /*unused*/)
                 {
-                    ShowWindow(window, SW_SHOWNA);
+                    Strategy::do_show_window(window);
                     return Visible{window};
                 }
 
                 /// Brings the splash window visible but changes its Z-order to stay behind a window specified by the
                 /// PlaceBehind event.
-                Visible on_event(Events::PlaceBehind event)
+                Visible on_event(typename Events::PlaceBehind event)
                 {
-                    ShowWindow(window, SW_SHOWNA);
-                    SetWindowPos(window, event.front, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                    Strategy::do_show_window(window);
+                    Strategy::do_place_behind(event.front, window);
                     return Visible{window};
                 }
-                // In the visible state, closing the window should allow the user to confirm closing or doing some clean
-                // up. That is the semantic difference between WM_CLOSE (enables that behavior) versus WM_QUIT (closes
-                // the window unconditionally). Interestingly, a GUI application that implements that semantics (think
-                // of document editor showing a dialog asking if the user wants to save their changes) will hang forever
-                // if the window receives WM_CLOSE while hidden, because the OS will not bring it back to the light,
-                // thus there is no way the user can hit any of the dialog buttons to let the window rest in piece.
-                ShouldBeClosed on_event(Events::Close event) const
+
+                ShouldBeClosed on_event(typename Events::Close /*unused*/) const
                 {
-                    PostMessage(window, WM_QUIT, 0, 0);
+                    Strategy::do_forcebly_close(window);
                     return ShouldBeClosed{};
                 }
             };
@@ -110,32 +219,34 @@ namespace Oobe
             struct Visible
             {
                 HWND window = nullptr;
-                Hidden on_event(Events::ToggleVisibility /*unused*/)
+                Hidden on_event(typename Events::ToggleVisibility /*unused*/)
                 {
-                    ShowWindow(window, SW_HIDE);
+                    Strategy::do_hide_window(window);
                     return Hidden{window};
                 }
 
-                ShouldBeClosed on_event(Events::Close event) const
+                ShouldBeClosed on_event(typename Events::Close /*unused*/) const
                 {
-                    PostMessage(window, WM_CLOSE, 0, 0);
+                    Strategy::do_gracefully_close(window);
                     return ShouldBeClosed{};
                 }
             };
         };
+
         // The state machine expects the symbol `State` to be visible.
-        using State = States::StateVariant;
+        // The repetition of `typename` is an unfortunate side effect of having this controller as a template. All event
+        // and state types are now dependant and cannot be explicitly referred to without the templated type argument.
+        using State = typename States::StateVariant;
+        using Event = typename Events::EventVariant;
+        internal::state_machine<SplashController<Strategy>> sm;
 
-        internal::state_machine<SplashController> sm;
-
-        ~SplashController();
-
-      private:
-        const std::filesystem::path exePath;
-        STARTUPINFO startInfo;
-        // this is the only member that requires ownership/resource management since it contains handles to the process
-        // that will be created and its threads and that must be closed at some point.
-        PROCESS_INFORMATION _piProcInfo;
+        ~SplashController()
+        {
+            if (procInfo.hProcess != nullptr) {
+                TerminateProcess(procInfo.hProcess, 0);
+                CloseHandle(procInfo.hThread);
+                CloseHandle(procInfo.hProcess);
+            }
+        }
     };
-
 }

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <variant>
+#include <type_traits>
+
+// There are quite good state machine implementations out there, but since we are avoiding dependencies I took the
+// freedom to model one using std::variant. I plan to use this model in other pieces very soon so I made it
+// somewhat generic an abstract enough to be composed in multiple situations.
+// To make that happen, there is some template magic going on under the internal namespace.
+
+namespace Oobe::internal
+{
+    /**
+     * is_variant_v metafunction holds true if the type argument is a concrete instantiation of std::variant.
+     */
+    template <typename T> struct is_variant : std::false_type
+    { };
+
+    template <typename... Args> struct is_variant<std::variant<Args...>> : std::true_type
+    { };
+
+    template <typename T> inline constexpr bool is_variant_v = is_variant<T>::value;
+
+    /**
+     * is_variant_of_v holds true if the type argument T is one of the alternative types of the variant V.
+     */
+    template <typename T, typename U> struct is_variant_of : std::false_type
+    { };
+
+    template <typename T, typename... Ts>
+    struct is_variant_of<T, std::variant<Ts...>> : public std::disjunction<std::is_same<T, Ts>...>
+    { };
+
+    template <typename T, typename V> inline constexpr bool is_variant_of_v = is_variant_of<T, V>::value;
+
+    // The overloaded pattern is amazingly helpful when dealing with variant visitation. It allows grouping lambdas or
+    // other callable objects that can receive one alternative type of the variant as an overload set that will be used
+    // by std::visit to implement the variant visitation in an exhaustive way, i.e. it fails to compile if some
+    // alternative type of the variant is left unhandled.
+    // It's usage is like:
+    // ```cpp
+    // std::visit(
+    // overloaded
+    // {
+    //  <list of callables, each one handling one possible alternative type of the referred variant>
+    // }, variant_);
+    //
+    template <class... Ts> struct overloaded : Ts...
+    {
+        using Ts::operator()...;
+    };
+    template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+    /**
+     * This state machine implementation builds on the value semantics of std::variant sum type instead of inheritance
+     * hierachies as commonly practiced in object oriented languages.
+     * The template mechanisms above just make a bit easier implementing pattern matching visitation of a variant based
+     * on the underlying types and compile-time checking of types in the context of std::variant instantiation.
+     *
+     * In this state machine the state transition logic is implemented in the state classes. Thus, this is a generic
+     * component which just connects the pieces, the business logic must be implemented somewhere else, being a subclass
+     * or a controller class which has one instance of this. They must provide a member function `ExpectedState
+     * on_event(Events event)` which matches against the Events variant returning the appropriate State. Unhandled
+     * events will default to `return nonstd::make_unexpected(InvalidTransition{state_, event});`
+     *
+     * To effectively build upon this state machine class, some conventions must be followed (they are reinforced by the
+     * template checking spread around this class):
+     *
+     * 1. Define an outer context class, enclosing the definition of states, events and holding the state_machine
+     *    instantiation.
+     * 2. Define state classes grouped in a States class (or struct) for easy discoverability (making dev life a bit
+     *    easier).
+     * 3. Define State as a type alias for std::variant of the state classes. The first type declared in the variant
+     *    argument will be the initial state when the machine is default constructed (if that type is deafult
+     *   constructible).
+     * 4. Apply the exact same steps 2 and 3 for the events, i.e. create the struct Events{}, define the possible events
+     *    inside it and define the alias `using Event = std::variant<list of all the event classes>...`.
+     * 5. Instantiate a state_machine or a subclass deriving from it passing the above mentioned outer scope as a
+     *    template type argument.
+     *
+     * Following those principles turn possible building the API shown in StateMachineTests.cpp. Refer to that file for
+     * examples of usage of this state_machine. It's easier than trying to understand everthying from this header file
+     * only.
+     */
+
+    template <
+      class Context,
+      class State_ = std::enable_if_t<is_variant<typename Context::State>::value, typename Context::State>,
+      class Event_ = std::enable_if_t<is_variant<typename Context::Event>::value, typename Context::Event>,
+      class States_ = std::enable_if_t<std::is_class<typename Context::States>::value, typename Context::States>,
+      class Events_ = std::enable_if_t<std::is_trivial<typename Context::Events>::value, typename Context::Events>>
+    class state_machine
+    {
+      public:
+        /// The Event variant - i.e. an alias to std::variant<list of events...>
+        using Event = Event_;
+        /// The enclosing class of all the event classes - makes easier to discover than from autocompletion.
+        using Events = Events_;
+        /// The State variant - i.e. an alias to std::variant<list of states...>
+        /// The current state of this state_machine is of type `State`.
+        using State = State_;
+        /// The enclosing class of all the state classes - makes easier to discover than from autocompletion.
+        using States = States_;
+
+        /// If an invalid state transition attemp occurs, this caches the current state and the surprising event
+        /// received.
+        struct InvalidTransition
+        {
+            State current;
+            Event received;
+        };
+
+        /// Since not all state transitions will be possible, we model the return value of the functions as an expected.
+        using ExpectedState = nonstd::expected<State, InvalidTransition>;
+
+      protected:
+        State state_;
+
+        /// Attempts to set current state if the argument is a valid one.
+        /// Returns the new state or the argument if it contains an error.
+        /// Serves as a post processing call after adding an event.
+        ExpectedState trySetState(ExpectedState maybe)
+        {
+            if (maybe.has_value()) {
+                state_ = maybe.value();
+                return state_;
+            }
+
+            return maybe;
+        }
+
+      public:
+        /// Returns true if the current state matches the template type argument.
+        /// use it like: `if(machine.isCurrentStateA<States::Connecting>()){`
+        template <typename Alt> auto isCurrentStateA() -> std::enable_if_t<is_variant_of_v<Alt, State>, bool>
+        {
+            return std::holds_alternative<Alt>(state_);
+        }
+        /// This function accepts any argument whose type is an alternative of the Event variant.
+        /// It effectively visits the state_ field (remember that it is a variant) and forwards the received event for
+        /// processing. The state classes implement the logic to know whether a transition should occur (i.e. return a
+        /// new state), or not (return unexpected(InvalidTransition)).
+        ///
+        /// This template is almost identical to the full specialisation `ExpectedState addEvent(Event event)` with the
+        /// benefit of not requiring building a Event variant object, which wold represent a minor overhead.
+        /// Usage: `machine.addEvent(Events::EstablishConnection{"10.0.2.2", 8080})`.
+        template <typename Ev> auto addEvent(Ev&& event) -> std::enable_if_t<is_variant_of_v<Ev, Event>, ExpectedState>
+        {
+            ExpectedState maybe = std::visit(
+              overloaded{
+                [&](auto&& s) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
+                                                    std::is_same_v<decltype(s.on_event(event)), State> ||
+                                                    std::is_same_v<decltype(s.on_event(event)), ExpectedState>,
+                                                  ExpectedState> { return s.on_event(event); },
+                [&](auto&&... arg) -> ExpectedState {
+                    return nonstd::make_unexpected(InvalidTransition{state_, event});
+                },
+              },
+              state_);
+
+            return trySetState(maybe);
+        }
+
+        ///  This overload of the addEvent() member function handles the case when the argument is not an alternative
+        ///  type of the Event variant, but the variant itself. It's useful when the variant has to be created anyway,
+        ///  such as when events are created programatically in a way that is not possible to predict exactly which
+        ///  alternative type is to be created at the call site. Although quite similar, the visitation pattern applied
+        ///  here visits simultaneously both state and event variants.
+        ExpectedState addEvent(Event event)
+        {
+            ExpectedState maybe = std::visit(
+              overloaded{
+                [](auto&& s,
+                   auto&& event) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
+                                                       std::is_same_v<decltype(s.on_event(event)), State> ||
+                                                       std::is_same_v<decltype(s.on_event(event)), ExpectedState>,
+                                                     ExpectedState> { return s.on_event(event); },
+                [&](auto&&... arg) -> ExpectedState {
+                    return nonstd::make_unexpected(InvalidTransition{state_, event});
+                },
+              },
+              state_, event);
+
+            return trySetState(maybe);
+        }
+    };
+}

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <unordered_map>
 #include "expected.hpp"
+#include "not_null.h"
 #include "WslApiLoader.h"
 #include "Helpers.h"
 #include "DistributionInfo.h"


### PR DESCRIPTION
I've been working slowly with this splash controller, adding the small pieces required to make it work, but this time it would be hard to do it in small chunks without showing where the value is. Let me explain why. 

> #### Before reviewing this code, please have a look at what is going on in `DistroLauncher-Tests\SplashControllerTests.cpp`. Try to understand what we gained in terms of testability and reasoning.

The splash controller (defined in `splash_controller.h`) might look scary at a first glance due the usage of a type argument called Strategy and the nested structs defined to model states and events that are connected together by an instance of `internal::state_machine<>` which is a member of the SplashController<> class and yet it's dependent on that type. Quite a lot of template going on.

`internal::state_machine<>` is a type template that depends on an outer `Context` that defines `States` and `Events` types. Internally, this state machine applies some sort of pattern matching on the `State` and `Event` variants (`std::variant`) to delegate to the states themselves the event handling and state transition, while defaulting to return a `InvalidTransition` when no suitable `on_event` member function is found in the states to handle a certain event. That enables automatic handling of invalid transitions.

There are state machine libraries out there able to handle invalid transitions at compile time, which would be even better ([see this one for example](https://github.com/boost-ext/sml)), but since we are striving to avoid adding dependencies and complicated dependency management, I took the freedom to write this from scratch. Yet, that idea is not new neither I can take the credit for inventing that. Using variants and pattern matching to implement state machines instead of the classic class hierarchies originally presented by GoF Design Patterns is something that have been presented and discussed many times out there. The commit history contains some references, if further understanding of that technique is necessary. Honestly there has been quite a while since I've been willing to make something similar to this.

> #### Pushing just the state machine full of templates would be hard to digest for code reviewers. 

For that reason I am pushing together the SplashController.

---

The `SplashController<>` is a templated on a Strategy class full of `do_` member functions for actually doing some work that requires interaction with the operating system. Without that it would be really, really hard to do any testing and leaving an untested controller is quite scary.

All those templates and indirection payoff in the `SplashControllerTests.cpp` test cases (IHMO).
There we can exercise the behavior of the Controller and it's underlying state machine in front of any successfull or unsuccesful call to the operating system.

I attempted to document as much as I could think the reasoning behind most of what I did for implementing this.

I implemented this controlling of the splash application in many ways to exercise how I would integrate those all together. Obviously what I'm pushing is what I believed to be the cleanest way, easier to reason about and less spaghetti-looking code.

---
#### A word on `not_null<>`

`not_null<>` is a class template that wraps a pointer to make sure it cannot be initialized with nullptr, which is a nice way to make sure pointers passed to functions are valid. It checks for nullptr at compile time. It's defined in the `Guidelines Support Library` which implements some types proposed by the C++ Core Guidelines, a community project that curates some best practices for applying the language. I humbly copied the Microsoft's implementation of the `not_null<>`.
That is useful when we want a reference as a member of a class and yet we want to keep that class copy-assignable. C++ references cannot be re-binded.
This is being used to pass an instance of the SplashController to the Idle state thru the Run event to let it properly fill in the data upon the splash process creation.

---

I'm foreseeing two more classes with a design similar to the `SplashController<>`, shall this PR makes success. Otherwise, I'll need to be more creative.