### PR TITLE
Workaround missing groups in the current rootfs.

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -39,6 +39,8 @@ HRESULT InstallDistribution(bool createUser, bool skipInstaller)
 
     // Create a user account.
     if (createUser) {
+        // TODO: Remove this when the rootfs gets the missing groups added.
+        DistributionInfo::createMissingGroups({L"admin", L"netdev"});
         if (DistributionInfo::isOOBEAvailable() && skipInstaller==false) {
             if(SUCCEEDED(DistributionInfo::OOBESetup())) {
                 return S_OK;

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "stdafx.h"
+#include <algorithm>
 
 namespace DistributionInfo
 {
@@ -35,6 +36,28 @@ namespace DistributionInfo
         auto r = std::distance(it, arguments.end());
         arguments.erase(it, arguments.end());
         return r == 0;
+    }
+
+    // TODO: Remove this when the rootfs gets the missing groups added.
+    void createMissingGroups(std::vector<std::wstring_view> groups)
+    {
+        std::wstring command;
+        command.reserve(80);
+        if (groups.empty()) {
+            return;
+        }
+
+        auto createOneGroup = [&command, wslApi = &g_wslApi](std::wstring_view grp) {
+            command.clear();
+            command.append(L"groupadd ");
+            command.append(grp);
+            command.append(L" 2>/dev/null");
+            DWORD exitCode;
+            // it doesn't really matter if it fails.
+            wslApi->WslLaunchInteractive(command.c_str(), false, &exitCode);
+        };
+
+        std::for_each(std::begin(groups), std::end(groups), createOneGroup);
     }
 
     bool isOOBEAvailable()

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -41,8 +41,9 @@ namespace DistributionInfo
     // TODO: Remove this when the rootfs gets the missing groups added.
     void createMissingGroups(std::vector<std::wstring_view> groups)
     {
+        constexpr size_t cmdLenght = 80;
         std::wstring command;
-        command.reserve(80);
+        command.reserve(cmdLenght);
         if (groups.empty()) {
             return;
         }
@@ -54,7 +55,7 @@ namespace DistributionInfo
             command.append(L" 2>/dev/null");
             DWORD exitCode;
             // it doesn't really matter if it fails.
-            wslApi->WslLaunchInteractive(command.c_str(), false, &exitCode);
+            wslApi->WslLaunchInteractive(command.c_str(), FALSE, &exitCode);
         };
 
         std::for_each(std::begin(groups), std::end(groups), createOneGroup);

--- a/DistroLauncher/OOBE.h
+++ b/DistroLauncher/OOBE.h
@@ -32,4 +32,7 @@ namespace DistributionInfo
     // Returns true if the argument ARG_SKIP_INSTALLER is present.
     // Removes it from the argument vector if present to avoid interference with upstream code.
     bool shouldSkipInstaller(std::vector<std::wstring_view>& arguments, std::wstring_view value);
+
+    // Temporary workaround to create missing groups required by the current installation.
+    void createMissingGroups(std::vector<std::wstring_view> groups);
 }


### PR DESCRIPTION
This should be reverted once the rootfs gets fixed. For now, this should be enough.

The function could be implemented by just hardcoding two commands, like:

```cpp
g_wslApi.WslLaunchInteractive(L"groupadd admin 2>/dev/null", false, &exitCode);
g_wslApi.WslLaunchInteractive(L"groupadd netdev 2>/dev/null", false, &exitCode);
```

But I don't quite like hardcoding things all around, so I'd rather do some extra work to make a little more generic. Should we need to add another group in the mean time it's just a matter of adding one more group at the call site, instead of another long command. 

Yet, if you think this is overkill, just let me know.