### PR TITLE
WSLInfo.cpp/h maintenance

### DIFF
--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -17,29 +17,39 @@
 
 #include "stdafx.h"
 
-namespace Helpers {
-    namespace {
+namespace Oobe::internal
+{
+    namespace
+    {
         bool isX11UnixSocketMounted();
     }
-
-    // Altough currently only used in this translation unit,
+    // Although currently only used in this translation unit,
     // this function has a lot of potential to not be exported.
-    bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds) {
+    bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds)
+    {
+        using defer = std::unique_ptr<std::remove_pointer_t<HANDLE>, decltype(&::CloseHandle)>;
         DWORD exitCode;
-        HANDLE child;
-        HRESULT hr = g_wslApi.WslLaunch(command, FALSE, NULL, NULL, NULL, &child);
-        if (child == NULL || FAILED(hr)) {
+        HANDLE child = nullptr;
+
+        HRESULT hr = g_wslApi.WslLaunch(command, FALSE, nullptr, nullptr, nullptr, &child);
+        if (child == nullptr || FAILED(hr)) {
             return false;
         }
+        defer processGuard{child, CloseHandle}; // ensures to call CloseHandle in the end of the scope.
 
-        WaitForSingleObject(child, dwMilisseconds);
-        auto success = GetExitCodeProcess(child, &exitCode);
-        CloseHandle(child);
-        return (success == TRUE && exitCode == 0);
+        if (WaitForSingleObject(child, dwMilisseconds) == WAIT_OBJECT_0) {
+            auto success = GetExitCodeProcess(child, &exitCode);
+            return (success == TRUE && exitCode == 0);
+        }
+
+        TerminateProcess(child, WAIT_TIMEOUT);
+        return false;
     }
 
     // Retrieves subsystem version from the WSL API.
-    DWORD WslGetDistroSubsystemVersion() {
+    DWORD WslGetDistroSubsystemVersion()
+    {
+        constexpr unsigned short FOURTHBIT = 0x08;
         ULONG distributionVersion;
         ULONG defaultUID;
         WSL_DISTRIBUTION_FLAGS wslDistributionFlags;
@@ -56,37 +66,36 @@ namespace Helpers {
             return 0;
         }
 
-        // discards the env variable string array otherwise they will leak.
-        for (int64_t i = defaultEnvironmentVariableCount-1; i >= 0; --i) {
+        // discarding the env variable string array otherwise they would leak.
+        for (int64_t i = defaultEnvironmentVariableCount - 1; i >= 0; --i) {
             CoTaskMemFree(static_cast<LPVOID>(defaultEnvironmentVariables[i]));
         }
 
-        return distributionVersion;
+        // Per conversation at https://github.com/microsoft/WSL-DistroLauncher/issues/96
+        // the information about version 1 or 2 is on the 4th bit of the distro flags, which is not
+        // currently referenced by the API nor docs. The `1+` is just to ensure we return 1 or two.
+        return (1 + ((wslDistributionFlags & FOURTHBIT) >> 3));
     }
 
-    inline bool isWslgEnabled() {
+    inline bool isWslgEnabled()
+    {
         return isX11UnixSocketMounted();
     }
 
-    bool WslGraphicsSupported() {
-        // Could WSL 3 or greater exist in the future?
-        return (Helpers::isWslgEnabled() &&
-                Helpers::WslGetDistroSubsystemVersion() > 1);
-    }
-     
-/* =========================== INTERNALS ================================== */
-    namespace {
+    namespace
+    {
         // Returns true if the WSL successfully launches a list
         // of commands to ensure X11 socket is properly mounted.
         // One indication that the distro has graphical support enabled.
-        bool isX11UnixSocketMounted() {
-            const std::array cmds = {
-                L"ls -l /tmp/.X11-unix",
-                L"ss -lx | grep \"/tmp/.X11-unix/X0\"",
-            };
+        bool isX11UnixSocketMounted()
+        {
+            const std::array cmds = {L"ls -l /tmp/.X11-unix",                // symlink is resolved,
+                                     L"ss -lx | grep \"/tmp/.X11-unix/X0\"", // socket is listening,
+                                     L"test -n $DISPLAY"};                   // display env var is set.
+
             // I'm sure is better to read this way than with the algorithm.
             // NOLINTNEXTLINE(readability-use-anyofallof)
-            for (const auto *const cmd : cmds) {
+            for (const auto* const cmd : cmds) {
                 if (!WslLaunchSuccess(cmd)) {
                     wprintf(L"Command %s failed.\n", cmd);
                     return false;
@@ -94,6 +103,20 @@ namespace Helpers {
             }
 
             return true;
-        } 
+        }
+
     } // namespace.
+
+} // namespace Oobe::internal
+
+// This was kept under Helpers namespace to avoid touching OOBE.cpp/h files.
+// TODO: move to Oobe namespace when its time to maintain OOBE.cpp/h
+namespace Helpers
+{
+    bool WslGraphicsSupported()
+    {
+        // Could WSL 3 or greater exist in the future?
+        return (Oobe::internal::isWslgEnabled() && Oobe::internal::WslGetDistroSubsystemVersion() > 1);
+    }
+
 } // namespace Helpers.

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -17,20 +17,23 @@
 
 #pragma once
 
-namespace Helpers {
-	// Returns true if user system has WSLg enabled.
-	inline bool isWslgEnabled();
+namespace Helpers
+{
+    // Returns true if WSLg is enabled and distro subsystem version is > 1.
+    bool WslGraphicsSupported();
+}
 
-	// Returns the subsystem version for this specific distro or 0 if failed.
-	DWORD WslGetDistroSubsystemVersion();
+namespace Oobe::internal
+{
+    // Returns true if user system has WSLg enabled.
+    inline bool isWslgEnabled();
 
-	// Returns true if WSLg is enabled and distro subsystem versin is > 1.
-	bool WslGraphicsSupported();
-
-	// Runs a Linux command and checks for successfull exit.
-	// Returns true if all the commands `exit 0`.
-	// Launched command will not be interactive nor show any output,
-	// but it blocks current thread for up to dwMilisseconds.
-	bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds=500); // NOLINT(readability-magic-numbers):
-	// Magic numbers in default arguments should not be an issue.
+    // Returns the subsystem version for this specific distro or 0 if failed.
+    DWORD WslGetDistroSubsystemVersion();
+    // Runs a Linux command and checks for successful exit.
+    // Returns true if all the commands `exit 0`.
+    // Launched command will not be interactive nor show any output,
+    // but it blocks current thread for up to dwMilisseconds.
+    bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds = 500); // NOLINT(readability-magic-numbers):
+    // Magic numbers in default arguments should not be an issue.
 }


### PR DESCRIPTION
Those files were selected to receive the systemd related functions. As they were, CI would generated formatting and linting warnings when pushing systemd related code.


This PR acts as a preparation, anticipating and avoiding those warnings. At the same time, some conceptual changes moving code from `Helpers` namespace (which should stay upstream-only) to `Oobe::internal`. One function was left off this code move to avoid touching other files. They will be treated at a proper time.

Yet, some behavior changes were done here:
- Corrected the distroVersion interpretation.
- Added a check for the $DISPLAY env var being set for Wslg detection.