### PR TITLE
Decreases the chance of failure to find Windows terminal window

### DIFF
--- a/DistroLauncher/console_service.h
+++ b/DistroLauncher/console_service.h
@@ -80,6 +80,7 @@ namespace Win32Utils
             assert(redirectTo.readHandle() != nullptr);
             // Attempting to find the console window is best-effort if it is not the old style console.
             // This has been tested for the new Windows Terminal. Other terminals out there may not fit.
+            Sleep(100);
             window_ = FindWindow(L"CASCADIA_HOSTING_WINDOW_CLASS", DistributionInfo::WindowTitle.c_str());
             if (window_ == NULL) {
                 window_ = GetConsoleWindow();


### PR DESCRIPTION
It's been observed with experimentation that sometimes we fail to find console window. Making the main thread sleep for a few milisseconds reduced dramatically the occurences of failure on call to `FindWindow()`.