### PR TITLE
Inverts the skip-installer option logic

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -12,7 +12,7 @@
 #define ARG_INSTALL_ROOT        L"--root"
 #define ARG_RUN                 L"run"
 #define ARG_RUN_C               L"-c"
-#define ARG_SKIP_INSTALLER      L"--skip-installer"
+#define ARG_ENABLE_INSTALLER      L"--enable-installer"
 
 // Helper class for calling WSL Functions:
 // https://msdn.microsoft.com/en-us/library/windows/desktop/mt826874(v=vs.85).aspx
@@ -107,7 +107,7 @@ int wmain(int argc, wchar_t const *argv[])
 
         // If the "--root" option is specified, do not create a user account.
         bool useRoot = ((installOnly) && (arguments.size() > 1) && (arguments[1] == ARG_INSTALL_ROOT));
-        hr = InstallDistribution(!useRoot, DistributionInfo::shouldSkipInstaller(arguments, ARG_SKIP_INSTALLER));
+        hr = InstallDistribution(!useRoot, DistributionInfo::shouldSkipInstaller(arguments, ARG_ENABLE_INSTALLER));
         if (FAILED(hr)) {
             if (hr == HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)) {
                 Helpers::PrintMessage(MSG_INSTALL_ALREADY_EXISTS);

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -34,7 +34,7 @@ namespace DistributionInfo
         auto it = std::remove(arguments.begin(), arguments.end(), value);
         auto r = std::distance(it, arguments.end());
         arguments.erase(it, arguments.end());
-        return r > 0;
+        return r == 0;
     }
 
     bool isOOBEAvailable()


### PR DESCRIPTION
Now users by default get the upstream experience.
To leverage the OOBE user is required to add the CLI option `--enable-installer`.

This is the expected result:
![image](https://user-images.githubusercontent.com/11138291/160883875-fde8008a-b76b-4f1e-b890-b023f1c16b55.png)
