### PR TITLE
Hides the OOBE window

### DIFF
--- a/.github/workflows/clang_lint/msbuild/clang_tidy_runner.py
+++ b/.github/workflows/clang_lint/msbuild/clang_tidy_runner.py
@@ -66,6 +66,14 @@ def run(*kwargs):
     print("==== Running clang-tidy with the following arguments:")
     print(cli)
 
+    # Workaround due crashes clang-tidy started to present while instantiating
+    # some template code. Some templating optimizations were done and didn't
+    # succeed in prevent the crash. It was noticed that just trying to run
+    # the linter again would succeed by the second or third attempt in average.
+    # This behavior was observed even when invoking the linter without this
+    # workflow or even without msbuild at all. Further investigation will be
+    # done and a bug report will be issued if confirmed to be a bug.
+    # TODO: Revert this workaround once a proper solution is discovered.
     for i in range(0, 9):
         proc = subprocess.run(cli)
         if proc.returncode < 100:

--- a/.github/workflows/clang_lint/msbuild/clang_tidy_runner.py
+++ b/.github/workflows/clang_lint/msbuild/clang_tidy_runner.py
@@ -66,7 +66,11 @@ def run(*kwargs):
     print("==== Running clang-tidy with the following arguments:")
     print(cli)
 
-    proc = subprocess.run(cli)
+    for i in range(0, 9):
+        proc = subprocess.run(cli)
+        if proc.returncode < 100:
+            break
+        print("\n\nClang-Tidy exit code: {}\n\n".format(proc.returncode))
 
     if proc.returncode != 0:
         print("clang-tidy failed to complete its run.")

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -26,7 +26,7 @@ jobs:
         shell: powershell
         run: | 
           copy .github\workflows\clang_lint\msbuild\Directory.Build.props DistroLauncher\
-          msbuild -p:Platform=x64 -p:Configuration=Debug -t:ClangTidy DistroLauncher\DistroLauncher.vcxproj
+          msbuild -p:Platform=x64 -p:Configuration=Debug -m:1 -t:ClangTidy DistroLauncher\DistroLauncher.vcxproj
       # Runs clang-format. At this point clang-tidy already ran and produced the fixes.yaml.
       # This piece is meant to be cross-platform to enable maximum future reuse. That's why bash.
       - name: Lint with Clang tools

--- a/DistroLauncher-Tests/DistroLauncher-Tests/InstallerControllerTestPolicies.h
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/InstallerControllerTestPolicies.h
@@ -48,7 +48,7 @@ namespace Oobe
             return false;
         }
 
-        static bool poll_success(const wchar_t* command, int repeatTimes)
+        static bool poll_success(const wchar_t* command, int repeatTimes, HANDLE monitoredProcess)
         {
             return false;
         }
@@ -68,6 +68,14 @@ namespace Oobe
         {
             return -1;
         }
+
+        static HWND try_hiding_installer_window(int repeatTimes)
+        {
+            return nullptr;
+        }
+
+        static void show_window(HWND window)
+        { }
     };
 
     const wchar_t* NothingWorksPolicy::OobeCommand = cmd; // unused
@@ -99,7 +107,7 @@ namespace Oobe
             return true;
         }
 
-        static bool poll_success(const wchar_t* command, int repeatTimes)
+        static bool poll_success(const wchar_t* command, int repeatTimes, HANDLE monitoredProcess)
         {
             return true;
         }
@@ -119,6 +127,14 @@ namespace Oobe
         {
             return 0;
         }
+
+        static HWND try_hiding_installer_window(int repeatTimes)
+        {
+            return static_cast<HWND>(GetStdHandle(STD_OUTPUT_HANDLE));
+        }
+
+        static void show_window(HWND window)
+        { }
     };
 
     const wchar_t* EverythingWorksPolicy::OobeCommand = cmd;
@@ -150,7 +166,7 @@ namespace Oobe
             return true;
         }
         // Socket is never listening.
