### PR TITLE
Integrating the workflow

### DIFF
--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -15,9 +15,6 @@
  *
  */
 #pragma once
-#include <variant>
-#include <optional>
-#include <filesystem>
 
 #include "extended_cli_parser.h"
 

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+#include <variant>
+#include <optional>
+#include <filesystem>
+
+#include "extended_cli_parser.h"
+
+namespace Oobe
+{
+    /// Provides the high level API through which the controllers and services are integrated to run (or not) the OOBE
+    /// according to the hardware platform capabilities and the result of the command line parsing. Platform specific
+    /// code is provided by the Strategy template type.
+    template <typename Strategy=DefaultAppStrategy> class Application
+    {
+      private:
+        Strategy impl_;
+        internal::Opts arg;
+        bool isAutoInstall()
+        {
+            return std::holds_alternative<internal::AutoInstall>(arg);
+        }
+        bool isReconfig()
+        {
+            return std::holds_alternative<internal::Reconfig>(arg);
+        }
+
+      public:
+        /// Returns true if the command line parsing doesn't require running the OOBE.
+        /// That implies partial command line parsing, with the required actions deferred to the upstream code.
+        bool shouldSkipInstaller()
+        {
+            return std::holds_alternative<std::monostate>(arg);
+        }
+
+        /// Constructs the initial state of the application. The [arguments] vector is assumed not to hold the argv[0]
+        /// parameter - i.e. the program name. It is passed as a mutating reference to ensure the extended command line
+        /// options will be trimmed out to avoid confusion in the upstream "command line parsing code".
+        Application(std::vector<std::wstring_view>& arguments) : arg{internal::parseExtendedOptions(arguments)}
+        { }
+        Application(const Application& other) = delete;
+        Application(Application&& other) = delete;
+        ~Application() = default;
+
+        /// Invokes the OOBE to perform a setup, which can be an automatic or interactive installation, decided by the
+        /// output of the command line parsing. In other scenarios this returns E_INVALIDARG to signify some CLI parsing
+        /// problem or wrong call-site.
+        HRESULT setup()
+        {
+            wprintf(L"Unpacking is complete!\n");
+            HRESULT hr =
+              std::visit(internal::overloaded{
+                           [&](internal::AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
+                           [&](internal::InteractiveInstallOnly& option) { return impl_.do_install(); },
+                           [&](internal::InteractiveInstallShell& option) { return impl_.do_install(); },
+                           [&](auto&& option) { return E_INVALIDARG; }, // for the cases not treated by this function.
+                         },
+                         arg);
+
+            if (FAILED(hr) && hr != E_NOTIMPL && hr != E_INVALIDARG) {
+                wprintf(L"Installer did not complete successfully.\n");
+                Helpers::PrintErrorMessage(hr);
+                wprintf(L"Applying fallback method.\n");
+            }
+
+            return hr;
+        }
+        /// Invokes the OOBE in reconfiguration mode.
+        /// In order to trigger reconfiguration with the command `launcher.exe config`, the call-site has to be
+        /// different from where the setup() function is called. Thus, checking whether the command line parsing
+        /// actually resulted in Reconfig mode in the first place helps preventing undesired exceptions. In other
+        /// scenarios this returns E_INVALIDARG to signify some CLI parsing problem or wrong call-site.
+        HRESULT reconfigure()
+        {
+            if (isReconfig()) {
+                return impl_.do_reconfigure();
+            }
+
+            return E_INVALIDARG;
+        }
+        /// Runs the splash application if the OOBE is enabled in interactive mode by the command line parsing.
+        void runSplash()
+        {
+            if (isAutoInstall() || shouldSkipInstaller()) {
+                return;
+            }
+            impl_.do_run_splash();
+        }
+    };
+}

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "stdafx.h"
+
+namespace Oobe
+{
+    namespace
+    {
+        // Those functions would be complete duplicates if they were methods in both strategy classes.
+        HRESULT do_reconfigure(Oobe::InstallerController<>& controller)
+        {
+            HRESULT hr = E_NOTIMPL;
+
+            auto ok = controller.sm.addEvent(InstallerController<>::Events::Reconfig{});
+            if (!ok) {
+                return hr;
+            }
+
+            std::visit(internal::overloaded{
+                         [&](InstallerController<>::States::Success& s) { hr = S_OK; },
+                         [&](InstallerController<>::States::UpstreamDefaultInstall& s) { hr = s.hr; },
+                         [&](auto&&... s) { hr = E_UNEXPECTED; },
+                       },
+                       ok.value());
+            return hr;
+        }
+        HRESULT do_autoinstall(InstallerController<>& controller, std::filesystem::path autoinstall_file)
+        {
+            auto& stateMachine = controller.sm;
+
+            auto ok = stateMachine.addEvent(InstallerController<>::Events::AutoInstall{autoinstall_file});
+            if (!ok) {
+                return E_FAIL;
+            }
+            ok = stateMachine.addEvent(InstallerController<>::Events::BlockOnInstaller{});
+            if (!ok) {
+                return E_FAIL;
+            }
+            HRESULT hr = E_NOTIMPL;
+            std::visit(internal::overloaded{
+                         [&](InstallerController<>::States::Success& s) { hr = S_OK; },
+                         [&](InstallerController<>::States::UpstreamDefaultInstall& s) { hr = s.hr; },
+                         [&](auto&&... s) { hr = E_UNEXPECTED; },
+                       },
+                       ok.value());
+            return hr;
+        }
+
+#ifndef _M_ARM64
+
+        std::filesystem::path splashPath()
+        {
+            const wchar_t* splashName = L"ubuntu_wsl_splash.exe";
+            TCHAR launcherName[MAX_PATH];
+            DWORD fnLength = GetModuleFileName(nullptr, launcherName, MAX_PATH);
+            if (fnLength == 0) {
+                return splashName;
+            }
+            std::filesystem::path splashPath{std::wstring_view{launcherName, fnLength}};
+            splashPath.replace_filename(splashName);
+
+            return splashPath;
+        }
+    } // namespace.
+
+    x64Strategy::x64Strategy() : splashExePath{splashPath()}
+    { }
+
+    void x64Strategy::do_run_splash()
+    {
+        if (!std::filesystem::exists(splashExePath)) {
+            wprintf(L"Splash executable [%s] not found.\n", splashExePath.c_str());
+            return;
+        }
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        auto pipe = Win32Utils::makeNamedPipe(true, false, std::to_wstring(now.count()));
+        if (!pipe.has_value()) {
+            wprintf(L"Unable to prepare for the execution of the splash. Error: %s.\n", pipe.error().c_str());
+            return;
+        }
+        // Even though pipe will be moved soon, the handle is just a pointer value, it won't change or invalidate after
+        // moving to another owner.
+        consoleReadHandle = pipe.value().readHandle();
+        console.emplace(std::move(pipe.value()));
+        splash.emplace(splashExePath, consoleReadHandle, [this]() { do_show_console(); });
+
+        // unlocks automatically by its destructor.
+        std::unique_lock<std::timed_mutex> guard{consoleGuard, std::defer_lock};
+        using namespace std::chrono_literals;
+        if (!guard.try_lock_for(5s)) {
+            wprintf(L"Failed to lock console state for modification. Somebody else is holding the lock.\n");
+            return;
+        }
+        console.value().redirectConsole();
+        auto transition = splash.value().sm.addEvent(SplashController<>::Events::Run{&(splash.value())});
+        if (!transition.has_value()) {
+            // rollback.
+            console.value().restoreConsole();
+            return;
+        }
+
+        console.value().hideConsoleWindow();
+        consoleIsVisible = false;
+        splashIsRunning = true;
+    }
+
+    void x64Strategy::do_toggle_splash()
+    {
+        splash.value().sm.addEvent(SplashController<>::Events::ToggleVisibility{});
+    }
+
+    void x64Strategy::do_show_console()
+    {
+        if (consoleIsVisible) {
+            return;
+        }
+        std::unique_lock<std::timed_mutex> guard{consoleGuard, std::defer_lock};
+        using namespace std::chrono_literals;
+        if (!guard.try_lock_for(5s)) {
+            wprintf(L"Failed to lock console state for modification. Somebody else is holding the lock.\n");
+            return;
+        }
+        console.value().showConsoleWindow();
+        console.value().restoreConsole();
+        consoleIsVisible = true;
+    }
+
+    void x64Strategy::do_close_splash()
+    {
+        if (splashIsRunning) {
+            splash.value().sm.addEvent(SplashController<>::Events::Close{&(splash.value())});
+            splashIsRunning = false;
+        }
+        do_show_console();
+    }
+
+    HRESULT x64Strategy::do_install()
+    {
+        std::array<InstallerController<>::Event, 3> eventSequence{InstallerController<>::Events::InteractiveInstall{},
+                                                                  InstallerController<>::Events::StartInstaller{},
+                                                                  InstallerController<>::Events::BlockOnInstaller{}};
+        HRESULT hr = E_NOTIMPL;
+        for (auto& ev : eventSequence) {
+            auto ok = installer.sm.addEvent(ev);
+
+            // unexpected transition occurred here?
+            if (!ok.has_value()) {
+                do_close_splash();
+                return E_FAIL;
+            }
+
+            std::visit(internal::overloaded{
+                         [&](InstallerController<>::States::PreparedTui& s) { do_show_console(); },
+                         [&](InstallerController<>::States::Ready& s) { do_toggle_splash(); },
+                         [&](InstallerController<>::States::Success& s) {
+                             do_close_splash();
+                             hr = S_OK;
+                         },
+                         [&](InstallerController<>::States::UpstreamDefaultInstall& s) {
+                             do_show_console();
+                             hr = s.hr;
+                         },
+                         [&](auto&&... s) { hr = E_UNEXPECTED; },
+                       },
+                       ok.value());
+        }
+
+        return hr;
+    }
+
+    HRESULT x64Strategy::do_reconfigure()
+    {
+        return Oobe::do_reconfigure(installer);
+    }
+
+    HRESULT x64Strategy::do_autoinstall(std::filesystem::path autoinstall_file)
+    {
+        return Oobe::do_autoinstall(installer, autoinstall_file);
+    }
+#else
+
+        HRESULT Arm64Strategy::do_install()
+        {
+            std::array<InstallerController<>::Event, 3> eventSequence{
+              InstallerController<>::Events::InteractiveInstall{}, InstallerController<>::Events::StartInstaller{},
+              InstallerController<>::Events::BlockOnInstaller{}};
+            HRESULT hr = E_NOTIMPL;
+            for (auto& ev : eventSequence) {
+                auto ok = installer.sm.addEvent(ev);
+
+                // unexpected transition occurred here?
+                if (!ok.has_value()) {
+                    return E_FAIL;
+                }
+
+                std::visit(internal::overloaded{
+                             [&](InstallerController<>::States::Success& s) { hr = S_OK; },
+                             [&](InstallerController<>::States::UpstreamDefaultInstall& s) { hr = s.hr; },
+                             [&](auto&&... s) { hr = E_UNEXPECTED; },
+                           },
+                           ok.value());
+            }
+
+            return hr;
+        }
+
+        HRESULT Arm64Strategy::do_reconfigure()
+        {
+            return Oobe::do_reconfigure(installer);
+        }
+        HRESULT Arm64Strategy::do_autoinstall(std::filesystem::path autoinstall_file)
+        {
+            return Oobe::do_autoinstall(installer, autoinstall_file);
+        }
+
+#endif
+}

--- a/DistroLauncher/ApplicationStrategy.h
+++ b/DistroLauncher/ApplicationStrategy.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "state_machine.h"
+#include "installer_policy.h"
+#include "installer_controller.h"
+
+#ifndef _M_ARM64
+#include <mutex>
+#include "local_named_pipe.h"
+#include "console_service.h"
+#include "splash_controller.h"
+
+namespace Oobe
+{
+    // This strategy fulfills the essential API required by the Oobe::Application<> class and augment it with the
+    // machinery necessary to coordinate the splash screen application, the console service for console redirection and
+    // visibility toggling and the OOBE itself running inside Ubuntu.
+    class x64Strategy
+    {
+      private:
+        // This mutex must be acquired before calling ConsoleService::redirectConsole() and
+        // ConsoleService::restoreConsole(). That's a consequence of using RegisterWaitSingleObject to notify if the
+        // user closes the splash application. That function imposes concurrent access to this class and could cause
+        // races and deadlocks if all stars and planets aligned.
+        std::timed_mutex consoleGuard;
+        bool consoleIsVisible = true;
+        bool splashIsRunning = false;
+        std::filesystem::path splashExePath;
+
+        HANDLE consoleReadHandle = nullptr;
+        InstallerController<> installer;
+        // optionals for lazy creation.
+        std::optional<SplashController<>> splash;
+        std::optional<Win32Utils::ConsoleService<Win32Utils::LocalNamedPipe>> console;
+
+        /// Restores the console context, which means undo the console redirection and making the window visible.
+        void do_show_console();
+
+        /// Hides the splash window.
+        void do_toggle_splash();
+
+        /// Notifies the splash controller to quit the application. Console restoration is immediately requested to
+        /// prevent leaving the launcher process without a stdout consumer.
+        void do_close_splash();
+
+      public:
+        /// Places the sequence of events to make the OOBE perform an automatic installation.
+        HRESULT do_autoinstall(std::filesystem::path autoinstall_file);
+
+        /// Places the sequence of events to make the OOBE perform an interactive installation.
+        HRESULT do_install();
+
+        /// Places the sequence of events to make the OOBE perform an automatic installation.
+        HRESULT do_reconfigure();
+
+        /// Triggers the console redirection and launch the splash screen application.
+        void do_run_splash();
+
+        x64Strategy(Win32Utils::LocalNamedPipe&& pipe);
+        x64Strategy();
+        ~x64Strategy() = default;
+    };
+
+}
+#define DefaultAppStrategy Oobe::x64Strategy
+#else
+
+namespace Oobe
+{
+    // This strategy fulfills the essential API required to run the OOBE without the complexity required by the
+    // synchronization of the slide show. That separation is necessary because Flutter is not supported on Windows
+    // ARM64. See: https://github.com/flutter/flutter/issues/62597
+    struct Arm64Strategy
+    {
+        InstallerController<> installer;
+
+        /// Prints to the console an error message informing that this platform doesn't support running the splash
+        /// screen.
+        void do_run_splash()
+        {
+            wprintf(L"This device architecture doesn't support running the splash screen.\n");
+        }
+
+        /// Places the sequence of events to make the OOBE perform an automatic installation.
+        HRESULT do_autoinstall(std::filesystem::path autoinstall_file);
+
+        /// Places the sequence of events to make the OOBE perform an interactive installation.
+        HRESULT do_install();
+
+        /// Places the sequence of events to make the OOBE perform an automatic installation.
+        HRESULT do_reconfigure();
+    };
+
+}
+#define DefaultAppStrategy Oobe::Arm64Strategy
+#endif

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -138,6 +138,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Application.h" />
+    <ClInclude Include="ApplicationStrategy.h" />
     <ClInclude Include="console_service.h" />
     <ClInclude Include="ExitStatus.h" />
     <ClInclude Include="extended_cli_parser.h" />
@@ -160,6 +162,7 @@
     <ClInclude Include="local_named_pipe.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ApplicationStrategy.cpp" />
     <ClCompile Include="DistributionInfo.cpp" />
     <ClCompile Include="ExitStatus.cpp" />
     <ClCompile Include="exit_status_parser.cpp" />

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -15,12 +15,6 @@
  *
  */
 #pragma once
-// TODO: Remove those includes when this file gets into stdafx.h
-#include <filesystem>
-#include <optional>
-#include <variant>
-#include <algorithm>
-
 #define ARG_EXT_ENABLE_INSTALLER L"--enable-installer"
 #define ARG_EXT_AUTOINSTALL      L"--autoinstall"
 

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -1,8 +1,5 @@
 #pragma once
-#include <type_traits>
-#include <iterator>
-#include <utility>
-#include <filesystem>
+
 namespace Oobe
 {
     struct InstallerPolicy

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -16,9 +16,6 @@
  */
 
 #pragma once
-#include "state_machine.h"
-#include <filesystem>
-#include <iostream>
 
 namespace Oobe
 {

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -15,10 +15,6 @@
  *
  */
 #pragma once
-
-#include <variant>
-#include <type_traits>
-
 // There are quite good state machine implementations out there, but since we are avoiding dependencies I took the
 // freedom to model one using std::variant. I plan to use this model in other pieces very soon so I made it
 // somewhat generic an abstract enough to be composed in multiple situations.

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -33,6 +33,12 @@
 #include <any>
 #include <map>
 #include <unordered_map>
+#include <algorithm>
+#include <iostream>
+#include <filesystem>
+#include <optional>
+#include <variant>
+#include <type_traits>
 #include "expected.hpp"
 #include "not_null.h"
 #include "WslApiLoader.h"

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -44,5 +44,7 @@
 #include "ProcessRunner.h"
 #include "WSLInfo.h"
 #include "Win32Utils.h"
+#include "ApplicationStrategy.h"
+#include "Application.h"
 // Message strings compiled from .MC file.
 #include "messages.h"


### PR DESCRIPTION
While I'm fighting against the build system in #122 I think we can advance on this one.

With this we complete the integration between the launcher, the slide show and the OOBE. Complete in the sense that is runnable and debuggable. #122 takes care of the build system.

Enhancements to the experience are expected, for instance, with this the OOBE window is not yet prevented to pop in front of the slide show if the OS chooses to do that. I'll take care of that at next.

As done in previous pull requests, the use of templates for the Application<> class is to select the strategy it uses at compile time (which depends on the target platform, known at compile time) but also to allow for easier tests, although I didn't figure out exactly how I'm going to test this without being redundant with the previous tests.

One interesting fact about this PR is that we end up with a not so big diff in `DistroLauncher.cpp` compared to upstream.

```diff
diff --git a/DistroLauncher/DistroLauncher.cpp b/DistroLauncher/DistroLauncher.cpp
index 9538dd7..ac260f3 100644
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -17,11 +17,12 @@
 // https://msdn.microsoft.com/en-us/library/windows/desktop/mt826874(v=vs.85).aspx
 WslApiLoader g_wslApi(DistributionInfo::Name);
 
-static HRESULT InstallDistribution(bool createUser);
+static HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app);
 static HRESULT SetDefaultUser(std::wstring_view userName);
 
-HRESULT InstallDistribution(bool createUser)
+HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
 {
+    app.runSplash();
     // Register the distribution.
     Helpers::PrintMessage(MSG_STATUS_INSTALLING);
     HRESULT hr = g_wslApi.WslRegisterDistribution();
@@ -31,13 +32,18 @@ HRESULT InstallDistribution(bool createUser)
 
     // Delete /etc/resolv.conf to allow WSL to generate a version based on Windows networking information.
     DWORD exitCode;
-    hr = g_wslApi.WslLaunchInteractive(L"/bin/rm /etc/resolv.conf", true, &exitCode);
+    hr = g_wslApi.WslLaunchInteractive(L"rm /etc/resolv.conf", true, &exitCode);
     if (FAILED(hr)) {
         return hr;
     }
 
     // Create a user account.
     if (createUser) {
+        if (!app.shouldSkipInstaller()) {
+            if (SUCCEEDED(app.setup())) {
+                return S_OK;
+            }
+        }
         Helpers::PrintMessage(MSG_CREATE_USER_PROMPT);
         std::wstring userName;
         do {
@@ -83,6 +89,7 @@ int wmain(int argc, wchar_t const *argv[])
         arguments.push_back(argv[index]);
     }
 
+    Oobe::Application<> app(arguments);
     // Ensure that the Windows Subsystem for Linux optional component is installed.
     DWORD exitCode = 1;
     if (!g_wslApi.WslIsOptionalComponentInstalled()) {
@@ -101,7 +108,7 @@ int wmain(int argc, wchar_t const *argv[])
 
         // If the "--root" option is specified, do not create a user account.
         bool useRoot = ((installOnly) && (arguments.size() > 1) && (arguments[1] == ARG_INSTALL_ROOT));
-        hr = InstallDistribution(!useRoot);
+        hr = InstallDistribution(!useRoot, app);
         if (FAILED(hr)) {
             if (hr == HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)) {
                 Helpers::PrintMessage(MSG_INSTALL_ALREADY_EXISTS);
@@ -117,7 +124,7 @@ int wmain(int argc, wchar_t const *argv[])
     // Parse the command line arguments.
     if ((SUCCEEDED(hr)) && (!installOnly)) {
         if (arguments.empty()) {
-            hr = g_wslApi.WslLaunchInteractive(L"", false, &exitCode);
+            hr = g_wslApi.WslLaunchInteractive(Oobe::WrapCommand(L"").c_str(), false, &exitCode);
 
             // Check exitCode to see if wsl.exe returned that it could not start the Linux process
             // then prompt users for input so they can view the error message.
@@ -134,10 +141,10 @@ int wmain(int argc, wchar_t const *argv[])
                 command += arguments[index];
             }
 
-            hr = g_wslApi.WslLaunchInteractive(command.c_str(), true, &exitCode);
+            hr = g_wslApi.WslLaunchInteractive(Oobe::WrapCommand(command.c_str()).c_str(), true, &exitCode);
 
         } else if (arguments[0] == ARG_CONFIG) {
-            hr = E_INVALIDARG;
+            hr = app.reconfigure();
             if (arguments.size() == 3) {
                 if (arguments[1] == ARG_CONFIG_DEFAULT_USER) {
                     hr = SetDefaultUser(arguments[2]);

```