### PR TITLE
Fix on close

### DIFF
--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -179,6 +179,31 @@ namespace Oobe
             constexpr auto WM_CUSTOM_AUTO_CLOSE = WM_USER + 7;
             PostMessage(window, WM_CUSTOM_AUTO_CLOSE, 0, 0);
         }
+
+        static HANDLE do_on_close(HANDLE process, WAITORTIMERCALLBACK callback, void* data)
+        {
+            HANDLE handle{nullptr};
+            if (RegisterWaitForSingleObject(&handle, process, callback, data, INFINITE,
+                                            WT_EXECUTEDEFAULT | WT_EXECUTEONLYONCE) == FALSE) {
+                wprintf(L"Failed to register splash window monitoring callback\n");
+                return nullptr;
+            }
+            return handle;
+        }
+
+        static void do_unsubscribe(HANDLE& waiter)
+        {
+            if (UnregisterWait(waiter) != FALSE) {
+                waiter = nullptr;
+            }
+        }
+
+        static void do_cleanup_process(PROCESS_INFORMATION& procInfo)
+        {
+            TerminateProcess(procInfo.hProcess, 0);
+            CloseHandle(procInfo.hThread);
+            CloseHandle(procInfo.hProcess);
+        }
     }; // struct SplashStrategy
 
     /// Implements the states, events and control of the splash application. Most of the actual work that requires
@@ -211,18 +236,44 @@ namespace Oobe
     /// Also, since the Run event can only be handled by the initial state, that event is expected to succeed only once.
     template <typename Strategy = SplashStrategy> class SplashController
     {
+      public:
+        // Instead of facilitating the typing, the intention of this using clause is to let it explicit that this
+        // callable must not be called in this thread.
+        using CallInOtherThread = std::function<void()>;
+
       private:
         const std::filesystem::path exePath;
         STARTUPINFO startInfo;
         // this is the only member that requires ownership/resource management since it contains handles to the process
         // that will be created and its threads and that must be closed at some point.
         PROCESS_INFORMATION procInfo;
+        HANDLE splashCloseNotifier = nullptr;
+        // This listener will be invoked if and only if the user closes the splash window before the launcher.
+        CallInOtherThread notifyListener;
+
+        // Call-once method which must be called only by the OS in reaction to the user closing the window.
+        // Since the notifyListener member is initialized before the splash runs and (must) never be touched since then,
+        // it's safe to assume no need for synchronization whatsoever in accessing it.
+        // Any need for synchronization must be taken care of by the callable itself.
+        static void onWindowClosedByUser(void* data, BOOLEAN /*unused*/)
+        {
+            auto* self = static_cast<typename SplashController<Strategy>*>(data);
+            self->notifyListener();
+        }
 
       public:
         /// Initializes the control structures to later run the splash application. Accepts the splash executable
-        /// file system path and the HANDLE to the device that will act as the splash standard input.
-        SplashController(std::filesystem::path exePath, not_null<HANDLE> stdIn) : exePath{std::move(exePath)}
+        /// file system path and the HANDLE to the device that will act as the splash standard input and a callable
+        /// object [onClose] to be invoked when the user closes the splash window, if that ever happens.
+        /// IMPORTANT NOTE ON MULTITHREADING: [onClose] will be invoked by another thread, thus any precaution required
+        /// to ensure safe concurrent call must be taken by the [onClose] callable implementation itself and any
+        /// functions it calls inside its body. That's the reason for the horrible type names.
+        template <typename CallableInOtherThread>
+        SplashController(std::filesystem::path exePath, not_null<HANDLE> stdIn, CallableInOtherThread&& onClose) :
+            exePath{std::move(exePath)}, notifyListener{std::forward<CallableInOtherThread>(onClose)}
         {
+            static_assert(std::is_convertible_v<CallableInOtherThread, CallInOtherThread>,
+                          "CallableInOtherThread callback must be void with no arguments.");
             // Most likely the exePath will be built on the fly from a string, so there is no sense in creating a
             // temporary and copy it when we can move.
             ZeroMemory(&procInfo, sizeof(PROCESS_INFORMATION));
@@ -255,7 +306,9 @@ namespace Oobe
             };
 
             struct Close
-            { };
+            {
+                not_null<SplashController<Strategy>*> controller;
+            };
             using EventVariant = std::variant<ToggleVisibility, Run, PlaceBehind, Close>;
         };
 
