### PR TITLE
Experimental systemd support on the launcher side

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -71,6 +71,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="ExitStatusParserTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests2.cpp" />
+    <ClCompile Include="IniFindValueTests.cpp" />
     <ClCompile Include="SplashControllerTests.cpp" />
     <ClCompile Include="StateMachineTests.cpp" />
   </ItemGroup>

--- a/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
@@ -1,0 +1,116 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+
+#include "ini_find_value.cpp"
+
+// The assertions below derive from real life experiments in WSL.
+namespace Oobe
+{
+    namespace internal
+    {
+
+        TEST(IniFindValueTests, GoodFileShouldPass)
+        {
+            std::wstring buffer{LR"(# This mimics the syntax of /etc/wsl.conf file with comments.
+[user]
+default = root
+[boot]
+command = /usr/libexec/wsl-systemd
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_TRUE(ini_find_value(fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+            ASSERT_TRUE(ini_find_value(fakeFile, L"user", L"default", L"root"));
+            ASSERT_FALSE(ini_find_value(fakeFile, L"automount", L"enabled", L"true"));
+        }
+
+        TEST(IniFindValueTests, SemicolonCommentsBreaksWSL)
+        {
+            std::wstring buffer{LR"(# This mimics the syntax of /etc/wsl.conf file with comments.
+; Some INI dialects accept semicolon comments. WSL breaks on this and ignores the rest of the file.
+[user]
+default = root
+[boot]
+command = /usr/libexec/wsl-systemd
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_FALSE(ini_find_value(fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+            ASSERT_FALSE(ini_find_value(fakeFile, L"user", L"default", L"root"));
+        }
+
+        TEST(IniFindValueTests, CommentedLineCommandMustResultFalse)
+        {
+            std::wstring buffer{LR"(# This mimics the syntax of /etc/wsl.conf file with comments.
+[user]
+# default = root
+[boot]
+# command = /usr/libexec/wsl-systemd
+# [automount]
+enable = true
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_FALSE(ini_find_value(fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+            ASSERT_FALSE(ini_find_value(fakeFile, L"user", L"default", L"root"));
+            ASSERT_FALSE(ini_find_value(fakeFile, L"automount", L"enabled", L"true"));
+        }
+        TEST(IniFindValueTests, WhiteSpacesAreIrrelevant)
+        {
+            std::wstring buffer{LR"(# This mimics the syntax of /etc/wsl.conf file with comments.
+[user]
+    default = root   
+[boot]
+    command = /usr/libexec/wsl-systemd
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_TRUE(ini_find_value(fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+            ASSERT_TRUE(ini_find_value(fakeFile, L"user", L"default", L"root"));
+        }
+        TEST(IniFindValueTests, IllFormedLinesStopParsing)
+        {
+            std::wstring buffer{LR"([automount]
+
+enabled = true
+mountFsTab = true
+
+[boot]
+command = /usr/libexec/wsl-systemd
+[user]
+name
+
+# The following configuration will never be applied because the syntax is broken in the line above. But the previous were.
+default = root
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_TRUE(ini_find_value(fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+            ASSERT_TRUE(ini_find_value(fakeFile, L"automount", L"enabled", L"true"));
+            ASSERT_TRUE(ini_find_value(fakeFile, L"automount", L"mountFsTab", L"true"));
+            ASSERT_FALSE(ini_find_value(fakeFile, L"user", L"default", L"root"));
+        }
+        TEST(IniFindValueTests, IllFormedSectionAlsoStopParsing)
+        {
+            std::wstring buffer{LR"([automount]
+enabled = true
+mountFsTab = true
+[network
+[boot]
+command = /usr/libexec/wsl-systemd
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_TRUE(ini_find_value(fakeFile, L"automount", L"enabled", L"true"));
+            ASSERT_TRUE(ini_find_value(fakeFile, L"automount", L"mountFsTab", L"true"));
+            ASSERT_FALSE(ini_find_value(fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+        }
+        TEST(IniFindValueTests, SectionsCanBeExtended)
+        {
+            std::wstring buffer{LR"([automount]
+enabled = true
+[boot]
+command = /usr/libexec/wsl-systemd
+[automount]
+mountFsTab = true
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_TRUE(ini_find_value(fakeFile, L"automount", L"enabled", L"true"));
+            ASSERT_TRUE(ini_find_value(fakeFile, L"automount", L"mountFsTab", L"true"));
+        }
+    }
+}

--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -120,7 +120,7 @@ int wmain(int argc, wchar_t const *argv[])
     // Parse the command line arguments.
     if ((SUCCEEDED(hr)) && (!installOnly)) {
         if (arguments.empty()) {
-            hr = g_wslApi.WslLaunchInteractive(L"", false, &exitCode);
+            hr = g_wslApi.WslLaunchInteractive(Oobe::WrapCommand(L"").c_str(), false, &exitCode);
 
             // Check exitCode to see if wsl.exe returned that it could not start the Linux process
             // then prompt users for input so they can view the error message.
@@ -137,7 +137,7 @@ int wmain(int argc, wchar_t const *argv[])
                 command += arguments[index];
             }
 
-            hr = g_wslApi.WslLaunchInteractive(command.c_str(), true, &exitCode);
+            hr = g_wslApi.WslLaunchInteractive(Oobe::WrapCommand(command.c_str()).c_str(), true, &exitCode);
 
         } else if (arguments[0] == ARG_CONFIG) {
             hr = E_INVALIDARG;

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -168,6 +168,7 @@
     <ClCompile Include="OOBE.cpp" />
     <ClCompile Include="ProcessRunner.cpp" />
     <ClCompile Include="find_main_thread_window.cpp" />
+    <ClCompile Include="ini_find_value.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -36,4 +36,15 @@ namespace Oobe::internal
     // but it blocks current thread for up to dwMilisseconds.
     bool WslLaunchSuccess(const TCHAR* command, DWORD dwMilisseconds = 500); // NOLINT(readability-magic-numbers):
     // Magic numbers in default arguments should not be an issue.
+
+    /// Parses an [ini]/conf input stream from the beginning checking for the existence of the entry [section.key].
+    /// Returns true if that sections is present and its value contains the string [valueContains].
+    /// This is intended to be called once, thus no caching.
+    bool ini_find_value(std::wistream& ini, std::wstring_view section, std::wstring_view key,
+                        std::wstring_view valueContains);
+}
+
+namespace Oobe
+{
+    std::wstring WrapCommand(std::wstring_view intendedCommand);
 }

--- a/DistroLauncher/ini_find_value.cpp
+++ b/DistroLauncher/ini_find_value.cpp
@@ -1,0 +1,95 @@
+#include "stdafx.h"
+#include <sstream>
+
+namespace Oobe::internal
+{
+    /// Trims both ends of a string in place.
+    inline void trim(std::wstring& str)
+    {
+        constexpr wchar_t* whitespaces = L" \t\n\r\f\v";
+
+        auto lastpos = str.find_last_not_of(whitespaces);
+        if (lastpos == std::wstring::npos) {
+            str.clear();
+            return;
+        }
+
+        str.erase(lastpos + 1);
+        str.erase(0, str.find_first_not_of(whitespaces));
+    }
+
+    /// Removes wrapping square brackets in place.
+    /// Returns false if the string didn't contain the wrapping bracket pair.
+    inline bool remove_surrounding_brackets(std::wstring& str)
+    {
+        if (str[0] != L'[') {
+            return false;
+        }
+        auto closingBracketPos = str.find_last_of(L']');
+        if (closingBracketPos == std::wstring::npos) {
+            return false;
+        }
+
+        str.erase(closingBracketPos);
+        str.erase(0, 1); // removes the first character only.
+        trim(str);
+        return true;
+    }
+
+    /// Returns true if the entry [section.key] is present in the [ini] file stream and its value contains the string
+    /// [valueContains]. This is intended to be called once, thus no caching.
+    bool ini_find_value(std::wistream& ini, std::wstring_view section, std::wstring_view key,
+                        std::wstring_view valueContains)
+    {
+        std::wstring line;
+        std::wistringstream splitter;
+        std::wstring currentSection, currentKey, value;
+        ini.seekg(0);
+        while (std::getline(ini, line)) {
+            // skip empty lines.
+            if (line.empty()) {
+                continue;
+            }
+            trim(line);
+            switch (line[0]) {
+            case L'#': // skip comments.
+                break;
+
+            case L'[':
+                // ill-formed section header breaks parsing.
+                if (!remove_surrounding_brackets(line)) {
+                    return false;
+                }
+                currentSection = line;
+                break;
+
+            default: // it has to be a key=value line.
+                // If there was no single '=' character in this line, most probably there is a syntax error and the
+                // configuration file is ill-formed. Thus, WSL would have ignored the rest of the file, so it doesn't
+                // matter whether we would find systemd activation line or not after this point or not. WSL current
+                // implementation stops parsing the file after a parsing error is found, yet it performs the
+                // configuration steps of the previously validated entries. There might be billions of other ways to
+                // break the syntax. It's probably not worthy attempting to prevent them all.
+                if (line.find_first_of(L'=') == std::wstring::npos) {
+                    return false;
+                }
+                splitter.clear();
+                splitter.str(line);
+                std::getline(splitter, currentKey, L'=');
+                std::getline(splitter, value, L'=');
+                trim(currentKey);
+                trim(value);
+
+                // The only possible way to return true from this function is finding the key=*valueContains* definition
+                // we are looking for inside the proper section.
+                if (currentSection.compare(section) == 0 && currentKey.compare(key) == 0 &&
+                    value.find(valueContains) != std::wstring::npos) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    } // bool ini_find_value()
+
+} // Oobe::internal


### PR DESCRIPTION
It builds on top of the setuid program we are working on [wsl-setup PR#1](https://github.com/ubuntu/wsl-setup/pull/1) to wrap any command the user passes to the launcher.

Command wrapping takes effect if the `boot.command` entry is found in `/etc/wsl.conf` and its value matches the distro expectation.

A set of test cases documents the assumptions and experiments done in WSL in regards to how it parses the `/etc/wsl.conf` to minimize false positives, i.e., situations in which we would consider systemd support active but WSL would not have activated it. Of course, that's best effort and many unforeseen situations leading to false positives may exist. It seems not scalable to try to prevent all.