### PR TITLE
Ensures splash always on top while visible

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
@@ -43,6 +43,12 @@ namespace Oobe
         {
             return nullptr;
         }
+
+        static bool do_show_window(HWND window)
+        {
+            return false;
+        }
+
         static HANDLE do_on_close(HANDLE process, WAITORTIMERCALLBACK callback, void* data)
         {
             return nullptr;
@@ -136,6 +142,12 @@ namespace Oobe
             {
                 return nullptr;
             }
+
+            static bool do_show_window(HWND window)
+            {
+                return false;
+            }
+
             static HANDLE do_on_close(HANDLE process, WAITORTIMERCALLBACK callback, void* data)
             {
                 return static_cast<HANDLE>(globalFakeWindow);

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -147,6 +147,7 @@ namespace Oobe
         {
             // If the window was previously visible, the return value is nonzero.
             // If the window was previously hidden, the return value is zero.
+            // NOLINTNEXTLINE(performance-no-int-to-ptr) - That's the API, there is no way around it.
             SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
             return ShowWindow(window, SW_SHOWNA) == 0;
         }

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -147,6 +147,7 @@ namespace Oobe
         {
             // If the window was previously visible, the return value is nonzero.
             // If the window was previously hidden, the return value is zero.
+            SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
             return ShowWindow(window, SW_SHOWNA) == 0;
         }
 
@@ -330,6 +331,7 @@ namespace Oobe
                     controller->splashCloseNotifier =
                       Strategy::do_on_close(controller->procInfo.hProcess, onWindowClosedByUser, controller);
                     if (HWND window = Strategy::do_read_window_from_ipc(); window != nullptr) {
+                        Strategy::do_show_window(window); // ensures always on top while visible.
                         return Visible{window};
                     }
 


### PR DESCRIPTION
With this change the splash application should stay on top when visible. This ensures the OOBE GUI won't pop up in front of it disruptively, allowing the launcher to control it more smoothly without surprising the user.

This always on top behavior could be annoying, but the slide show will stay for a short period of time, so we should be fine.