### PR TITLE
Corrects substring matching on distro shutdown.

### DIFF
--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -125,7 +125,8 @@ namespace Oobe
 
                 // Returns true once we don't find the DistributionInfo::Name in process's stdout
                 auto output = runner.getStdOut();
-                if (output.find(DistributionInfo::Name) == std::wstring::npos) {
+                auto distroNameLine = DistributionInfo::Name + L'\r';
+                if (output.find(distroNameLine) == std::wstring::npos) {
                     return true;
                 }
 


### PR DESCRIPTION
Without the line break if user has two running distros and the name of one of those is a substring of the other,
the algorithm fails to detect the substring distro had shutdown.

For instance, let's say you have `Ubuntu` and `Ubuntu20.04LTS` running and you want to shutdown `Ubuntu`. The existing logic would fail to detect that `Ubuntu` shutdown because it would always find a match on `Ubuntu22.04LTS`.