### PR TITLE
Extended command line options.

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -66,6 +66,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ConsoleServiceTests.cpp" />
+    <ClCompile Include="ExtendedCliParserTests.cpp" />
     <ClCompile Include="InstallerControllerTests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ExitStatusParserTests.cpp" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
@@ -1,0 +1,115 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+#include "extended_cli_parser.cpp"
+
+namespace Oobe::internal
+{
+    TEST(ExtendedCliParserTests, AutoInstallGoodCLI)
+    {
+        const wchar_t path[]{L"~/Downloads/autoinstall.yaml"};
+        std::vector<std::wstring_view> args{L"install", ARG_EXT_AUTOINSTALL, path};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<AutoInstall>(opts));
+        auto& opt = std::get<AutoInstall>(opts);
+        ASSERT_TRUE(opt.autoInstallFile == path);
+    }
+
+    TEST(ExtendedCliParserTests, AutoInstallMissingDashesIsFailure)
+    {
+        const wchar_t path[]{L"~/Downloads/autoinstall.yaml"};
+        std::vector<std::wstring_view> args{L"install", L"autoinstall", path};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_FALSE(std::holds_alternative<AutoInstall>(opts));
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+    }
+
+    TEST(ExtendedCliParserTests, AutoInstallMissingPathResultsNone)
+    {
+        std::vector<std::wstring_view> args{L"install", ARG_EXT_AUTOINSTALL};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_FALSE(std::holds_alternative<AutoInstall>(opts));
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+    }
+
+    TEST(ExtendedCliParserTests, InstallOobeNoShell)
+    {
+        std::vector<std::wstring_view> args{L"install", ARG_EXT_ENABLE_INSTALLER};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<InteractiveInstallOnly>(opts));
+    }
+    TEST(ExtendedCliParserTests, InstallOobeWithShell)
+    {
+        std::vector<std::wstring_view> args{ARG_EXT_ENABLE_INSTALLER};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<InteractiveInstallShell>(opts));
+    }
+    TEST(ExtendedCliParserTests, OobeReconfig)
+    {
+        std::vector<std::wstring_view> args{L"config"};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<Reconfig>(opts));
+    }
+    // Tests whether the upstream options remain preserved:
+    TEST(ExtendedCliParserUpstreamPreservedTests, InstallOobeDisabledWithShell)
+    {
+        std::vector<std::wstring_view> args{};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+    }
+    TEST(ExtendedCliParserTests, InstallRootIsUpstream)
+    {
+        std::vector<std::wstring_view> args{L"install", L"--root"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+    TEST(ExtendedCliParserUpstreamPreservedTests, InstallOobeDisabledNoShell)
+    {
+        std::vector<std::wstring_view> args{L"install"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+    TEST(ExtendedCliParserUpstreamPreservedTests, ConfigDefaultUserIsUpstream)
+    {
+        std::vector<std::wstring_view> args{L"config", L"--default-user", L"u"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+    TEST(ExtendedCliParserUpstreamPreservedTests, HelpIsUpstream)
+    {
+        std::vector<std::wstring_view> args{L"help"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+    TEST(ExtendedCliParserUpstreamPreservedTests, RunIsUpstream)
+    {
+        std::vector<std::wstring_view> args{L"run", L"whoami"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+    TEST(ExtendedCliParserUpstreamPreservedTests, InvalidIntallIsUpstream)
+    {
+        std::vector<std::wstring_view> args{L"install", L"--user"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+    TEST(ExtendedCliParserUpstreamPreservedTests, InvalidConfigIsUpstream)
+    {
+        std::vector<std::wstring_view> args{L"config", L"--boot-command", L"/usr/libexec/wsl-systemd"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+}

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -140,6 +140,7 @@
   <ItemGroup>
     <ClInclude Include="console_service.h" />
     <ClInclude Include="ExitStatus.h" />
+    <ClInclude Include="extended_cli_parser.h" />
     <ClInclude Include="installer_controller.h" />
     <ClInclude Include="installer_policy.h" />
     <ClInclude Include="not_null.h" />
@@ -162,6 +163,7 @@
     <ClCompile Include="DistributionInfo.cpp" />
     <ClCompile Include="ExitStatus.cpp" />
     <ClCompile Include="exit_status_parser.cpp" />
+    <ClCompile Include="extended_cli_parser.cpp" />
     <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="DistroLauncher.cpp" />
     <ClCompile Include="local_named_pipe.cpp" />

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "stdafx.h"
+#include "extended_cli_parser.h"
+
+namespace Oobe::internal
+{
+    // Currently all CLI argument parsing outputs can be constructed in the same way, except for the AutoInstall,
+    // which requires a file path, thus templates with an specialization for the AutoInstall case. Those templates are
+    // only visible and accessible in this file.
+    template <typename ParsedOpt> std::optional<ParsedOpt> tryParse(const std::vector<std::wstring_view>& arguments)
+    {
+        if (arguments.size() != ParsedOpt::requirements.size()) {
+            return std::nullopt;
+        }
+        auto mismatch = std::mismatch(std::begin(ParsedOpt::requirements), std::end(ParsedOpt::requirements),
+                                      std::begin(arguments), std::end(arguments));
+        if (mismatch.first == ParsedOpt::requirements.end() && mismatch.second == arguments.end()) {
+            return ParsedOpt{};
+        }
+
+        return std::nullopt;
+    }
+    template <> std::optional<AutoInstall> tryParse(const std::vector<std::wstring_view>& arguments)
+    {
+        if (arguments.size() != AutoInstall::requirements.size()) {
+            return std::nullopt;
+        }
+        auto mismatch = std::mismatch(std::begin(AutoInstall::requirements), std::end(AutoInstall::requirements),
+                                      std::begin(arguments), std::end(arguments));
+        // a mismatch is expected at the last position of the vector, so the iterators must be `previous to end()`.
+        if (mismatch.first == std::prev(AutoInstall::requirements.end()) &&
+            mismatch.second == std::prev(arguments.end())) {
+            return AutoInstall{*(mismatch.second)};
+        }
+
+        return std::nullopt;
+    }
+
+    Opts parse(const std::vector<std::wstring_view>& arguments)
+    {
+        // launcher.exe install --autoinstall <autoinstallfile>
+        if (auto result = tryParse<AutoInstall>(arguments); result.has_value()) {
+            return result.value();
+        }
+
+        // launcher.exe install --enable-installer - Runs the OOBE and quits.
+        if (auto result = tryParse<InteractiveInstallOnly>(arguments); result.has_value()) {
+            return result.value();
+        }
+        // launcher.exe --enable-installer - Runs the OOBE and brings the shell at the end.
+        if (auto result = tryParse<InteractiveInstallShell>(arguments); result.has_value()) {
+            return result.value();
+        }
+        // launcher.exe config - Runs the OOBE in reconfiguration mode.
+        if (auto result = tryParse<Reconfig>(arguments); result.has_value()) {
+            return result.value();
+        }
+
+        // Any other combination of parameters - should delegate to the "upstream command line parsing".
+        return std::monostate{};
+    }
+
+    Opts parseExtendedOptions(std::vector<std::wstring_view>& arguments)
+    {
+        Opts options{parse(arguments)};
+        // Erasing the extended command line options to avoid confusion in the upstream code.
+        auto it = std::remove_if(arguments.begin(), arguments.end(), [](auto arg) {
+            return arg == ARG_EXT_AUTOINSTALL || arg == ARG_EXT_ENABLE_INSTALLER;
+        });
+        arguments.erase(it, arguments.end());
+        return options;
+    }
+}

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+// TODO: Remove those includes when this file gets into stdafx.h
+#include <filesystem>
+#include <optional>
+#include <variant>
+#include <algorithm>
+
+#define ARG_EXT_ENABLE_INSTALLER L"--enable-installer"
+#define ARG_EXT_AUTOINSTALL      L"--autoinstall"
+
+namespace Oobe::internal
+{
+    // Types resulting of the extended command line parsing.
+    struct AutoInstall
+    {
+        static constexpr std::array<std::wstring_view, 3> requirements{L"install", ARG_EXT_AUTOINSTALL, L""};
+        std::filesystem::path autoInstallFile;
+    };
+    struct InteractiveInstallOnly
+    {
+        static constexpr std::array<std::wstring_view, 2> requirements{L"install", ARG_EXT_ENABLE_INSTALLER};
+    };
+    struct InteractiveInstallShell
+    {
+        static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_ENABLE_INSTALLER};
+    };
+    struct Reconfig
+    {
+        static constexpr std::array<std::wstring_view, 1> requirements{L"config"};
+    };
+    using Opts = std::variant<std::monostate, AutoInstall, InteractiveInstallOnly, InteractiveInstallShell, Reconfig>;
+
+    /// Parses a vector of command line arguments according to the extended command line options declared above. The
+    /// extended options are removed from the original vector as a side effect to avoid confusing the "upstream command
+    /// line parsing" routines. Notice that argv[0], i.e. the program name, is presumed not to be part of the arguments
+    /// vector. See DistroLauncher.cpp main() function.
+    Opts parseExtendedOptions(std::vector<std::wstring_view>& arguments);
+}

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -95,3 +95,37 @@ Language=English
 Please enable the Virtual Machine Platform Windows feature and ensure virtualization is enabled in the BIOS.
 For information please visit https://aka.ms/enablevirtualization
 .
+
+MessageId=2001 SymbolicName=MSG_USAGE_EXTENDED
+Language=English
+Launches or configures a Linux distribution.
+
+Usage:
+    <no args>
+        Launches the user's default shell in the user's home directory.
+
+    install [options]
+        Install the distribution and do not launch the shell when complete.
+          --root
+              Do not create a user account and leave the default user set to root.
+          --autoinstall <AUTOINSTALL-FILE-PATH>
+              Reads information from an YAML file to automatically configure the distribution.
+          --enable-installer
+              Runs the Out of the Box Experience installer user interface.
+              Without the [install] option it launches the user's default shell after finishing installation.
+
+    run <command line>
+        Run the provided command line in the current working directory. If no
+        command line is provided, the default shell is launched.
+
+    config [setting [value]]
+        Configure settings for this distribution.
+        <no args>
+            Presents an user interface with some configuration options.
+        Settings:
+          --default-user <username>
+              Sets the default user to <username>. This must be an existing user.
+
+    help
+        Print usage information.
+.


### PR DESCRIPTION
With PR #123 , #125 and #129 we added a new command line option to the launcher: `--enable-installer`.

This PR presents a more flexible way to add new command line options while preserving the existing ones, including the upstream. It is designed to avoid interaction with the upstream "command line parsing" (a series of if-else clauses in `DistroLauncher.cpp`) by removing the "extended" options from the vector of arguments (which is passed by a mutating reference).

The parsing output is a variant of types representing the tasks the launcher is supposed to do plus a `std::monostate` to represent the not-our-business options, which must be handled by the upstream code. Think of `std::monostate` like a `nil` type for variants.

Shall we want to support more command lines arguments in the future, it's just a matter of creating one new subtype in this file  and a tryParse function mimicking the existing implementations.

You'll notice a contrieved usage of templates inside the cpp file. That doesn't leak to the interface. It's used because for most of the options we added at this time are parsed in the very same way, except for `--autoinstall`, varying only in the quantity and contents of the required strings.

There are better command line parsing libraries out there, like `boost::program_options` or [docopt.cpp](https://github.com/docopt/docopt.cpp), but we are still avoiding bringing dependencies to the launcher and also, this requirement on not disturbing the "upstream CLI parsing" would require some customization anyway.

This, as well as the `MSG_USAGE_EXTENDED` message will be brought together by my next PR.