-        static bool poll_success(const wchar_t* command, int repeatTimes)
+        static bool poll_success(const wchar_t* command, int repeatTimes, HANDLE monitoredProcess)
         {
             return true;
         }
@@ -165,6 +181,14 @@ namespace Oobe
         {
             return nullptr; // no child process.
         }
+
+        static HWND try_hiding_installer_window(int repeatTimes)
+        {
+            return nullptr;
+        }
+
+        static void show_window(HWND window)
+        { }
 
         static DWORD do_launch_sync(const wchar_t* cli)
         {
@@ -200,7 +224,7 @@ namespace Oobe
             return true;
         }
 
-        static bool poll_success(const wchar_t* command, int repeatTimes)
+        static bool poll_success(const wchar_t* command, int repeatTimes, HANDLE monitoredProcess)
         {
             return true;
         }
@@ -220,6 +244,14 @@ namespace Oobe
         {
             return -1;
         }
+
+        static HWND try_hiding_installer_window(int repeatTimes)
+        {
+            return static_cast<HWND>(GetStdHandle(STD_OUTPUT_HANDLE));
+        }
+
+        static void show_window(HWND window)
+        { }
     };
     const wchar_t* OobeCrashDetectedPolicy::OobeCommand = cmd;
 }

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -122,7 +122,7 @@ namespace Oobe
             console.value().restoreConsole();
             return;
         }
-        if(!std::holds_alternative<SplashController<>::States::Visible>(transition.value())) {
+        if (!std::holds_alternative<SplashController<>::States::Visible>(transition.value())) {
             // also rollback.
             console.value().restoreConsole();
             return;

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -122,7 +122,12 @@ namespace Oobe
             console.value().restoreConsole();
             return;
         }
-
+        if(!std::holds_alternative<SplashController<>::States::Visible>(transition.value())) {
+            // also rollback.
+            console.value().restoreConsole();
+            return;
+        }
+        splashWindow = std::get<SplashController<>::States::Visible>(transition.value()).window;
         console.value().hideConsoleWindow();
         consoleIsVisible = false;
         splashIsRunning = true;
@@ -145,18 +150,23 @@ namespace Oobe
             wprintf(L"Failed to lock console state for modification. Somebody else is holding the lock.\n");
             return;
         }
-        console.value().showConsoleWindow();
         console.value().restoreConsole();
+        HWND topWindow = nullptr;
+        if (splashWindow.has_value()) {
+            topWindow = splashWindow.value();
+        }
+        console.value().showConsoleWindow(topWindow);
         consoleIsVisible = true;
     }
 
     void SplashEnabledStrategy::do_close_splash()
     {
+        do_show_console();
         if (splashIsRunning) {
             splash.value().sm.addEvent(SplashController<>::Events::Close{&(splash.value())});
             splashIsRunning = false;
+            splashWindow.reset();
         }
-        do_show_console();
     }
 
     HRESULT SplashEnabledStrategy::do_install()

--- a/DistroLauncher/ApplicationStrategy.h
+++ b/DistroLauncher/ApplicationStrategy.h
@@ -50,6 +50,7 @@ namespace Oobe
         InstallerController<> installer;
         // optionals for lazy creation.
         std::optional<SplashController<>> splash;
+        std::optional<HWND> splashWindow;
         std::optional<Win32Utils::ConsoleService<Win32Utils::LocalNamedPipe>> console;
 
         /// Restores the console context, which means undo the console redirection and making the window visible.

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -17,40 +17,42 @@
 
 #include "stdafx.h"
 
