### PR TITLE
Terminal theme fixes

### DIFF
--- a/.github/workflows/detect-update-releases.yaml
+++ b/.github/workflows/detect-update-releases.yaml
@@ -7,7 +7,7 @@ on:
       - 'meta/src/**'
       - 'meta/*/src/**'
       - 'DistroLauncher/DistributionInfo.h'
-      - 'DistroLauncher-Appx/*'
+      - 'DistroLauncher-Appx/**'
       - '.github/workflows/detect-update-releases.yaml'
       - 'wsl-builder/**'
   schedule:

--- a/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>{{.LauncherName}}</TargetName>
     <ProjectName>Ubuntu</ProjectName>

--- a/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -156,6 +156,9 @@
     <Image Include="Assets\Wide310x150Logo.scale-200.png" />
     <Image Include="Assets\Wide310x150Logo.scale-400.png" />
   </ItemGroup>
+  <ItemGroup>
+    <Image Include="Terminal\Fragments\terminal.json" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -21,7 +21,7 @@
           // Also, referencing it if it does not exist will show an error message when opening
           // the profile.
           //"face": "Ubuntu Mono",
-          "face": "Cascadia",
+          "face": "Cascadia Mono",
           "size": 13
         },
         "useAcrylic": true

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu</TargetName>
     <ProjectName>Ubuntu</ProjectName>
@@ -155,6 +155,9 @@
     <Image Include="Assets\Wide310x150Logo.scale-150.png" />
     <Image Include="Assets\Wide310x150Logo.scale-200.png" />
     <Image Include="Assets\Wide310x150Logo.scale-400.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Terminal\Fragments\terminal.json" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -21,7 +21,7 @@
           // Also, referencing it if it does not exist will show an error message when opening
           // the profile.
           //"face": "Ubuntu Mono",
-          "face": "Cascadia",
+          "face": "Cascadia Mono",
           "size": 13
         },
         "useAcrylic": true

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu1804</TargetName>
     <ProjectName>Ubuntu</ProjectName>
@@ -155,6 +155,9 @@
     <Image Include="Assets\Wide310x150Logo.scale-150.png" />
     <Image Include="Assets\Wide310x150Logo.scale-200.png" />
     <Image Include="Assets\Wide310x150Logo.scale-400.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Terminal\Fragments\terminal.json" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -21,7 +21,7 @@
           // Also, referencing it if it does not exist will show an error message when opening
           // the profile.
           //"face": "Ubuntu Mono",
-          "face": "Cascadia",
+          "face": "Cascadia Mono",
           "size": 13
         },
         "useAcrylic": true

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu2004</TargetName>
     <ProjectName>Ubuntu</ProjectName>
@@ -155,6 +155,9 @@
     <Image Include="Assets\Wide310x150Logo.scale-150.png" />
     <Image Include="Assets\Wide310x150Logo.scale-200.png" />
     <Image Include="Assets\Wide310x150Logo.scale-400.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Terminal\Fragments\terminal.json" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -21,7 +21,7 @@
           // Also, referencing it if it does not exist will show an error message when opening
           // the profile.
           //"face": "Ubuntu Mono",
-          "face": "Cascadia",
+          "face": "Cascadia Mono",
           "size": 13
         },
         "useAcrylic": true

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntu2204</TargetName>
     <ProjectName>Ubuntu</ProjectName>
@@ -155,6 +155,9 @@
     <Image Include="Assets\Wide310x150Logo.scale-150.png" />
     <Image Include="Assets\Wide310x150Logo.scale-200.png" />
     <Image Include="Assets\Wide310x150Logo.scale-400.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Terminal\Fragments\terminal.json" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -21,7 +21,7 @@
           // Also, referencing it if it does not exist will show an error message when opening
           // the profile.
           //"face": "Ubuntu Mono",
-          "face": "Cascadia",
+          "face": "Cascadia Mono",
           "size": 13
         },
         "useAcrylic": true

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16215.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <TargetName>ubuntupreview</TargetName>
     <ProjectName>Ubuntu</ProjectName>
@@ -155,6 +155,9 @@
     <Image Include="Assets\Wide310x150Logo.scale-150.png" />
     <Image Include="Assets\Wide310x150Logo.scale-200.png" />
     <Image Include="Assets\Wide310x150Logo.scale-400.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="Terminal\Fragments\terminal.json" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -21,7 +21,7 @@
           // Also, referencing it if it does not exist will show an error message when opening
           // the profile.
           //"face": "Ubuntu Mono",
-          "face": "Cascadia",
+          "face": "Cascadia Mono",
           "size": 13
         },
         "useAcrylic": true

--- a/wsl-builder/prepare-build/go.sum
+++ b/wsl-builder/prepare-build/go.sum
@@ -61,6 +61,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -232,6 +234,8 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Terminal theme fix, with the platform number fix which pass also in CI.

Note that it can look weird that the json is under an "Image" item type. There is no defined name, but I tried "None", "Item" and a set of assets + others and they do not work.
Image does not seem to have any side-effects and works well. There is no official guide on the Windows Terminal example for now, so let’s use this for now.

This branch was both tested on CI (and package installed from CI) from https://github.com/ubuntu/WSL/actions/runs/1887626864 and with Visual Studio, local sideloaded build.