### PR TITLE
Remove acrylic from theme

### DIFF
--- a/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -23,8 +23,7 @@
           //"face": "Ubuntu Mono",
           "face": "Cascadia Mono",
           "size": 13
-        },
-        "useAcrylic": true
+        }
       }
     ],
     "schemes": [

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -23,8 +23,7 @@
           //"face": "Ubuntu Mono",
           "face": "Cascadia Mono",
           "size": 13
-        },
-        "useAcrylic": true
+        }
       }
     ],
     "schemes": [

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -23,8 +23,7 @@
           //"face": "Ubuntu Mono",
           "face": "Cascadia Mono",
           "size": 13
-        },
-        "useAcrylic": true
+        }
       }
     ],
     "schemes": [

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -23,8 +23,7 @@
           //"face": "Ubuntu Mono",
           "face": "Cascadia Mono",
           "size": 13
-        },
-        "useAcrylic": true
+        }
       }
     ],
     "schemes": [

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -23,8 +23,7 @@
           //"face": "Ubuntu Mono",
           "face": "Cascadia Mono",
           "size": 13
-        },
-        "useAcrylic": true
+        }
       }
     ],
     "schemes": [

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -23,8 +23,7 @@
           //"face": "Ubuntu Mono",
           "face": "Cascadia Mono",
           "size": 13
-        },
-        "useAcrylic": true
+        }
       }
     ],
     "schemes": [


### PR DESCRIPTION
Remove acrylic as discussed last week.

I did a rebuild of Ubuntu Preview, and when installing it on ubuntudev1, the expected color profile (generated with Preview) is selected, so nothing more to be done in this regard AFAIK.