### PR TITLE
Removes the option --skip-installer from the arguments vector

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -107,7 +107,7 @@ int wmain(int argc, wchar_t const *argv[])
 
         // If the "--root" option is specified, do not create a user account.
         bool useRoot = ((installOnly) && (arguments.size() > 1) && (arguments[1] == ARG_INSTALL_ROOT));
-        hr = InstallDistribution(!useRoot, arguments[0] == ARG_SKIP_INSTALLER);
+        hr = InstallDistribution(!useRoot, DistributionInfo::shouldSkipInstaller(arguments, ARG_SKIP_INSTALLER));
         if (FAILED(hr)) {
             if (hr == HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)) {
                 Helpers::PrintMessage(MSG_INSTALL_ALREADY_EXISTS);

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -29,6 +29,14 @@ namespace DistributionInfo
         const TCHAR* const OOBE_NAME = L"/usr/libexec/wsl-setup";
     }
 
+    bool shouldSkipInstaller(std::vector<std::wstring_view>& arguments, std::wstring_view value)
+    {
+        auto it = std::remove(arguments.begin(), arguments.end(), value);
+        auto r = std::distance(it, arguments.end());
+        arguments.erase(it, arguments.end());
+        return r > 0;
+    }
+
     bool isOOBEAvailable()
     {
         DWORD exitCode = -1;

--- a/DistroLauncher/OOBE.h
+++ b/DistroLauncher/OOBE.h
@@ -27,4 +27,8 @@ namespace DistributionInfo {
     // GetPrefillInfoInYaml generates a YAML string from Windows user 
     // and locale information, UTF-8 encoded, thus std::string.
     std::string GetPrefillInfoInYaml();
+
+    // Returns true if the argument ARG_SKIP_INSTALLER is present.
+    // Removes it from the argument vector if present to avoid interference with upstream code.
+    bool shouldSkipInstaller(std::vector<std::wstring_view>& arguments, std::wstring_view value);
 }

--- a/DistroLauncher/OOBE.h
+++ b/DistroLauncher/OOBE.h
@@ -17,14 +17,15 @@
 
 #pragma once
 
-namespace DistributionInfo {
+namespace DistributionInfo
+{
     // OOBE Experience.
     HRESULT OOBESetup();
 
-    // isOOBEAvailable returns true if OOBE executable is found inside rootfs. 
+    // isOOBEAvailable returns true if OOBE executable is found inside rootfs.
     bool isOOBEAvailable();
 
-    // GetPrefillInfoInYaml generates a YAML string from Windows user 
+    // GetPrefillInfoInYaml generates a YAML string from Windows user
     // and locale information, UTF-8 encoded, thus std::string.
     std::string GetPrefillInfoInYaml();
 


### PR DESCRIPTION
My previous solution was too naive. Upon conclusion of the installation the rest of the upstream "command line parsing" code understood the existance of the option `--skip-installer` as an argument error and terminated the application when we should run the shell instead.

Now we detect that specific command line argument with a function call that removes it, if exists. So, after installation, the rest of the existing code in `DistroLauncher.cpp` can keep working as if nothing ever changed.