### PR TITLE
Exports two functions out of OOBE.cpp

### DIFF
--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -22,10 +22,8 @@ namespace DistributionInfo
 
     namespace
     {
-        std::wstring PreparePrefillInfo();
         HRESULT OOBEStatusHandling(std::wstring_view status);
         bool EnsureStopped(unsigned int maxNoOfRetries);
-        bool mustRunOOBEinTextMode();
         const TCHAR* const OOBE_NAME = L"/usr/libexec/wsl-setup";
     }
 
@@ -77,43 +75,77 @@ namespace DistributionInfo
         return S_OK;
     }
 
+    // Saves Windows information inside Linux filesystem to supply to the OOBE.
+    // Returns empty string if we fail to generate the prefill file
+    // or the postfix to be added to the OOBE command line.
+    std::wstring PreparePrefillInfo()
+    {
+        std::wstring commandLine;
+        const auto prefillInfo = DistributionInfo::GetPrefillInfoInYaml();
+        if (prefillInfo.empty()) {
+            return commandLine;
+        }
+
+        // Write it to a file inside \\wsl.localhost distro filesystem.
+        const std::wstring prefillFileNameDest = L"/var/tmp/prefill-system-setup.yaml";
+        const std::wstring wslPrefix = L"\\\\wsl.localhost\\" + DistributionInfo::Name;
+        std::ofstream prefillFile;
+        // Mixing slashes and backslashes that way is not a problem for Windows.
+        prefillFile.open(wslPrefix + prefillFileNameDest, std::ios::ate);
+        if (prefillFile.fail()) {
+            Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
+            return commandLine;
+        }
+
+        prefillFile << prefillInfo;
+        prefillFile.close();
+        if (prefillFile.fail()) {
+            Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
+            return commandLine;
+        }
+
+        commandLine += L" --prefill=" + prefillFileNameDest;
+        return commandLine;
+    } // std::wstring PreparePrefillInfo().
+
+    // Returns true if OOBE has to be launched in text mode.
+    // That might be the case due lack of graphics support in WSL
+    // or user requirement, by setting the environment variable
+    // LAUNCHER_FORCE_MODE, which can only be:
+    //	0 or unset or invalid = autodetection
+    //	1 = text mode
+    //	2 = GUI mode.
+    bool mustRunOOBEinTextMode()
+    {
+        // has to consider the NULL-terminating.
+        const DWORD expectedSize = 2;
+        wchar_t value[expectedSize];
+        auto readResult = GetEnvironmentVariable(L"LAUNCHER_FORCE_MODE", value, expectedSize);
+        // var unset is not an error.
+        const bool unset = (readResult == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND);
+        // more than one char + NULL, that's invalid. Like a string or a more than one digit number.
+        const bool notASingleChar = (readResult >= expectedSize || value[1] != NULL);
+        // Handle both in the same way: autodetect.
+        if (unset || notASingleChar) {
+            return !Helpers::WslGraphicsSupported();
+        }
+
+        // Expected result if the env var is correctly set:
+        // readResult == 1 && value[1] == NULL && value[0] in (0,1,2).
+        switch (value[0]) {
+        case L'1': // forced text mode.
+            return true;
+        case L'2': // forced GUI mode, no autodetection.
+            return false;
+        case L'0':
+        default:
+            return !Helpers::WslGraphicsSupported();
+        }
+    }
+
     // Anonimous namespace to avoid exposing internal details of the implementation.
     namespace
     {
-
-        // Saves Windows information inside Linux filesystem to supply to the OOBE.
-        // Returns empty string if we fail to generate the prefill file
-        // or the postfix to be added to the OOBE command line.
-        std::wstring PreparePrefillInfo()
-        {
-            std::wstring commandLine;
-            const auto prefillInfo = DistributionInfo::GetPrefillInfoInYaml();
-            if (prefillInfo.empty()) {
-                return commandLine;
-            }
-
-            // Write it to a file inside \\wsl.localhost distro filesystem.
-            const std::wstring prefillFileNameDest = L"/var/tmp/prefill-system-setup.yaml";
-            const std::wstring wslPrefix = L"\\\\wsl.localhost\\" + DistributionInfo::Name;
-            std::ofstream prefillFile;
-            // Mixing slashes and backslashes that way is not a problem for Windows.
-            prefillFile.open(wslPrefix + prefillFileNameDest, std::ios::ate);
-            if (prefillFile.fail()) {
-                Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
-                return commandLine;
-            }
-
-            prefillFile << prefillInfo;
-            prefillFile.close();
-            if (prefillFile.fail()) {
-                Helpers::PrintErrorMessage(CO_E_FAILEDTOCREATEFILE);
-                return commandLine;
-            }
-
-            commandLine += L" --prefill=" + prefillFileNameDest;
-            return commandLine;
-        } // std::wstring PreparePrefillInfo().
-
         // OOBEStatusHandling checks the exit status of wsl-setup script
         // and takes the required actions.
         HRESULT OOBEStatusHandling(std::wstring_view status)
@@ -189,40 +221,6 @@ namespace DistributionInfo
             return false;
         }
 