-namespace Win32Utils {
-    nonstd::expected<std::wstring, std::wstring> utf8_to_wide_string(const std::string& utf8str) {
+namespace Win32Utils
+{
+    nonstd::expected<std::wstring, std::wstring> utf8_to_wide_string(const std::string& utf8str)
+    {
         if (utf8str.empty()) {
             return L"";
         }
 
-        const auto size_needed = MultiByteToWideChar(CP_UTF8, 0, &utf8str.at(0),
-                                                     static_cast<int>(utf8str.size()), nullptr, 0);
+        const auto size_needed =
+          MultiByteToWideChar(CP_UTF8, 0, &utf8str.at(0), static_cast<int>(utf8str.size()), nullptr, 0);
         if (size_needed <= 0) {
-            nonstd::make_unexpected(L"MultiByteToWideChar() failed. Win32 error code: "
-                                    + std::to_wstring(GetLastError()));
+            nonstd::make_unexpected(L"MultiByteToWideChar() failed. Win32 error code: " +
+                                    std::to_wstring(GetLastError()));
         }
 
         std::wstring result(size_needed, 0);
-        auto convResult = MultiByteToWideChar(CP_UTF8, 0, &utf8str.at(0), static_cast<int>(utf8str.size()),
-                                              &result.at(0), size_needed);
+        auto convResult =
+          MultiByteToWideChar(CP_UTF8, 0, &utf8str.at(0), static_cast<int>(utf8str.size()), &result.at(0), size_needed);
         if (convResult == 0) {
-            nonstd::make_unexpected(L"MultiByteToWideChar() failed. Win32 error code: "
-                                    + std::to_wstring(GetLastError()));
+            nonstd::make_unexpected(L"MultiByteToWideChar() failed. Win32 error code: " +
+                                    std::to_wstring(GetLastError()));
         }
         return result;
     }
 
-    nonstd::expected<std::string, std::wstring> wide_string_to_utf8(const std::wstring& wide_str) {
+    nonstd::expected<std::string, std::wstring> wide_string_to_utf8(const std::wstring& wide_str)
+    {
         if (wide_str.empty()) {
             return "";
         }
 
-        const auto size_needed = WideCharToMultiByte(CP_UTF8, 0, &wide_str.at(0),
-                                                     static_cast<int>(wide_str.size()),
+        const auto size_needed = WideCharToMultiByte(CP_UTF8, 0, &wide_str.at(0), static_cast<int>(wide_str.size()),
                                                      nullptr, 0, nullptr, nullptr);
         if (size_needed <= 0) {
-            nonstd::make_unexpected(L"WideCharToMultiByte() failed. Win32 error code: "
-                                    + std::to_wstring(GetLastError()));
+            nonstd::make_unexpected(L"WideCharToMultiByte() failed. Win32 error code: " +
+                                    std::to_wstring(GetLastError()));
         }
 
         std::string result(size_needed, 0);
@@ -58,8 +60,8 @@ namespace Win32Utils {
                                               &result.at(0), size_needed, nullptr, nullptr);
 
         if (convResult == 0) {
-            nonstd::make_unexpected(L"WideCharToMultiByte() failed. Win32 error code: "
-                                    + std::to_wstring(GetLastError()));
+            nonstd::make_unexpected(L"WideCharToMultiByte() failed. Win32 error code: " +
+                                    std::to_wstring(GetLastError()));
         }
         return result;
     }

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -83,7 +83,7 @@ namespace Win32Utils
 
                 RECT rect;
 
-                if (GetWindowRect(window, &rect)==FALSE) {
+                if (GetWindowRect(window, &rect) == FALSE) {
                     return nonstd::make_unexpected(GetLastError());
                 }
                 auto width = rect.right - rect.left;
@@ -110,7 +110,7 @@ namespace Win32Utils
             DWORD place(HWND window, DWORD flags) const
             {
                 // NOLINTNEXTLINE(modernize-use-nullptr)
-                if (SetWindowPos(window, 0, x, y, width, height, flags)==FALSE) {
+                if (SetWindowPos(window, 0, x, y, width, height, flags) == FALSE) {
                     return GetLastError();
                 }
 
@@ -121,7 +121,7 @@ namespace Win32Utils
             /// on success. See docs for SetWindowPos function.
             DWORD place(HWND window, HWND topWindow, DWORD flags) const
             {
-                if (SetWindowPos(window, topWindow, x, y, width, height, flags)==FALSE) {
+                if (SetWindowPos(window, topWindow, x, y, width, height, flags) == FALSE) {
                     return GetLastError();
                 }
 

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -65,4 +65,101 @@ namespace Win32Utils
         }
         return result;
     }
+
+    namespace
+    {
+
+        /// Groups coordinates and sizes to simplify the SetWindowPos API for the cases when we want to center a window
+        /// on the display or resize it to the same size of another window. There is no current usage for this class
+        /// outside of the following two functions, so let's keep it local until the need arises.
+        struct placement
+        {
+            int x = -1, y = -1, width = -1, height = -1;
+
+            /// Attempts to construct a placement object with sizes and coordinates equal to the [window].
+            static nonstd::expected<placement, DWORD> from_window(HWND window)
+            {
+                assert(window != nullptr);
+
+                RECT rect;
+
+                if (GetWindowRect(window, &rect)==FALSE) {
+                    return nonstd::make_unexpected(GetLastError());
+                }
+                auto width = rect.right - rect.left;
+                auto height = rect.bottom - rect.top;
+                return placement{rect.left, rect.top, width, height};
+            }
+
+            /// Attempts to construct a placement object with [width] and [height] set, but with x and y coordinates
+            /// calculated so the window can be placed centered on the screen.
+            static nonstd::expected<placement, DWORD> centered_on_monitor(HMONITOR& monitor, int width, int height)
+            {
+                MONITORINFO mInfo;
+                mInfo.cbSize = sizeof(MONITORINFO);
+                if (!GetMonitorInfo(monitor, &mInfo)) {
+                    return nonstd::make_unexpected(GetLastError());
+                }
+                int x = (mInfo.rcWork.right - width) / 2;
+                int y = (mInfo.rcWork.bottom - height) / 2;
+                return placement{x, y, width, height};
+            }
+
+            /// Applies this placement to [window] according to [flags]. Returns 0 on success.
+            /// See docs for SetWindowPos function.
+            DWORD place(HWND window, DWORD flags) const
+            {
+                // NOLINTNEXTLINE(modernize-use-nullptr)
+                if (SetWindowPos(window, 0, x, y, width, height, flags)==FALSE) {
+                    return GetLastError();
+                }
+
+                return 0;
+            }
+
+            /// Applies this placement to [window] according to [flags], while preserving [topWindow] on top. Returns 0
+            /// on success. See docs for SetWindowPos function.
+            DWORD place(HWND window, HWND topWindow, DWORD flags) const
+            {
+                if (SetWindowPos(window, topWindow, x, y, width, height, flags)==FALSE) {
+                    return GetLastError();
+                }
+
+                return 0;
+            }
+        };
+
+    } // namespace
+
+    DWORD resize_to(HWND window, HWND topWindow)
+    {
+        assert(window != nullptr);
+        assert(topWindow != nullptr);
+        auto targetResult = placement::from_window(topWindow);
+        if (!targetResult.has_value()) {
+            return targetResult.error();
+        }
+
+        placement& target = targetResult.value();
+        return target.place(window, topWindow, SWP_SHOWWINDOW);
+    }
+
+    DWORD center_window(HWND window)
+    {
+        assert(window != nullptr);
+        HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
+        auto current = placement::from_window(window);
+        if (!current.has_value()) {
+            return current.error();
+        }
+
+        auto targetResult = placement::centered_on_monitor(monitor, current.value().width, current.value().height);
+        if (!targetResult.has_value()) {
+            return targetResult.error();
+        }
+
+        placement& target = targetResult.value();
+        return target.place(window, SWP_SHOWWINDOW);
+    }
+
 } // namespace Win32Utils

--- a/DistroLauncher/Win32Utils.h
+++ b/DistroLauncher/Win32Utils.h
@@ -15,11 +15,20 @@
  *
  */
 
- // This namespace holds a set of functions and utility classes to deal
- // with Win32 specificities in a modern way.
- // It aims to be lighweigth enough to justify not using more robust
- // solutions like those found in Boost libraries.
-namespace Win32Utils {
+// This namespace holds a set of functions and utility classes to deal
+// with Win32 specificities in a modern way.
+// It aims to be lighweigth enough to justify not using more robust
+// solutions like those found in Boost libraries.
+namespace Win32Utils
+{
     nonstd::expected<std::string, std::wstring> wide_string_to_utf8(const std::wstring& wide_string);
     nonstd::expected<std::wstring, std::wstring> utf8_to_wide_string(const std::string& utf8str);
+
+    /// Positions [window] at the center of the monitor it's displayed in with the Z-order right after [topWindow].
+    /// Returns 0 on success.
+    DWORD center_window(HWND window);
+
+    /// Resizes [window] to be equal in size and placement to [topWindow] while preserving [topWindow] on top.
+    /// Returns 0 on success.
+    DWORD resize_to(HWND window, HWND topWindow);
 }

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -4,7 +4,8 @@ namespace Oobe
 {
     struct InstallerPolicy
     {
-        static const wchar_t* OobeCommand;
+        static const wchar_t* const OobeCommand;
+        static constexpr auto crashedExitCode = -5;
 
         static bool is_oobe_available()
         {
@@ -37,10 +38,49 @@ namespace Oobe
             return std::filesystem::copy_file(from, realDest, ec);
         }
 
+        /// Attempts to find and hide the installer GUI window.
+        static HWND try_hiding_installer_window(int repeatTimes)
+        {
+            // attempt to find the window by class "RAIL_WINDOW" and flutterCaption "Ubuntu WSL (UbuntuPreview)".
+            // it appears before Subiquity is ready.
+            HWND rdpWindow = nullptr;
+            std::array<std::wstring, 2> possibleCaptions{L"Ubuntu WSL (", L"[WARN:COPY MODE] Ubuntu WSL ("};
+            std::for_each(possibleCaptions.begin(), possibleCaptions.end(), [](auto& caption) {
+                caption.append(DistributionInfo::Name);
+                caption.append(1, ')');
+            });
+
+            for (int i = 0; i < repeatTimes; ++i) {
+
+                for (const auto& caption : possibleCaptions) {
+                    auto res = FindWindow(L"RAIL_WINDOW", caption.c_str());
+                    if (res == 0) {
+                        continue;
+                    }
+
+                    rdpWindow = res;
+                    ShowWindow(rdpWindow, SW_HIDE);
+                    return rdpWindow;
+                };
+                Sleep(10);
+            }
+            return rdpWindow;
+        }
+
+        static void show_window(HWND window)
+        {
+            // Currently when the window is moved programmatically its buttons and interactive elements appear
+            // mis calibrated in the screen, i.e. user needs to find some offset between the position of the interactive
+            // element and the clickable area.
+
+            // Win32Utils::center_window(window);
+            ShowWindow(window, SW_RESTORE);
+        }
         // Repeatedly launches asynchronously the [command] up to [repeatTimes] until it succeeds.
         // Return false if attempts are exhausted with no success. This is suitable for launching small processes that
         // can be used to monitor the status of long running processes.
-        static bool poll_success(const wchar_t* command, int repeatTimes)
+        // If the monitored process is never ready, this function will clean it up.
+        static bool poll_success(const wchar_t* command, int repeatTimes, HANDLE monitoredProcess)
         {
             using defer = std::unique_ptr<std::remove_pointer_t<HANDLE>, decltype(&::CloseHandle)>;
             constexpr DWORD watcherTimeout = 1000; // ms
@@ -49,7 +89,7 @@ namespace Oobe
             DWORD sslxExitCode;
             HRESULT sslxHr;
 
-            auto delaysGenerator = [cur = 11e3f, q = 0.65f]() mutable {
+            auto delaysGenerator = [cur = 3e3F, q = 0.65F]() mutable {
                 cur *= q;
                 return cur;
             };
@@ -57,7 +97,6 @@ namespace Oobe
             for (int i = 0; i < repeatTimes; ++i) {
                 sslxProcess = nullptr;
                 sslxExitCode = -1;
-                sslxHr = E_INVALIDARG;
 
                 sslxHr =
                   g_wslApi.WslLaunch(command, TRUE, GetStdHandle(STD_INPUT_HANDLE), GetStdHandle(STD_OUTPUT_HANDLE),
@@ -70,7 +109,7 @@ namespace Oobe
                     if (WaitForSingleObject(sslxProcess, watcherTimeout) != WAIT_OBJECT_0) {
 
                         // If the process didn't exit within the timeout we kill it.
-                        TerminateProcess(sslxProcess, -5);
+                        TerminateProcess(sslxProcess, crashedExitCode);
                     }
                     auto getExit = GetExitCodeProcess(sslxProcess, &sslxExitCode);
                     if (getExit != FALSE && sslxExitCode == 0) {
@@ -81,6 +120,10 @@ namespace Oobe
                 // Sleeps progressively less time than the last iteration.
                 Sleep(static_cast<DWORD>(delaysGenerator()));
             }
+
+            // started but is never ready, so we must kill it.
+            TerminateProcess(monitoredProcess, crashedExitCode);
+            CloseHandle(monitoredProcess);
             return false;
         }
 
@@ -94,12 +137,20 @@ namespace Oobe
 
             DWORD exitCode = -1;
             if (WaitForSingleObject(process, timeout) != WAIT_OBJECT_0) {
-                exitCode = -5;
+                exitCode = crashedExitCode;
                 TerminateProcess(process, exitCode);
                 return exitCode;
             }
 
             GetExitCodeProcess(process, &exitCode);
+            // The Flutter installer exits 0 on some crashes.
+            // And sometimes reports crash even though Subiquity has finished. This gets fixed in [UDI PR
+            // 786](https://github.com/canonical/ubuntu-desktop-installer/pull/786)
+            if (exitCode == 0) {
+                g_wslApi.WslLaunchInteractive(L"grep -E 'EXITED|DONE' /run/subiquity/server-state", FALSE, &exitCode);
+                DWORD clearExitCode;
+                g_wslApi.WslLaunchInteractive(L"clear", FALSE, &clearExitCode);
+            }
             return exitCode;
         }
 
@@ -109,8 +160,6 @@ namespace Oobe
         static HANDLE start_installer_async(const wchar_t* command,
                                             const wchar_t* watcher = L"ss -lx | grep subiquity &>/dev/null")
         {
-            constexpr int numIterations = 8;
-            DWORD exitCode = -1;
             HANDLE child = nullptr;
             HRESULT hr = g_wslApi.WslLaunch(command, TRUE, GetStdHandle(STD_INPUT_HANDLE),
                                             GetStdHandle(STD_OUTPUT_HANDLE), GetStdHandle(STD_ERROR_HANDLE), &child);
@@ -122,14 +171,7 @@ namespace Oobe
                 return nullptr;
             }
 
-            if (poll_success(watcher, numIterations)) {
-                // Ownership of the installer sslxProcess handle is being passed by.
-                return child;
-            }
-            // started but is never ready, so we must kill it.
-            TerminateProcess(child, -5);
-            CloseHandle(child);
-            return nullptr;
+            return child;
         }
 
         // Launches the OOBE command by [cli] synchronously, blocking this thread from start to finish.
@@ -149,5 +191,5 @@ namespace Oobe
     // This imposes deprecation of the symbol DistributionInfo::OOBE_NAME exposed in OOBE.h.
     // This is useful because the controller can launch the OOBE in a couple of different ways, but in all of them we
     // need `sudo`. At some point those files OOBE.cpp and OOBE.h will be dropped in favor of this one.
-    inline const wchar_t* InstallerPolicy::OobeCommand = L"sudo /usr/libexec/wsl-setup";
+    inline const wchar_t* const InstallerPolicy::OobeCommand = L"sudo /usr/libexec/wsl-setup";
 }

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -101,9 +101,8 @@ namespace Oobe
                 sslxProcess = nullptr;
                 sslxExitCode = -1;
 
-                sslxHr =
-                  g_wslApi.WslLaunch(command, TRUE, GetStdHandle(STD_INPUT_HANDLE), GetStdHandle(STD_OUTPUT_HANDLE),
-                                     GetStdHandle(STD_ERROR_HANDLE), &sslxProcess);
+                // We most likely will not want to see any output of this command, just its exit code.
+                sslxHr = g_wslApi.WslLaunch(command, TRUE, nullptr, nullptr, nullptr, &sslxProcess);
 
                 if (SUCCEEDED(sslxHr)) {
                     defer guard{sslxProcess, CloseHandle};
@@ -157,11 +156,9 @@ namespace Oobe
             return exitCode;
         }
 
-        // Launches the OOBE installer [command] asynchronously and block this thread until it's ready for
-        // interaction, according to the prescription of the [watcher] command. If this succeeds, caller is responsible
-        // for the lifetime of the process represented by the returned handle.
-        static HANDLE start_installer_async(const wchar_t* command,
-                                            const wchar_t* watcher = L"ss -lx | grep subiquity &>/dev/null")
+        /// Launches the OOBE installer [command] asynchronously and return its handle if launched successfully without
+        /// waiting for its completion. It's caller responsibility to monitor and clean-up the returned process handle.
+        static HANDLE start_installer_async(const wchar_t* command)
         {
             HANDLE child = nullptr;
             HRESULT hr = g_wslApi.WslLaunch(command, TRUE, GetStdHandle(STD_INPUT_HANDLE),

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -156,7 +156,11 @@ namespace Oobe
         {
             // This enables Flutter code to react on our hide request.
             constexpr auto WM_CUSTOM_AUTO_HIDE = WM_USER + 7;
+            constexpr auto sleepFor = 50;
             PostMessage(window, WM_CUSTOM_AUTO_HIDE, 0, 0);
+            while (IsWindowVisible(window)==TRUE) {
+                Sleep(sleepFor);
+            }
             return true;
         }
 
@@ -249,7 +253,7 @@ namespace Oobe
         // Any need for synchronization must be taken care of by the callable itself.
         static void onWindowClosedByUser(void* data, BOOLEAN /*unused*/)
         {
-            auto* self = static_cast<typename SplashController<Strategy>*>(data);
+            auto* self = static_cast<SplashController<Strategy>*>(data);
             self->notifyListener();
         }
 

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -158,7 +158,7 @@ namespace Oobe
             constexpr auto WM_CUSTOM_AUTO_HIDE = WM_USER + 7;
             constexpr auto sleepFor = 50;
             PostMessage(window, WM_CUSTOM_AUTO_HIDE, 0, 0);
-            while (IsWindowVisible(window)==TRUE) {
+            while (IsWindowVisible(window) == TRUE) {
                 Sleep(sleepFor);
             }
             return true;

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -160,9 +160,7 @@ namespace Oobe::internal
         {
             ExpectedState maybe = std::visit(
               overloaded{
-                [&](auto& s) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
-                                                    std::is_same_v<decltype(s.on_event(event)), State> ||
-                                                    std::is_same_v<decltype(s.on_event(event)), ExpectedState>,
+                [&](auto& s) -> std::enable_if_t<std::is_convertible_v<decltype(s.on_event(event)), ExpectedState>,
                                                   ExpectedState> { return s.on_event(event); },
                 [&](auto&&... arg) -> ExpectedState {
                     return nonstd::make_unexpected(InvalidTransition{state_, event});
@@ -183,10 +181,8 @@ namespace Oobe::internal
             ExpectedState maybe = std::visit(
               overloaded{
                 [](auto& s,
-                   auto& event) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
-                                                       std::is_same_v<decltype(s.on_event(event)), State> ||
-                                                       std::is_same_v<decltype(s.on_event(event)), ExpectedState>,
-                                                     ExpectedState> { return s.on_event(event); },
+                   auto& event) -> std::enable_if_t<std::is_convertible_v<decltype(s.on_event(event)), ExpectedState>,
+                                                    ExpectedState> { return s.on_event(event); },
                 [&](auto&&... arg) -> ExpectedState {
                     return nonstd::make_unexpected(InvalidTransition{state_, event});
                 },

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -160,7 +160,7 @@ namespace Oobe::internal
         {
             ExpectedState maybe = std::visit(
               overloaded{
-                [&](auto&& s) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
+                [&](auto& s) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
                                                     std::is_same_v<decltype(s.on_event(event)), State> ||
                                                     std::is_same_v<decltype(s.on_event(event)), ExpectedState>,
                                                   ExpectedState> { return s.on_event(event); },
@@ -182,8 +182,8 @@ namespace Oobe::internal
         {
             ExpectedState maybe = std::visit(
               overloaded{
-                [](auto&& s,
-                   auto&& event) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
+                [](auto& s,
+                   auto& event) -> std::enable_if_t<is_variant_of_v<decltype(s.on_event(event)), State> ||
                                                        std::is_same_v<decltype(s.on_event(event)), State> ||
                                                        std::is_same_v<decltype(s.on_event(event)), ExpectedState>,
                                                      ExpectedState> { return s.on_event(event); },

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -161,7 +161,7 @@ namespace Oobe::internal
             ExpectedState maybe = std::visit(
               overloaded{
                 [&](auto& s) -> std::enable_if_t<std::is_convertible_v<decltype(s.on_event(event)), ExpectedState>,
-                                                  ExpectedState> { return s.on_event(event); },
+                                                 ExpectedState> { return s.on_event(event); },
                 [&](auto&&... arg) -> ExpectedState {
                     return nonstd::make_unexpected(InvalidTransition{state_, event});
                 },


### PR DESCRIPTION
This adds the capability to find the WSLg window where the OOBE GUI is displayed and controlling its visibility while synchronizing with the splash application, to ensure a smooth transition.

For the console, upon restoration, its resized to match the splash size and placement, so it can stay nicely hidden by the splash until it disappears. Also, asking to hide the splash now blocks while it stays visible.  This prevents other windows from popping up in front of it and causing disruption to the user attention.

I wanted to do the very same with the WSLg window, but moving it programmatically causes a very strange behavior. I'll investigate first whether this has been fixed in the latest updates or not and report a bug if not. It behaves as if the window had moved but the internal widgets had not, so that the user would have to guess the right offset to be able to click a button from where she sees it. So, for now, just toggling the OOBE GUI visibility.

Here is a video recording of the complete experience:

https://user-images.githubusercontent.com/11138291/163055156-ed2971fc-7ed4-48a0-bda4-3d324ee5c979.mp4

I had to tweak the CI. For some reason not yet clear to me clang-tidy was crashing, but with some patiency and brute-forcing it to try again I could get the CI running through again.

```diff
-    proc = subprocess.run(cli)
+    for i in range(0, 9):
+        proc = subprocess.run(cli)
+        if proc.returncode < 100:
+            break
+        print("\n\nClang-Tidy exit code: {}\n\n".format(proc.returncode))
```
