### PR TITLE
Rename go build projects with real github path

### DIFF
--- a/wsl-builder/common/go.mod
+++ b/wsl-builder/common/go.mod
@@ -1,4 +1,4 @@
-module github.com/ubuntu/WSL/wsl-builder/common
+module github.com/ubuntu/wsl/wsl-builder/common
 
 go 1.16
 

--- a/wsl-builder/prepare-assets/assets.go
+++ b/wsl-builder/prepare-assets/assets.go
@@ -16,7 +16,7 @@ import (
 	"text/template"
 
 	shutil "github.com/termie/go-shutil"
-	"github.com/ubuntu/WSL/wsl-builder/common"
+	"github.com/ubuntu/wsl/wsl-builder/common"
 	"gopkg.in/gographics/imagick.v2/imagick"
 )
 

--- a/wsl-builder/prepare-assets/go.mod
+++ b/wsl-builder/prepare-assets/go.mod
@@ -1,13 +1,13 @@
-module github.com/ubuntu/WSL-DistroLauncher/wsl-builder/prepare-assets
+module github.com/ubuntu/wsl/wsl-builder/prepare-assets
 
 go 1.16
 
 require (
 	github.com/spf13/cobra v1.1.3
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
-	github.com/ubuntu/WSL/wsl-builder/common v0.0.0-00010101000000-000000000000
+	github.com/ubuntu/wsl/wsl-builder/common v0.0.0-00010101000000-000000000000
 	gopkg.in/gographics/imagick.v2 v2.6.0
 )
 
 // We always want to use the latest local version.
-replace github.com/ubuntu/WSL/wsl-builder/common => ../common
+replace github.com/ubuntu/wsl/wsl-builder/common => ../common

--- a/wsl-builder/prepare-build/build.go
+++ b/wsl-builder/prepare-build/build.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	shutil "github.com/termie/go-shutil"
-	"github.com/ubuntu/WSL/wsl-builder/common"
+	"github.com/ubuntu/wsl/wsl-builder/common"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/wsl-builder/prepare-build/buildGHMatrix.go
+++ b/wsl-builder/prepare-build/buildGHMatrix.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ubuntu/WSL/wsl-builder/common"
+	"github.com/ubuntu/wsl/wsl-builder/common"
 )
 
 type matrixElem struct {

--- a/wsl-builder/prepare-build/go.mod
+++ b/wsl-builder/prepare-build/go.mod
@@ -1,13 +1,13 @@
-module github.com/ubuntu/WSL-DistroLauncher/wsl-builder/prepare-build
+module github.com/ubuntu/wsl/wsl-builder/prepare-build
 
 go 1.16
 
 require (
 	github.com/spf13/cobra v1.1.3
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
-	github.com/ubuntu/WSL/wsl-builder/common v0.0.0-00010101000000-000000000000
+	github.com/ubuntu/wsl/wsl-builder/common v0.0.0-00010101000000-000000000000
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 // We always want to use the latest local version.
-replace github.com/ubuntu/WSL/wsl-builder/common => ../common
+replace github.com/ubuntu/wsl/wsl-builder/common => ../common

--- a/wsl-builder/prepare-build/main.go
+++ b/wsl-builder/prepare-build/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/ubuntu/WSL/wsl-builder/common"
+	"github.com/ubuntu/wsl/wsl-builder/common"
 )
 
 func main() {


### PR DESCRIPTION
We are now using wsl/ instead of distrolauncher in the package name.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>