### PR TITLE
wsl$ versus wsl.localhost

### DIFF
--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -52,7 +52,7 @@ namespace Oobe
 
     void ExitStatusHandling()
     {
-        std::string prefixedFilePath{"\\\\wsl$\\"};
+        std::string prefixedFilePath{"\\\\wsl.localhost\\"};
         auto distroName = Win32Utils::wide_string_to_utf8(DistributionInfo::Name);
         // That should never fail, but if that happens it is a real bug.
         if (!distroName.has_value()) {

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -64,7 +64,7 @@ namespace DistributionInfo
         // Before shutting down the distro, make sure we set the default
         // user through the WSL API.
         std::wifstream statusFile;
-        const std::wstring wslPrefix = L"\\\\wsl$\\" + DistributionInfo::Name;
+        const std::wstring wslPrefix = L"\\\\wsl.localhost\\" + DistributionInfo::Name;
 
         const TCHAR* subiquityRunPath = L"/run/subiquity/";
         const TCHAR* defaultUIDPath = L"default-uid";
@@ -127,9 +127,9 @@ namespace DistributionInfo
                 return commandLine;
             }
 
-            // Write it to a file inside \\wsl$ distro filesystem.
+            // Write it to a file inside \\wsl.localhost distro filesystem.
             const std::wstring prefillFileNameDest = L"/var/tmp/prefill-system-setup.yaml";
-            const std::wstring wslPrefix = L"\\\\wsl$\\" + DistributionInfo::Name;
+            const std::wstring wslPrefix = L"\\\\wsl.localhost\\" + DistributionInfo::Name;
             std::ofstream prefillFile;
             // Mixing slashes and backslashes that way is not a problem for Windows.
             prefillFile.open(wslPrefix + prefillFileNameDest, std::ios::ate);

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -17,239 +17,247 @@
 
 #include "stdafx.h"
 
-namespace DistributionInfo {
+namespace DistributionInfo
+{
 
-	namespace {
-		std::wstring PreparePrefillInfo();
-		HRESULT OOBEStatusHandling(std::wstring_view status);
-		bool EnsureStopped(unsigned int maxNoOfRetries);
-		bool mustRunOOBEinTextMode();
-		const TCHAR* OOBE_NAME = L"/usr/libexec/wsl-setup";
-	}
+    namespace
+    {
+        std::wstring PreparePrefillInfo();
+        HRESULT OOBEStatusHandling(std::wstring_view status);
+        bool EnsureStopped(unsigned int maxNoOfRetries);
+        bool mustRunOOBEinTextMode();
+        const TCHAR* const OOBE_NAME = L"/usr/libexec/wsl-setup";
+    }
 
-	bool isOOBEAvailable(){
-		DWORD exitCode=-1;
-		std::wstring whichCdm{ L"which " };
-		whichCdm.append(DistributionInfo::OOBE_NAME);
-		HRESULT hr = g_wslApi.WslLaunchInteractive(whichCdm.c_str(), TRUE, &exitCode);
-		// true if launching the process succeeds and `which` command returns 0.
-		return ((SUCCEEDED(hr)) && (exitCode == 0));
-	}
+    bool isOOBEAvailable()
+    {
+        DWORD exitCode = -1;
+        std::wstring whichCdm{L"which "};
+        whichCdm.append(DistributionInfo::OOBE_NAME);
+        HRESULT hr = g_wslApi.WslLaunchInteractive(whichCdm.c_str(), TRUE, &exitCode);
+        // true if launching the process succeeds and `which` command returns 0.
+        return ((SUCCEEDED(hr)) && (exitCode == 0));
+    }
 
-	HRESULT OOBESetup()
-	{
-		// Prepare prefill information to send to the OOBE.
-		std::wstring prefillCLIPostFix = DistributionInfo::PreparePrefillInfo();
-		std::wstring commandLine{ L"sudo " };
-		commandLine.append(DistributionInfo::OOBE_NAME + prefillCLIPostFix);
-		// OOBE runs GUI by default, unless arg --text is set.
-		if (mustRunOOBEinTextMode()) {
-			commandLine.append(L" --text");
-		}
-		// calling the OOBE.
-		DWORD exitCode=-1;
-		HRESULT hr = g_wslApi.WslLaunchInteractive(commandLine.c_str(), TRUE, &exitCode);
-		if ((FAILED(hr)) || (exitCode != 0)) {
-			return hr;
-		}
+    HRESULT OOBESetup()
+    {
+        // Prepare prefill information to send to the OOBE.
+        std::wstring prefillCLIPostFix = DistributionInfo::PreparePrefillInfo();
+        std::wstring commandLine{L"sudo "};
+        commandLine.append(DistributionInfo::OOBE_NAME + prefillCLIPostFix);
+        // OOBE runs GUI by default, unless arg --text is set.
+        if (mustRunOOBEinTextMode()) {
+            commandLine.append(L" --text");
+        }
+        // calling the OOBE.
+        DWORD exitCode = -1;
+        HRESULT hr = g_wslApi.WslLaunchInteractive(commandLine.c_str(), TRUE, &exitCode);
+        if ((FAILED(hr)) || (exitCode != 0)) {
+            return hr;
+        }
 
-		hr = g_wslApi.WslLaunchInteractive(L"clear", TRUE, &exitCode);
-		if (FAILED(hr)) {
-			return hr;
-		}
+        hr = g_wslApi.WslLaunchInteractive(L"clear", TRUE, &exitCode);
+        if (FAILED(hr)) {
+            return hr;
+        }
 
-		// Before shutting down the distro, make sure we set the default
-		// user through the WSL API.
-		std::wifstream statusFile;
-		const std::wstring wslPrefix = L"\\\\wsl$\\" + DistributionInfo::Name;
+        // Before shutting down the distro, make sure we set the default
+        // user through the WSL API.
+        std::wifstream statusFile;
+        const std::wstring wslPrefix = L"\\\\wsl$\\" + DistributionInfo::Name;
 
-		const TCHAR* subiquityRunPath = L"/run/subiquity/";
-		const TCHAR* defaultUIDPath = L"default-uid";
-		statusFile.open(wslPrefix + subiquityRunPath + defaultUIDPath, std::ios::in);
-		if (statusFile.fail()) {
-			Helpers::PrintErrorMessage(E_FAIL);
-			return E_FAIL;
-		}
+        const TCHAR* subiquityRunPath = L"/run/subiquity/";
+        const TCHAR* defaultUIDPath = L"default-uid";
+        statusFile.open(wslPrefix + subiquityRunPath + defaultUIDPath, std::ios::in);
+        if (statusFile.fail()) {
+            Helpers::PrintErrorMessage(E_FAIL);
+            return E_FAIL;
+        }
 
-		ULONG defaultUID = UID_INVALID;
-		// The file should contain the UID and nothing else.
-		// TODO: migrate this to a more robust solution, like one single
-		// YAML file.
-		statusFile >> defaultUID;
-		if (statusFile.fail() || defaultUID == UID_INVALID) {
-			Helpers::PrintErrorMessage(E_FAIL);
-			return E_FAIL;
-		}
-		statusFile.close();
+        ULONG defaultUID = UID_INVALID;
+        // The file should contain the UID and nothing else.
+        // TODO: migrate this to a more robust solution, like one single
+        // YAML file.
+        statusFile >> defaultUID;
+        if (statusFile.fail() || defaultUID == UID_INVALID) {
+            Helpers::PrintErrorMessage(E_FAIL);
+            return E_FAIL;
+        }
+        statusFile.close();
 
-		hr = g_wslApi.WslConfigureDistribution(defaultUID, WSL_DISTRIBUTION_FLAGS_DEFAULT);
-		if (FAILED(hr)) {
-			return hr;
-		}
+        hr = g_wslApi.WslConfigureDistribution(defaultUID, WSL_DISTRIBUTION_FLAGS_DEFAULT);
+        if (FAILED(hr)) {
+            return hr;
+        }
 
-		// read the OOBE exit status file.
-		// Even without interop activated Windows can still access Linux files under WSL.
-		const TCHAR* launcherStatusPath = L"launcher-status";		
-		
-		statusFile.open(wslPrefix + subiquityRunPath + launcherStatusPath, std::ios::in);
-		if (statusFile.fail()) {
-			Helpers::PrintErrorMessage(E_FAIL);
-			return E_FAIL;
-		}
+        // read the OOBE exit status file.
+        // Even without interop activated Windows can still access Linux files under WSL.
+        const TCHAR* launcherStatusPath = L"launcher-status";
 
-		std::wstring launcherStatus;
-		// Launcher status file should have just one word.
-		statusFile >> launcherStatus;
-		if (statusFile.fail() || launcherStatus.empty()) {
-			Helpers::PrintErrorMessage(E_FAIL);
-			return E_FAIL;
-		}
-		statusFile.close();
+        statusFile.open(wslPrefix + subiquityRunPath + launcherStatusPath, std::ios::in);
+        if (statusFile.fail()) {
+            Helpers::PrintErrorMessage(E_FAIL);
+            return E_FAIL;
+        }
 
-		return OOBEStatusHandling(launcherStatus);
-	}
+        std::wstring launcherStatus;
+        // Launcher status file should have just one word.
+        statusFile >> launcherStatus;
+        if (statusFile.fail() || launcherStatus.empty()) {
+            Helpers::PrintErrorMessage(E_FAIL);
+            return E_FAIL;
+        }
+        statusFile.close();
 
-	// Anonimous namespace to avoid exposing internal details of the implementation.
-	namespace {
+        return OOBEStatusHandling(launcherStatus);
+    }
 
-		// Saves Windows information inside Linux filesystem to supply to the OOBE.
-		// Returns empty string if we fail to generate the prefill file
-		// or the postfix to be added to the OOBE command line.
-		std::wstring PreparePrefillInfo() {
-			std::wstring commandLine;
-			const auto prefillInfo = DistributionInfo::GetPrefillInfoInYaml();
-			if (prefillInfo.empty()) {
-				return commandLine;
-			}
+    // Anonimous namespace to avoid exposing internal details of the implementation.
+    namespace
+    {
 
-			// Write it to a file inside \\wsl$ distro filesystem.        
-			const std::wstring prefillFileNameDest = L"/var/tmp/prefill-system-setup.yaml";
-			const std::wstring wslPrefix = L"\\\\wsl$\\" + DistributionInfo::Name;
-			std::ofstream prefillFile;
-			// Mixing slashes and backslashes that way is not a problem for Windows.
-			prefillFile.open(wslPrefix + prefillFileNameDest, std::ios::ate);
-			if (prefillFile.fail()) {
-				Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
-				return commandLine;
-			}
+        // Saves Windows information inside Linux filesystem to supply to the OOBE.
+        // Returns empty string if we fail to generate the prefill file
+        // or the postfix to be added to the OOBE command line.
+        std::wstring PreparePrefillInfo()
+        {
+            std::wstring commandLine;
+            const auto prefillInfo = DistributionInfo::GetPrefillInfoInYaml();
+            if (prefillInfo.empty()) {
+                return commandLine;
+            }
 
-			prefillFile << prefillInfo;
-			prefillFile.close();
-			if (prefillFile.fail()) {
-				Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
-				return commandLine;
-			}
-			
-			commandLine += L" --prefill=" + prefillFileNameDest;
-			return commandLine;
-		} // std::wstring PreparePrefillInfo().
+            // Write it to a file inside \\wsl$ distro filesystem.
+            const std::wstring prefillFileNameDest = L"/var/tmp/prefill-system-setup.yaml";
+            const std::wstring wslPrefix = L"\\\\wsl$\\" + DistributionInfo::Name;
+            std::ofstream prefillFile;
+            // Mixing slashes and backslashes that way is not a problem for Windows.
+            prefillFile.open(wslPrefix + prefillFileNameDest, std::ios::ate);
+            if (prefillFile.fail()) {
+                Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
+                return commandLine;
+            }
 
-		// OOBEStatusHandling checks the exit status of wsl-setup script
-		// and takes the required actions.
-		HRESULT OOBEStatusHandling(std::wstring_view status) {
-			if (status.compare(L"complete") == 0) {
-				// Do nothing, just return.
-				return S_OK;
-			}
+            prefillFile << prefillInfo;
+            prefillFile.close();
+            if (prefillFile.fail()) {
+                Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
+                return commandLine;
+            }
 
-			bool needsReboot = (status.compare(L"reboot") == 0);
+            commandLine += L" --prefill=" + prefillFileNameDest;
+            return commandLine;
+        } // std::wstring PreparePrefillInfo().
 
-			// Neither reboot nor shutdown
-			if (!needsReboot && (status.compare(L"shutdown") != 0)) {
-				return E_INVALIDARG;
-			}
+        // OOBEStatusHandling checks the exit status of wsl-setup script
+        // and takes the required actions.
+        HRESULT OOBEStatusHandling(std::wstring_view status)
+        {
+            if (status.compare(L"complete") == 0) {
+                // Do nothing, just return.
+                return S_OK;
+            }
 
-			const std::wstring shutdownCmd = L"wsl -t " + DistributionInfo::Name;
-			int cmdResult = _wsystem(shutdownCmd.c_str());
-			if (cmdResult != 0) {
-				return ERROR_FAIL_SHUTDOWN;
-			}
+            bool needsReboot = (status.compare(L"reboot") == 0);
 
-			if (!needsReboot) {
-				return S_OK;
-			}
+            // Neither reboot nor shutdown
+            if (!needsReboot && (status.compare(L"shutdown") != 0)) {
+                return E_INVALIDARG;
+            }
 
-			// Before relaunching, give WSL some time to make sure 
-			// distro is stopped.
-			bool stopSuccess = EnsureStopped(30); // NOLINT(readability-magic-numbers): only used here.
-			if (!stopSuccess) {
-				// We could try again, but who knows why
-				// we failed to stop the distro in the first time.
-				return ERROR_FAIL_SHUTDOWN;
-			}
+            const std::wstring shutdownCmd = L"wsl -t " + DistributionInfo::Name;
+            int cmdResult = _wsystem(shutdownCmd.c_str());
+            if (cmdResult != 0) {
+                return ERROR_FAIL_SHUTDOWN;
+            }
 
-			// We could, but may not want to just `wsl -d Distro`.
-			// We can explore running our launcher in the future.
-			TCHAR launcherName[MAX_PATH];
-			DWORD fnLength = GetModuleFileName(NULL, launcherName, MAX_PATH);
-			if (fnLength == 0) {
-				return HRESULT_FROM_WIN32(GetLastError());
-			}
+            if (!needsReboot) {
+                return S_OK;
+            }
 
-			cmdResult = _wsystem(launcherName);
-			if (cmdResult != 0) {
-				return ERROR_FAIL_RESTART;
-			}
+            // Before relaunching, give WSL some time to make sure
+            // distro is stopped.
+            bool stopSuccess = EnsureStopped(30); // NOLINT(readability-magic-numbers): only used here.
+            if (!stopSuccess) {
+                // We could try again, but who knows why
+                // we failed to stop the distro in the first time.
+                return ERROR_FAIL_SHUTDOWN;
+            }
 
-			return S_OK;
-		} // HRESULT OOBEStatusHandling(std::wstring_view status).
+            // We could, but may not want to just `wsl -d Distro`.
+            // We can explore running our launcher in the future.
+            TCHAR launcherName[MAX_PATH];
+            DWORD fnLength = GetModuleFileName(nullptr, launcherName, MAX_PATH);
+            if (fnLength == 0) {
+                return HRESULT_FROM_WIN32(GetLastError());
+            }
 
-		// Polls WSL to ensure the distro is actually stopped.
-		bool EnsureStopped(unsigned int maxNoOfRetries) {
-			for (unsigned int i=0; i<maxNoOfRetries; ++i) {
-				auto runner = Helpers::ProcessRunner(L"wsl -l --quiet --running");
-				auto exitCode = runner.run();
-				if (exitCode != 0L) {
-					// I'm sure we will want to customize those messages in the short future.
-					Helpers::PrintErrorMessage(ERROR_FAIL_SHUTDOWN);
-					return false;
-				}
+            cmdResult = _wsystem(launcherName);
+            if (cmdResult != 0) {
+                return ERROR_FAIL_RESTART;
+            }
 
-				// Returns true once we don't find the DistributionInfo::Name in process's stdout
-				auto output = runner.getStdOut();
-				if (output.find(DistributionInfo::Name)==std::wstring::npos) {
-					return true;
-				}
+            return S_OK;
+        } // HRESULT OOBEStatusHandling(std::wstring_view status).
 
-				// We don't need to be hard real time precise.
-				Sleep(997); // NOLINT(readability-magic-numbers): only used here.
-			}
-			return false;
-		}
+        // Polls WSL to ensure the distro is actually stopped.
+        bool EnsureStopped(unsigned int maxNoOfRetries)
+        {
+            for (unsigned int i = 0; i < maxNoOfRetries; ++i) {
+                auto runner = Helpers::ProcessRunner(L"wsl -l --quiet --running");
+                auto exitCode = runner.run();
+                if (exitCode != 0L) {
+                    // I'm sure we will want to customize those messages in the short future.
+                    Helpers::PrintErrorMessage(ERROR_FAIL_SHUTDOWN);
+                    return false;
+                }
 
-		// Returns true if OOBE has to be launched in text mode.
-		// That might be the case due lack of graphics support in WSL
-		// or user requirement, by setting the environment variable
-		// LAUNCHER_FORCE_MODE, which can only be:
-		//	0 or unset or invalid = autodetection
-		//	1 = text mode
-		//	2 = GUI mode.
-		bool mustRunOOBEinTextMode() {
-			// has to consider the NULL-terminating.
-			const DWORD expectedSize = 2;
-			wchar_t value[expectedSize];
-			auto readResult = GetEnvironmentVariable(L"LAUNCHER_FORCE_MODE", value, expectedSize);
-			// var unset is not an error.
-			const bool unset = (readResult == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND);
-			// more than one char + NULL, that's invalid. Like a string or a more than one digit number.
-			const bool notASingleChar = (readResult >= expectedSize || value[1] != NULL);
-			// Handle both in the same way: autodetect.
-			if (unset || notASingleChar) {
-				return !Helpers::WslGraphicsSupported();
-			}
+                // Returns true once we don't find the DistributionInfo::Name in process's stdout
+                auto output = runner.getStdOut();
+                if (output.find(DistributionInfo::Name) == std::wstring::npos) {
+                    return true;
+                }
 
-			// Expected result if the env var is correctly set:
-			// readResult == 1 && value[1] == NULL && value[0] in (0,1,2).
-			switch (value[0]) {
-			case L'1': // forced text mode.
-				return true;
-			case L'2': // forced GUI mode, no autodetection.
-				return false;
-			case L'0':
-			default:
-				return !Helpers::WslGraphicsSupported();
-			}
-		}
-	} // namespace.
+                // We don't need to be hard real time precise.
+                Sleep(997); // NOLINT(readability-magic-numbers): only used here.
+            }
+            return false;
+        }
+
+        // Returns true if OOBE has to be launched in text mode.
+        // That might be the case due lack of graphics support in WSL
+        // or user requirement, by setting the environment variable
+        // LAUNCHER_FORCE_MODE, which can only be:
+        //	0 or unset or invalid = autodetection
+        //	1 = text mode
+        //	2 = GUI mode.
+        bool mustRunOOBEinTextMode()
+        {
+            // has to consider the NULL-terminating.
+            const DWORD expectedSize = 2;
+            wchar_t value[expectedSize];
+            auto readResult = GetEnvironmentVariable(L"LAUNCHER_FORCE_MODE", value, expectedSize);
+            // var unset is not an error.
+            const bool unset = (readResult == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND);
+            // more than one char + NULL, that's invalid. Like a string or a more than one digit number.
+            const bool notASingleChar = (readResult >= expectedSize || value[1] != NULL);
+            // Handle both in the same way: autodetect.
+            if (unset || notASingleChar) {
+                return !Helpers::WslGraphicsSupported();
+            }
+
+            // Expected result if the env var is correctly set:
+            // readResult == 1 && value[1] == NULL && value[0] in (0,1,2).
+            switch (value[0]) {
+            case L'1': // forced text mode.
+                return true;
+            case L'2': // forced GUI mode, no autodetection.
+                return false;
+            case L'0':
+            default:
+                return !Helpers::WslGraphicsSupported();
+            }
+        }
+    } // namespace.
 
 } // namespace DistributionInfo.


### PR DESCRIPTION
Not sure why this is happening, but sometimes trying to access `\\wsl$\<DISTRO>` blocks forever while `\\wsl.localhost\<DISTRO>` works.

While no enlightment comes to this issue, let's workaround.

Although this PR looks huge, that's mainly due formatting. The file `OOBE.cpp` predates the current CI and would trigger a lot of warnings. For actual content review focus on commit fbada24edb1ddcffef99cd4946068eb32d77b0bc

Now all filesystem accesses thru WSL Service in the launcher is done with `\\wsl.locahost` path prefix.