### PR TITLE
Adding the Flutter splash project as part of the bundle

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -93,6 +93,7 @@ jobs:
           git clone https://github.com/ubuntu/wsl.git ${{ env.workDir }}
           cd ${{ env.workDir }}
           git checkout "${GITHUB_SHA}"
+          git submodule update --init --recursive
       - name: Checkout build-info
         shell: bash
         run: |
@@ -134,6 +135,31 @@ jobs:
           $pwd = ConvertTo-SecureString  '${{ secrets.CERTIFICATE_PASSWORD }}' -AsPlainText -Force
           Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:LocalMachine\Trust -FilePath certificate\certificate.pfx
           Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:CurrentUser\My -FilePath certificate\certificate.pfx
+      - name: Check if packaging the splash app is necessary
+        working-directory: ${{ env.workDir }}
+        shell: bash
+        run: |
+          BUILD_TREE_HASH=$(sha256sum DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
+          META_TREE_HASH=$(sha256sum meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
+          if [ ${BUILD_TREE_HASH} != ${META_TREE_HASH} ]; then
+            echo "withFlutterSplash=true" >> $GITHUB_ENV
+          else
+            echo "Skipping Flutter steps due hashes comparing equal:"
+            echo "    Build tree:  ${BUILD_TREE_HASH}. Meta tree: ${META_TREE_HASH}"
+          fi
+      - uses: subosito/flutter-action@v2
+        if: ${{ env.withFlutterSplash == 'true' }}
+        with:
+          channel: stable
+      - name: Build the splash screen
+        working-directory: ${{ env.workDir }}
+        if: ${{ env.withFlutterSplash == 'true' }}
+        run: |
+          flutter config --enable-windows-desktop
+          cp "DistroLauncher/images/icon.ico" "ubuntu-wsl-splash/windows/runner/resources/app_icon.ico"
+          cd "ubuntu-wsl-splash"
+          flutter gen-l10n
+          flutter build windows --release
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="${{ env.AppxBundlePlatforms }}" /p:UapAppxPackageBuildMode=${{ env.UapAppxPackageBuildMode }} -verbosity:normal

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ubuntu-wsl-splash"]
+	path = ubuntu-wsl-splash
+	url = https://github.com/ubuntu/ubuntu-wsl-splash
+	branch = main

--- a/DistroLauncher-Appx/Directory.build.props
+++ b/DistroLauncher-Appx/Directory.build.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+        <FlutterSplashDir>..\ubuntu-wsl-splash\build\windows\runner\Release\</FlutterSplashDir>
+    </PropertyGroup>
+	<ItemGroup>
+		<FlutterSplashFiles Include="$(FlutterSplashDir)" /> 
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="@(FlutterSplashFiles)">
+			<DeploymentContent>true</DeploymentContent>
+		</None>
+	</ItemGroup>
+</Project>

--- a/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,6 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/DistroLauncher-Appx/MyDistro.appxmanifest.tmpl
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest.tmpl
@@ -9,6 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,6 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Directory.build.props
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Directory.build.props
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,6 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu18.04LTS/src/DistroLauncher-Appx/Directory.build.props
+++ b/meta/Ubuntu18.04LTS/src/DistroLauncher-Appx/Directory.build.props
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Directory.build.props
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Directory.build.props
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,6 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu20.04LTS/src/DistroLauncher-Appx/Directory.build.props
+++ b/meta/Ubuntu20.04LTS/src/DistroLauncher-Appx/Directory.build.props
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,6 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,6 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />


### PR DESCRIPTION
This PR aims to bring the Flutter splash screen as a submodule of the launcher and bundle its build artifacts into the generated appx bundle. This is done by:

- Adding the Flutter repository as a submodule;
- Making the CI fetch and build it;
- Make the Appx project automatically bundle the Flutter build artifacts. This is achieved by the `Directory.build.props` file added to the Appx project directory. To make it specific to the releases that feature the OOBE, the referred build system file is added to the `meta/generated` directories. They are not available in the build tree by default.
- Ensuring the availability of the VC++ runtime on the target host. Achieved by adding the PackageDependency declaration to the `MyDistro.appxmanifest` files. This requires testing on a host we can ensure the runtime will be missing.


The current form of this PR has some drawbacks that may be matter for future efficiency enhancements:
- Flutter build artifacts built for x64 are bundled inside ARM64 packages. Flutter does not currently support ARM64 Windows targets, so the launcher will not even try to make use of those artifacts. 
- Splash flutter app is built at every iteration of the build matrix. The main reason is the icon change between WSLID's. We use the same icon of the launcher.
