### PR TITLE
Silent which

### DIFF
--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -66,6 +66,7 @@ namespace DistributionInfo
         DWORD exitCode = -1;
         std::wstring whichCmd{L"which "};
         whichCmd.append(DistributionInfo::OOBE_NAME);
+        whichCmd.append(L" &>/dev/null");
         HRESULT hr = g_wslApi.WslLaunchInteractive(whichCmd.c_str(), TRUE, &exitCode);
         // true if launching the process succeeds and `which` command returns 0.
         return ((SUCCEEDED(hr)) && (exitCode == 0));

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -66,8 +66,10 @@ namespace DistributionInfo
         DWORD exitCode = -1;
         std::wstring whichCmd{L"which "};
         whichCmd.append(DistributionInfo::OOBE_NAME);
-        whichCmd.append(L" &>/dev/null");
-        HRESULT hr = g_wslApi.WslLaunchInteractive(whichCmd.c_str(), TRUE, &exitCode);
+        HANDLE child = nullptr;
+        HRESULT hr = g_wslApi.WslLaunch(whichCmd.c_str(), FALSE, nullptr, nullptr, nullptr, &child);
+        WaitForSingleObject(child, INFINITE);
+        GetExitCodeProcess(child, &exitCode);
         // true if launching the process succeeds and `which` command returns 0.
         return ((SUCCEEDED(hr)) && (exitCode == 0));
     }

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -64,9 +64,9 @@ namespace DistributionInfo
     bool isOOBEAvailable()
     {
         DWORD exitCode = -1;
-        std::wstring whichCdm{L"which "};
-        whichCdm.append(DistributionInfo::OOBE_NAME);
-        HRESULT hr = g_wslApi.WslLaunchInteractive(whichCdm.c_str(), TRUE, &exitCode);
+        std::wstring whichCmd{L"which "};
+        whichCmd.append(DistributionInfo::OOBE_NAME);
+        HRESULT hr = g_wslApi.WslLaunchInteractive(whichCmd.c_str(), TRUE, &exitCode);
         // true if launching the process succeeds and `which` command returns 0.
         return ((SUCCEEDED(hr)) && (exitCode == 0));
     }


### PR DESCRIPTION
Besides the typo in the variable name, while checking for the existence of the OOBE, this function caused some undesired output to console with not much context or information. This PR silences it, since for this function, checking the exit code is enough.