@@ -279,11 +332,13 @@ namespace Oobe
                 StateVariant on_event(typename Events::Run event)
                 {
                     auto controller = event.controller;
-                    if (!Strategy::do_create_process(
-                          controller->exePath, controller->startInfo, controller->procInfo)) {
+                    if (!Strategy::do_create_process(controller->exePath, controller->startInfo,
+                                                     controller->procInfo)) {
                         std::wcerr << L"Failed to create the splash process\n";
                         return *this; // return the same (Closed) state.
                     }
+                    controller->splashCloseNotifier =
+                      Strategy::do_on_close(controller->procInfo.hProcess, onWindowClosedByUser, controller);
                     if (HWND window = Strategy::do_read_window_from_ipc(); window != nullptr) {
                         return Visible{window};
                     }
@@ -321,8 +376,11 @@ namespace Oobe
                     return Visible{window};
                 }
 
-                ShouldBeClosed on_event(typename Events::Close /*unused*/) const
+                // If the window gets closed programmatically we need to unsubscribe the closing notification.
+                ShouldBeClosed on_event(typename Events::Close event) const
                 {
+                    Strategy::do_unsubscribe(event.controller->splashCloseNotifier);
+                    event.controller->splashCloseNotifier = nullptr;
                     Strategy::do_forcebly_close(window);
                     return ShouldBeClosed{};
                 }
@@ -337,8 +395,10 @@ namespace Oobe
                     return Hidden{window};
                 }
 
-                ShouldBeClosed on_event(typename Events::Close /*unused*/) const
+                ShouldBeClosed on_event(typename Events::Close event) const
                 {
+                    Strategy::do_unsubscribe(event.controller->splashCloseNotifier);
+                    event.controller->splashCloseNotifier = nullptr;
                     Strategy::do_gracefully_close(window);
                     return ShouldBeClosed{};
                 }
@@ -354,10 +414,12 @@ namespace Oobe
 
         ~SplashController()
         {
+            if (splashCloseNotifier != nullptr) {
+                // This ensures that the OS will not call us back when there is no controller alive anymore.
+                Strategy::do_unsubscribe(splashCloseNotifier);
+            }
             if (procInfo.hProcess != nullptr) {
-                TerminateProcess(procInfo.hProcess, 0);
-                CloseHandle(procInfo.hThread);
-                CloseHandle(procInfo.hProcess);
+                Strategy::do_cleanup_process(procInfo);
             }
         }
     };


### PR DESCRIPTION
During tests it was noticed that deadlocks could occur if the user closes the splash window before the application restored the console. We need to have the operating system to notify the application code when the child process ends, if that ever happen, asynchronously. Using only raw Win32 API requires multithreading. 

The heart of the changes are the pair `RegisterWaitForSingleObject/UnregisterWait`. The first assigns a thread from the system's thread pool to execute a callback we supply whenever the monitored object becomes signaled (in this case the splash process handle being closed). As this will be executed in another thread, care must be taken in the callback itself to make the call thread safe. As this monitoring is demanded only by the case of unexpected close-out (most likely by users) `UnregisterWait` must be called before executing a programmatic splash window close, thus the CloseEvent has to carry a way to `do_unsubscribe`. The supplied callback is stored in a type-erased `std::function<void()>`, so it can be a stateless or statefull callable object.

To further harden this PR to eliminate the risk of deadlocks due lack of console reader, the dynamics between the splash and installer GUI were changed in a way that the splash will be preferrably hidden instead of closed when it's time to leave room for the installer window to show up. This was implemented on the splash side on [PR Nº13](https://github.com/ubuntu/ubuntu-wsl-splash/pull/13).

The last piece of change in this PR was just a correction on the SplashController destructor, since it was calling Win32 API directly, defeating the purpose of having the SplashStrategy class.

```diff
        ~SplashController()
        {
            if (splashCloseNotifier != nullptr) {
                // This ensures that the OS will not call us back when there is no controller alive anymore.
                Strategy::do_unsubscribe(splashCloseNotifier);
            }
            if (procInfo.hProcess != nullptr) {
-                TerminateProcess(procInfo.hProcess, 0);
-                CloseHandle(procInfo.hThread);
-                CloseHandle(procInfo.hProcess);
+                Strategy::do_cleanup_process(procInfo);
            }
        }
```

Yet, as before, this is still isolated to the main program and won't cause any change in the launcher application's behavior.