-        // Returns true if OOBE has to be launched in text mode.
-        // That might be the case due lack of graphics support in WSL
-        // or user requirement, by setting the environment variable
-        // LAUNCHER_FORCE_MODE, which can only be:
-        //	0 or unset or invalid = autodetection
-        //	1 = text mode
-        //	2 = GUI mode.
-        bool mustRunOOBEinTextMode()
-        {
-            // has to consider the NULL-terminating.
-            const DWORD expectedSize = 2;
-            wchar_t value[expectedSize];
-            auto readResult = GetEnvironmentVariable(L"LAUNCHER_FORCE_MODE", value, expectedSize);
-            // var unset is not an error.
-            const bool unset = (readResult == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND);
-            // more than one char + NULL, that's invalid. Like a string or a more than one digit number.
-            const bool notASingleChar = (readResult >= expectedSize || value[1] != NULL);
-            // Handle both in the same way: autodetect.
-            if (unset || notASingleChar) {
-                return !Helpers::WslGraphicsSupported();
-            }
-
-            // Expected result if the env var is correctly set:
-            // readResult == 1 && value[1] == NULL && value[0] in (0,1,2).
-            switch (value[0]) {
-            case L'1': // forced text mode.
-                return true;
-            case L'2': // forced GUI mode, no autodetection.
-                return false;
-            case L'0':
-            default:
-                return !Helpers::WslGraphicsSupported();
-            }
-        }
     } // namespace.
 
 } // namespace DistributionInfo.

--- a/DistroLauncher/OOBE.h
+++ b/DistroLauncher/OOBE.h
@@ -29,6 +29,20 @@ namespace DistributionInfo
     // and locale information, UTF-8 encoded, thus std::string.
     std::string GetPrefillInfoInYaml();
 
+    // Saves Windows information inside Linux filesystem to supply to the OOBE.
+    // Returns empty string if we fail to generate the prefill file
+    // or the postfix to be added to the OOBE command line.
+    std::wstring PreparePrefillInfo();
+
+    // Returns true if OOBE has to be launched in text mode.
+    // That might be the case due lack of graphics support in WSL
+    // or user requirement, by setting the environment variable
+    // LAUNCHER_FORCE_MODE, which can only be:
+    //	0 or unset or invalid = autodetection
+    //	1 = text mode
+    //	2 = GUI mode.
+    bool mustRunOOBEinTextMode();
+
     // Returns true if the argument ARG_SKIP_INSTALLER is present.
     // Removes it from the argument vector if present to avoid interference with upstream code.
     bool shouldSkipInstaller(std::vector<std::wstring_view>& arguments, std::wstring_view value);


### PR DESCRIPTION
The two functions subject to this set of changes were previosuly hidden by an anonymous namespace, but now we need to expose them so that the InstallerPolicy can call them.