### PR TITLE
Reverts `--enable-installer` option into a more complete `--ui=` command line.

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
@@ -60,7 +60,7 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, InstallOobeWithShellTui)
     {
-        // launcher.exe install --ui=tui
+        // launcher.exe --ui=tui
         std::vector<std::wstring_view> args{ARG_EXT_INSTALLER_TUI};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<InteractiveInstallShell<OobeTui>>(opts));

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
@@ -99,13 +99,13 @@ namespace Oobe::internal
     }
 
     // This also used to be upstream, but now is OOBE
-    TEST(ExtendedCliParserUpstreamPreservedTests, InstallOnlyOobeNoShell)
+    TEST(ExtendedCliParserTests, InstallOnlyOobeNoShell)
     {
         // launcher.exe install
         std::vector<std::wstring_view> args{L"install"};
         auto previousSize = args.size();
         auto opts = parseExtendedOptions(args);
-        ASSERT_TRUE(std::holds_alternative<InteractiveInstallOnly<OobeGui>>(opts));
+        ASSERT_TRUE(std::holds_alternative<InstallOnlyDefault>(opts));
         ASSERT_EQ(previousSize, args.size());
     }
 
@@ -117,12 +117,12 @@ namespace Oobe::internal
         ASSERT_TRUE(std::holds_alternative<Reconfig>(opts));
     }
 
-    TEST(ExtendedCliParserUpstreamPreservedTests, DefaultEmptyCase)
+    // used to be upstream minimal setup experience, but it's now OOBE GUI.
+    TEST(ExtendedCliParserTests, DefaultEmptyCase)
     {
-        // used to be upstream minimal setup experience, but it's now OOBE GUI.
         std::vector<std::wstring_view> args{};
         auto opts = parseExtendedOptions(args);
-        ASSERT_TRUE(std::holds_alternative<DEFAULT_EMPTY_CLI_CASE>(opts));
+        ASSERT_TRUE(std::holds_alternative<InstallDefault>(opts));
     }
 
     // Tests whether the upstream options remain preserved:

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
@@ -36,7 +36,7 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, InstallOobeNoShellGui)
     {
-        // launcher.exe install --installer=gui
+        // launcher.exe install --ui=gui
         std::vector<std::wstring_view> args{L"install", ARG_EXT_INSTALLER_GUI};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<InteractiveInstallOnly<OobeGui>>(opts));
@@ -44,7 +44,7 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, InstallOobeWithShellGui)
     {
-        // launcher.exe --installer=gui
+        // launcher.exe --ui=gui
         std::vector<std::wstring_view> args{ARG_EXT_INSTALLER_GUI};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<InteractiveInstallShell<OobeGui>>(opts));
@@ -52,7 +52,7 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, InstallOobeNoShellTui)
     {
-        // launcher.exe install --installer=tui
+        // launcher.exe install --ui=tui
         std::vector<std::wstring_view> args{L"install", ARG_EXT_INSTALLER_TUI};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<InteractiveInstallOnly<OobeTui>>(opts));
@@ -60,7 +60,7 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, InstallOobeWithShellTui)
     {
-        // launcher.exe install --installer=tui
+        // launcher.exe install --ui=tui
         std::vector<std::wstring_view> args{ARG_EXT_INSTALLER_TUI};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<InteractiveInstallShell<OobeTui>>(opts));
@@ -68,7 +68,7 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, SkipInstallerNoShell)
     {
-        // launcher.exe install --installer=none
+        // launcher.exe install --ui=none
         std::vector<std::wstring_view> args{L"install", ARG_EXT_DISABLE_INSTALLER};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
@@ -76,7 +76,7 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, SkipInstallerWithShell)
     {
-        // launcher.exe --installer=none
+        // launcher.exe --ui=none
         std::vector<std::wstring_view> args{ARG_EXT_DISABLE_INSTALLER};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
@@ -84,19 +84,31 @@ namespace Oobe::internal
 
     TEST(ExtendedCliParserTests, BrokenOptionGoesUpstream1)
     {
-        // [X] launcher.exe install --installer
-        std::vector<std::wstring_view> args{L"install", L"--installer"};
+        // [X] launcher.exe install --ui
+        std::vector<std::wstring_view> args{L"install", L"--ui"};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
     }
 
     TEST(ExtendedCliParserTests, BrokenOptionGoesUpstream2)
     {
-        // [X] launcher.exe --installer
-        std::vector<std::wstring_view> args{L"--installer"};
+        // [X] launcher.exe --ui
+        std::vector<std::wstring_view> args{L"--ui"};
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
     }
+
+    // This also used to be upstream, but now is OOBE
+    TEST(ExtendedCliParserUpstreamPreservedTests, InstallOnlyOobeNoShell)
+    {
+        // launcher.exe install
+        std::vector<std::wstring_view> args{L"install"};
+        auto previousSize = args.size();
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<InteractiveInstallOnly<OobeGui>>(opts));
+        ASSERT_EQ(previousSize, args.size());
+    }
+
     TEST(ExtendedCliParserTests, OobeReconfig)
     {
         // launcher.exe config
@@ -117,14 +129,6 @@ namespace Oobe::internal
     TEST(ExtendedCliParserTests, InstallRootIsUpstream)
     {
         std::vector<std::wstring_view> args{L"install", L"--root"};
-        auto previousSize = args.size();
-        auto opts = parseExtendedOptions(args);
-        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
-        ASSERT_EQ(previousSize, args.size());
-    }
-    TEST(ExtendedCliParserUpstreamPreservedTests, InstallOobeDisabledNoShell)
-    {
-        std::vector<std::wstring_view> args{L"install"};
         auto previousSize = args.size();
         auto opts = parseExtendedOptions(args);
         ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -61,14 +61,16 @@ namespace Oobe
         HRESULT setup()
         {
             wprintf(L"Unpacking is complete!\n");
-            HRESULT hr =
-              std::visit(internal::overloaded{
-                           [&](internal::AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
-                           [&](internal::InteractiveInstallOnly& option) { return impl_.do_install(); },
-                           [&](internal::InteractiveInstallShell& option) { return impl_.do_install(); },
-                           [&](auto&& option) { return E_INVALIDARG; }, // for the cases not treated by this function.
-                         },
-                         arg);
+            HRESULT hr = std::visit(
+              internal::overloaded{
+                [&](internal::AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
+                [&](internal::InteractiveInstallOnly<internal::OobeGui>& option) { return impl_.do_install(); },
+                [&](internal::InteractiveInstallOnly<internal::OobeTui>& option) { return impl_.do_install(); },
+                [&](internal::InteractiveInstallShell<internal::OobeGui>& option) { return impl_.do_install(); },
+                [&](internal::InteractiveInstallShell<internal::OobeTui>& option) { return impl_.do_install(); },
+                [&](auto&& option) { return E_INVALIDARG; }, // for the cases not treated by this function.
+              },
+              arg);
 
             if (FAILED(hr) && hr != E_NOTIMPL && hr != E_INVALIDARG) {
                 wprintf(L"Installer did not complete successfully.\n");

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -64,10 +64,10 @@ namespace Oobe
             HRESULT hr = std::visit(
               internal::overloaded{
                 [&](internal::AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
-                [&](internal::InteractiveInstallOnly<internal::OobeGui>& option) { return impl_.do_install(); },
-                [&](internal::InteractiveInstallOnly<internal::OobeTui>& option) { return impl_.do_install(); },
-                [&](internal::InteractiveInstallShell<internal::OobeGui>& option) { return impl_.do_install(); },
-                [&](internal::InteractiveInstallShell<internal::OobeTui>& option) { return impl_.do_install(); },
+                [&](internal::InteractiveInstallOnly<internal::OobeGui>& option) { return impl_.do_install(false); },
+                [&](internal::InteractiveInstallOnly<internal::OobeTui>& option) { return impl_.do_install(true); },
+                [&](internal::InteractiveInstallShell<internal::OobeGui>& option) { return impl_.do_install(false); },
+                [&](internal::InteractiveInstallShell<internal::OobeTui>& option) { return impl_.do_install(true); },
                 [&](auto&& option) { return E_INVALIDARG; }, // for the cases not treated by this function.
               },
               arg);

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -169,11 +169,11 @@ namespace Oobe
         }
     }
 
-    HRESULT SplashEnabledStrategy::do_install()
+    HRESULT SplashEnabledStrategy::do_install(bool forceTextMode)
     {
-        std::array<InstallerController<>::Event, 3> eventSequence{InstallerController<>::Events::InteractiveInstall{},
-                                                                  InstallerController<>::Events::StartInstaller{},
-                                                                  InstallerController<>::Events::BlockOnInstaller{}};
+        std::array<InstallerController<>::Event, 3> eventSequence{
+          InstallerController<>::Events::InteractiveInstall{forceTextMode},
+          InstallerController<>::Events::StartInstaller{}, InstallerController<>::Events::BlockOnInstaller{}};
         HRESULT hr = E_NOTIMPL;
         for (auto& ev : eventSequence) {
             auto ok = installer.sm.addEvent(ev);
@@ -215,11 +215,11 @@ namespace Oobe
 
 #else // _M_ARM64
 
-    HRESULT NoSplashStrategy::do_install()
+    HRESULT NoSplashStrategy::do_install(bool forceTextMode)
     {
-        std::array<InstallerController<>::Event, 3> eventSequence{InstallerController<>::Events::InteractiveInstall{},
-                                                                  InstallerController<>::Events::StartInstaller{},
-                                                                  InstallerController<>::Events::BlockOnInstaller{}};
+        std::array<InstallerController<>::Event, 3> eventSequence{
+          InstallerController<>::Events::InteractiveInstall{forceTextMode},
+          InstallerController<>::Events::StartInstaller{}, InstallerController<>::Events::BlockOnInstaller{}};
         HRESULT hr = E_NOTIMPL;
         for (auto& ev : eventSequence) {
             auto ok = installer.sm.addEvent(ev);

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -169,11 +169,11 @@ namespace Oobe
         }
     }
 
-    HRESULT SplashEnabledStrategy::do_install(bool forceTextMode)
+    HRESULT SplashEnabledStrategy::do_install(Mode ui)
     {
-        std::array<InstallerController<>::Event, 3> eventSequence{
-          InstallerController<>::Events::InteractiveInstall{forceTextMode},
-          InstallerController<>::Events::StartInstaller{}, InstallerController<>::Events::BlockOnInstaller{}};
+        std::array<InstallerController<>::Event, 3> eventSequence{InstallerController<>::Events::InteractiveInstall{ui},
+                                                                  InstallerController<>::Events::StartInstaller{},
+                                                                  InstallerController<>::Events::BlockOnInstaller{}};
         HRESULT hr = E_NOTIMPL;
         for (auto& ev : eventSequence) {
             auto ok = installer.sm.addEvent(ev);
@@ -215,11 +215,11 @@ namespace Oobe
 
 #else // _M_ARM64
 
-    HRESULT NoSplashStrategy::do_install(bool forceTextMode)
+    HRESULT NoSplashStrategy::do_install(Mode ui)
     {
         std::array<InstallerController<>::Event, 3> eventSequence{
-          InstallerController<>::Events::InteractiveInstall{forceTextMode},
-          InstallerController<>::Events::StartInstaller{}, InstallerController<>::Events::BlockOnInstaller{}};
+          InstallerController<>::Events::InteractiveInstall{Mode ui}, InstallerController<>::Events::StartInstaller{},
+          InstallerController<>::Events::BlockOnInstaller{}};
         HRESULT hr = E_NOTIMPL;
         for (auto& ev : eventSequence) {
             auto ok = installer.sm.addEvent(ev);

--- a/DistroLauncher/ApplicationStrategy.h
+++ b/DistroLauncher/ApplicationStrategy.h
@@ -31,6 +31,7 @@
 
 namespace Oobe
 {
+    using Mode = InstallerController<>::Mode;
     // This strategy fulfills the essential API required by the Oobe::Application<> class and augment it with the
     // machinery necessary to coordinate the splash screen application, the console service for console redirection and
     // visibility toggling and the OOBE itself running inside Ubuntu.
@@ -70,7 +71,7 @@ namespace Oobe
         /// Places the sequence of events to make the OOBE perform an interactive installation.
         /// By default GUI support is checked before launching the OOBE, unless [forceTextMode]
         /// is set to true, in which case the check is skipped and the installer run in TUI mode.
-        HRESULT do_install(bool forceTextMode = false);
+        HRESULT do_install(Mode ui);
 
         /// Places the sequence of events to make the OOBE perform an automatic installation.
         HRESULT do_reconfigure();
@@ -107,7 +108,7 @@ namespace Oobe
         HRESULT do_autoinstall(std::filesystem::path autoinstall_file);
 
         /// Places the sequence of events to make the OOBE perform an interactive installation.
-        HRESULT do_install(bool forceTextMode = false);
+        HRESULT do_install(Mode ui);
 
         /// Places the sequence of events to make the OOBE perform an automatic installation.
         HRESULT do_reconfigure();

--- a/DistroLauncher/ApplicationStrategy.h
+++ b/DistroLauncher/ApplicationStrategy.h
@@ -68,7 +68,9 @@ namespace Oobe
         HRESULT do_autoinstall(const std::filesystem::path& autoinstall_file);
 
         /// Places the sequence of events to make the OOBE perform an interactive installation.
-        HRESULT do_install();
+        /// By default GUI support is checked before launching the OOBE, unless [forceTextMode]
+        /// is set to true, in which case the check is skipped and the installer run in TUI mode.
+        HRESULT do_install(bool forceTextMode = false);
 
         /// Places the sequence of events to make the OOBE perform an automatic installation.
         HRESULT do_reconfigure();
@@ -105,7 +107,7 @@ namespace Oobe
         HRESULT do_autoinstall(std::filesystem::path autoinstall_file);
 
         /// Places the sequence of events to make the OOBE perform an interactive installation.
-        HRESULT do_install();
+        HRESULT do_install(bool forceTextMode = false);
 
         /// Places the sequence of events to make the OOBE perform an automatic installation.
         HRESULT do_reconfigure();

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -143,6 +143,7 @@
     <ClInclude Include="console_service.h" />
     <ClInclude Include="ExitStatus.h" />
     <ClInclude Include="extended_cli_parser.h" />
+    <ClInclude Include="extended_messages.h" />
     <ClInclude Include="installer_controller.h" />
     <ClInclude Include="installer_policy.h" />
     <ClInclude Include="not_null.h" />

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -25,7 +25,7 @@ namespace Oobe::internal
     template <typename ParsedOpt> std::optional<ParsedOpt> tryParse(const std::vector<std::wstring_view>& arguments)
     {
         if constexpr (std::is_same_v<ParsedOpt, DEFAULT_EMPTY_CLI_CASE>) {
-            if (arguments.size() == 0) {
+            if (arguments.empty()) {
                 return DEFAULT_EMPTY_CLI_CASE{};
             }
         }

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -54,16 +54,36 @@ namespace Oobe::internal
 
     Opts parse(const std::vector<std::wstring_view>& arguments)
     {
-        // launcher.exe install --autoinstall <autoinstallfile>
-        if (auto result = tryParse<AutoInstall>(arguments); result.has_value()) {
-            return result.value();
-        }
-
         // launcher.exe - Runs the OOBE (auto detect graphics support) and brings the shell at the end.
         if (auto result = tryParse<InstallDefault>(arguments); result.has_value()) {
             return result.value();
         }
-        // launcher.exe --ui=gui - Same as above.
+
+        // launcher.exe install - Runs the OOBE (auto detect graphics support) and quits.
+        if (auto result = tryParse<InstallOnlyDefault>(arguments); result.has_value()) {
+            return result.value();
+        }
+
+        // launcher.exe config - Runs the OOBE in reconfiguration mode.
+        if (auto result = tryParse<Reconfig>(arguments); result.has_value()) {
+            return result.value();
+        }
+
+        // launcher.exe --ui=none - Upstream minimal setup experience with the shell in the end.
+        if (auto result = tryParse<InteractiveInstallShell<SkipInstaller>>(arguments); result.has_value()) {
+            return std::monostate{};
+        }
+
+        // launcher.exe install --ui=none - Upstream minimal setup experience and quit.
+        if (auto result = tryParse<InteractiveInstallOnly<SkipInstaller>>(arguments); result.has_value()) {
+            return std::monostate{};
+        }
+
+        // launcher.exe install --autoinstall <autoinstallfile>
+        if (auto result = tryParse<AutoInstall>(arguments); result.has_value()) {
+            return result.value();
+        }
+        // launcher.exe --ui=gui - Runs the OOBE (forces GUI) and brings the shell at the end.
         if (auto result = tryParse<InteractiveInstallShell<OobeGui>>(arguments); result.has_value()) {
             return result.value();
         }
@@ -73,32 +93,13 @@ namespace Oobe::internal
             return result.value();
         }
 
-        // launcher.exe --ui=none - Upstream minimal setup experience with the shell in the end.
-        if (auto result = tryParse<InteractiveInstallShell<SkipInstaller>>(arguments); result.has_value()) {
-            return std::monostate{};
-        }
-
-        // launcher.exe install - Runs the OOBE (auto detect graphics support) and quits.
-        if (auto result = tryParse<InstallOnlyDefault>(arguments); result.has_value()) {
-            return result.value();
-        }
-        // launcher.exe install --ui=gui - Same as above.
+        // launcher.exe install --ui=gui - Runs the OOBE (forces GUI) and quits.
         if (auto result = tryParse<InteractiveInstallOnly<OobeGui>>(arguments); result.has_value()) {
             return result.value();
         }
 
         // launcher.exe install --ui=tui - Runs the OOBE (forces TUI) and quits.
         if (auto result = tryParse<InteractiveInstallOnly<OobeTui>>(arguments); result.has_value()) {
-            return result.value();
-        }
-
-        // launcher.exe install --ui=none - Upstream minimal setup experience and quit.
-        if (auto result = tryParse<InteractiveInstallOnly<SkipInstaller>>(arguments); result.has_value()) {
-            return std::monostate{};
-        }
-
-        // launcher.exe config - Runs the OOBE in reconfiguration mode.
-        if (auto result = tryParse<Reconfig>(arguments); result.has_value()) {
             return result.value();
         }
 

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -110,7 +110,7 @@ namespace Oobe::internal
         Opts options{parse(arguments)};
         // Erasing the extended command line options to avoid confusion in the upstream code.
         auto it = std::remove_if(arguments.begin(), arguments.end(), [](auto arg) {
-            return arg == ARG_EXT_AUTOINSTALL || arg == ARG_EXT_ENABLE_INSTALLER;
+            return std::find(allExtendedArgs.begin(), allExtendedArgs.end(), arg) != allExtendedArgs.end();
         });
         arguments.erase(it, arguments.end());
         return options;

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -81,6 +81,9 @@ namespace Oobe::internal
         }
 
         // launcher.exe install - Runs the OOBE (auto detect graphics support) and quits.
+        if (auto result = tryParse<InstallOnlyDefault>(arguments); result.has_value()) {
+            return InteractiveInstallOnly<OobeGui>{};
+        }
         // launcher.exe install --installer=gui - Same as above.
         if (auto result = tryParse<InteractiveInstallOnly<OobeGui>>(arguments); result.has_value()) {
             return result.value();

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -15,7 +15,7 @@
  *
  */
 #pragma once
-#define ARG_EXT_ENABLE_INSTALLER  L"--installer="
+#define ARG_EXT_ENABLE_INSTALLER  L"--ui="
 #define ARG_EXT_INSTALLER_GUI     ARG_EXT_ENABLE_INSTALLER L"gui"
 #define ARG_EXT_INSTALLER_TUI     ARG_EXT_ENABLE_INSTALLER L"tui"
 #define ARG_EXT_DISABLE_INSTALLER ARG_EXT_ENABLE_INSTALLER L"none"
@@ -56,10 +56,13 @@ namespace Oobe::internal
     {
         static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_INSTALLER_TUI};
     };
-    template <typename InstallerOption> struct InteractiveInstallOnly
+    struct InstallOnlyDefault
     {
-        static constexpr std::array<std::wstring_view, 1> thisRequirements{L"install"};
-        static constexpr auto requirements = join(thisRequirements, InstallerOption::requirements);
+        static constexpr std::array<std::wstring_view, 1> requirements{L"install"};
+    };
+    template <typename InstallerOption> struct InteractiveInstallOnly : InstallOnlyDefault
+    {
+        static constexpr auto requirements = join(InstallOnlyDefault::requirements, InstallerOption::requirements);
     };
     template <typename InstallerOption> struct InteractiveInstallShell : InstallerOption
     {

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -23,6 +23,8 @@
 
 namespace Oobe::internal
 {
+    static constexpr std::array allExtendedArgs{ARG_EXT_AUTOINSTALL, ARG_EXT_DISABLE_INSTALLER, ARG_EXT_INSTALLER_GUI,
+                                                  ARG_EXT_INSTALLER_TUI};
     // compile-time array concatenation.
     template <typename T, std::size_t SizeA, std::size_t SizeB>
     constexpr std::array<T, SizeA + SizeB> join(const std::array<T, SizeA>& a, const std::array<T, SizeB>& b)
@@ -67,9 +69,11 @@ namespace Oobe::internal
     {
         static constexpr std::array<std::wstring_view, 1> requirements{L"config"};
     };
+
+    // InteractiveInstallOnly<SkipInstaller> and InteractiveInstallShell<SkipInstaller> are actually std::monostate,
+    // i.e. both go to upstream resolution.
     using Opts =
-      std::variant<std::monostate, AutoInstall, InteractiveInstallOnly<SkipInstaller>, InteractiveInstallOnly<OobeGui>,
-                   InteractiveInstallOnly<OobeTui>, InteractiveInstallShell<SkipInstaller>,
+      std::variant<std::monostate, AutoInstall, InteractiveInstallOnly<OobeGui>, InteractiveInstallOnly<OobeTui>,
                    InteractiveInstallShell<OobeGui>, InteractiveInstallShell<OobeTui>, Reconfig>;
 
     /// Parses a vector of command line arguments according to the extended command line options declared above. The
@@ -78,5 +82,5 @@ namespace Oobe::internal
     /// vector. See DistroLauncher.cpp main() function.
     Opts parseExtendedOptions(std::vector<std::wstring_view>& arguments);
 
-    using DEFAULT_EMPTY_CLI_CASE=InteractiveInstallShell<OobeGui>;
+    using DEFAULT_EMPTY_CLI_CASE = InteractiveInstallShell<OobeGui>;
 }

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -24,7 +24,7 @@
 namespace Oobe::internal
 {
     static constexpr std::array allExtendedArgs{ARG_EXT_AUTOINSTALL, ARG_EXT_DISABLE_INSTALLER, ARG_EXT_INSTALLER_GUI,
-                                                  ARG_EXT_INSTALLER_TUI};
+                                                ARG_EXT_INSTALLER_TUI};
     // compile-time array concatenation.
     template <typename T, std::size_t SizeA, std::size_t SizeB>
     constexpr std::array<T, SizeA + SizeB> join(const std::array<T, SizeA>& a, const std::array<T, SizeB>& b)

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -56,6 +56,10 @@ namespace Oobe::internal
     {
         static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_INSTALLER_TUI};
     };
+    struct InstallDefault
+    {
+        static constexpr std::array<std::wstring_view, 0> requirements{};
+    };
     struct InstallOnlyDefault
     {
         static constexpr std::array<std::wstring_view, 1> requirements{L"install"};
@@ -75,15 +79,13 @@ namespace Oobe::internal
 
     // InteractiveInstallOnly<SkipInstaller> and InteractiveInstallShell<SkipInstaller> are actually std::monostate,
     // i.e. both go to upstream resolution.
-    using Opts =
-      std::variant<std::monostate, AutoInstall, InteractiveInstallOnly<OobeGui>, InteractiveInstallOnly<OobeTui>,
-                   InteractiveInstallShell<OobeGui>, InteractiveInstallShell<OobeTui>, Reconfig>;
+    using Opts = std::variant<std::monostate, AutoInstall, InstallDefault, InstallOnlyDefault,
+                              InteractiveInstallOnly<OobeGui>, InteractiveInstallOnly<OobeTui>,
+                              InteractiveInstallShell<OobeGui>, InteractiveInstallShell<OobeTui>, Reconfig>;
 
     /// Parses a vector of command line arguments according to the extended command line options declared above. The
     /// extended options are removed from the original vector as a side effect to avoid confusing the "upstream command
     /// line parsing" routines. Notice that argv[0], i.e. the program name, is presumed not to be part of the arguments
     /// vector. See DistroLauncher.cpp main() function.
     Opts parseExtendedOptions(std::vector<std::wstring_view>& arguments);
-
-    using DEFAULT_EMPTY_CLI_CASE = InteractiveInstallShell<OobeGui>;
 }

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -15,34 +15,68 @@
  *
  */
 #pragma once
-#define ARG_EXT_ENABLE_INSTALLER L"--enable-installer"
-#define ARG_EXT_AUTOINSTALL      L"--autoinstall"
+#define ARG_EXT_ENABLE_INSTALLER  L"--installer="
+#define ARG_EXT_INSTALLER_GUI     ARG_EXT_ENABLE_INSTALLER L"gui"
+#define ARG_EXT_INSTALLER_TUI     ARG_EXT_ENABLE_INSTALLER L"tui"
+#define ARG_EXT_DISABLE_INSTALLER ARG_EXT_ENABLE_INSTALLER L"none"
+#define ARG_EXT_AUTOINSTALL       L"--autoinstall"
 
 namespace Oobe::internal
 {
+    // compile-time array concatenation.
+    template <typename T, std::size_t SizeA, std::size_t SizeB>
+    constexpr std::array<T, SizeA + SizeB> join(const std::array<T, SizeA>& a, const std::array<T, SizeB>& b)
+    {
+        std::array<T, SizeA + SizeB> result;
+        for (int i = 0; i < SizeA; ++i) {
+            result[i] = a[i];
+        }
+        for (int i = 0; i < SizeB; ++i) {
+            result[i + SizeA] = b[i];
+        }
+        return result;
+    }
     // Types resulting of the extended command line parsing.
     struct AutoInstall
     {
         static constexpr std::array<std::wstring_view, 3> requirements{L"install", ARG_EXT_AUTOINSTALL, L""};
         std::filesystem::path autoInstallFile;
     };
-    struct InteractiveInstallOnly
+    struct SkipInstaller
     {
-        static constexpr std::array<std::wstring_view, 2> requirements{L"install", ARG_EXT_ENABLE_INSTALLER};
+        static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_DISABLE_INSTALLER};
     };
-    struct InteractiveInstallShell
+    struct OobeGui
     {
-        static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_ENABLE_INSTALLER};
+        static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_INSTALLER_GUI};
+    };
+    struct OobeTui
+    {
+        static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_INSTALLER_TUI};
+    };
+    template <typename InstallerOption> struct InteractiveInstallOnly
+    {
+        static constexpr std::array<std::wstring_view, 1> thisRequirements{L"install"};
+        static constexpr auto requirements = join(thisRequirements, InstallerOption::requirements);
+    };
+    template <typename InstallerOption> struct InteractiveInstallShell : InstallerOption
+    {
+        using InstallerOption::requirements;
     };
     struct Reconfig
     {
         static constexpr std::array<std::wstring_view, 1> requirements{L"config"};
     };
-    using Opts = std::variant<std::monostate, AutoInstall, InteractiveInstallOnly, InteractiveInstallShell, Reconfig>;
+    using Opts =
+      std::variant<std::monostate, AutoInstall, InteractiveInstallOnly<SkipInstaller>, InteractiveInstallOnly<OobeGui>,
+                   InteractiveInstallOnly<OobeTui>, InteractiveInstallShell<SkipInstaller>,
+                   InteractiveInstallShell<OobeGui>, InteractiveInstallShell<OobeTui>, Reconfig>;
 
     /// Parses a vector of command line arguments according to the extended command line options declared above. The
     /// extended options are removed from the original vector as a side effect to avoid confusing the "upstream command
     /// line parsing" routines. Notice that argv[0], i.e. the program name, is presumed not to be part of the arguments
     /// vector. See DistroLauncher.cpp main() function.
     Opts parseExtendedOptions(std::vector<std::wstring_view>& arguments);
+
+    using DEFAULT_EMPTY_CLI_CASE=InteractiveInstallShell<OobeGui>;
 }

--- a/DistroLauncher/extended_messages.h
+++ b/DistroLauncher/extended_messages.h
@@ -1,0 +1,3 @@
+#pragma once
+#undef MSG_USAGE
+#define MSG_USAGE MSG_USAGE_EXTENDED

--- a/DistroLauncher/installer_controller.h
+++ b/DistroLauncher/installer_controller.h
@@ -84,7 +84,9 @@ namespace Oobe
 
             // The opposite of the AutoInstalling, triggered by launching in install mode where OOBE exists.
             struct InteractiveInstall
-            { };
+            {
+                bool forceTextMode = false;
+            };
 
             // Command line parsing equivalent of `launcher config`. Implies the distro is already installed.
             struct Reconfig
@@ -145,7 +147,7 @@ namespace Oobe
                 }
 
                 // Decides whether OOBE must be launched in text or GUI mode and seeds it with user information.
-                StateVariant on_event(typename Events::InteractiveInstall /*unused*/)
+                StateVariant on_event(typename Events::InteractiveInstall event)
                 {
                     if (!Policy::is_oobe_available()) {
                         return UpstreamDefaultInstall{E_NOTIMPL};
@@ -155,7 +157,8 @@ namespace Oobe
                     commandLine += Policy::prepare_prefill_info();
 
                     // OOBE runs GUI by default, unless command line option --text is set.
-                    if (Policy::must_run_in_text_mode()) {
+                    // short circuiting ensures the function call will not happen if event.forceTextMode is true.
+                    if (event.forceTextMode || Policy::must_run_in_text_mode()) {
                         commandLine.append(L" --text");
                         return PreparedTui{commandLine};
                     }

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -103,6 +103,12 @@ Launches or configures a Linux distribution.
 Usage:
     <no args>
         Launches the user's default shell in the user's home directory.
+    --installer=[gui/tui/none]
+        Runs the Out of the Box Experience installer user interface, unless the option [none] is passed.
+        Passing [gui] enables running the graphical interface, which is the default behavior if this option is not supplied.
+        Pass [tui] instead to force the terminal user interface instead.
+        Pass [none] to run the minimal setup experience instead of the Out of the Box Experience.
+        Can be prepended with the [install] option below with no further options.
 
     install [options]
         Install the distribution and do not launch the shell when complete.
@@ -110,9 +116,6 @@ Usage:
               Do not create a user account and leave the default user set to root.
           --autoinstall <AUTOINSTALL-FILE-PATH>
               Reads information from an YAML file to automatically configure the distribution.
-          --enable-installer
-              Runs the Out of the Box Experience installer user interface.
-              Without the [install] option it launches the user's default shell after finishing installation.
 
     run <command line>
         Run the provided command line in the current working directory. If no

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -104,19 +104,19 @@ Usage:
     <no args>
         Launches the user's default shell in the user's home directory.
 
-    --installer=[gui/tui/none]
-        Runs the Out of the Box Experience installer user interface, unless the option [none] is passed.
-        Pass [gui] to enable running the graphical interface, which is the default behavior if this option is not supplied.
-        Pass [tui] instead to force the terminal user interface instead.
-        Pass [none] to run the minimal setup experience instead of the Out of the Box Experience.
-        Can be prepended with the [install] option below with no further options.
-
     install [options]
         Install the distribution and do not launch the shell when complete.
           --root
               Do not create a user account and leave the default user set to root.
           --autoinstall <AUTOINSTALL-FILE-PATH>
               Reads information from an YAML file to automatically configure the distribution.
+
+    --ui=[gui/tui/none]
+        Runs the Out of the Box Experience installer user interface to perform the final setup, unless the option [none] is passed.
+        Pass [gui] to enable running the graphical interface, which is the default behavior if this option is not supplied.
+        Pass [tui] instead to select the terminal user interface instead.
+        Pass [none] to run the minimal setup experience instead of the Out of the Box Experience.
+        Can be applied with the [install] option above to avoid launching the shell when complete.
 
     run <command line>
         Run the provided command line in the current working directory. If no

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -103,9 +103,10 @@ Launches or configures a Linux distribution.
 Usage:
     <no args>
         Launches the user's default shell in the user's home directory.
+
     --installer=[gui/tui/none]
         Runs the Out of the Box Experience installer user interface, unless the option [none] is passed.
-        Passing [gui] enables running the graphical interface, which is the default behavior if this option is not supplied.
+        Pass [gui] to enable running the graphical interface, which is the default behavior if this option is not supplied.
         Pass [tui] instead to force the terminal user interface instead.
         Pass [none] to run the minimal setup experience instead of the Out of the Box Experience.
         Can be prepended with the [install] option below with no further options.

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -54,3 +54,4 @@
 #include "Application.h"
 // Message strings compiled from .MC file.
 #include "messages.h"
+#include "extended_messages.h"

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher/extended_messages.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/meta/Ubuntu18.04LTS/src/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu18.04LTS/src/DistroLauncher/extended_messages.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher/extended_messages.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/meta/Ubuntu20.04LTS/src/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu20.04LTS/src/DistroLauncher/extended_messages.h
@@ -1,0 +1,1 @@
+#pragma once


### PR DESCRIPTION
Notice that the `=` signal is mandatory and spaces around are not tolerated in the current implementation. That can be enhanced if necessary, but will require more cleverness.

There is a header file trick to redefine the `MSG_USAGE` to `MSG_USAGE_EXTENDED` for the releases that support the OOBE. The header file `extended_messages.h` does this redefinition. For the releases that won't offer the OOBE, there should be an empty version of this file in meta subtrees, so the workflow can do the selection work.

With this implementation there is a nesting semantics on whether the shell should be available in the end or not (mandated by the argument `install` in the argv[1] position) versus whether the installer should be GUI, TUI or none (the original experience).

There are some compile-time tricks here and there to do some array manipulation in order to avoid repeating ourselves with the expected command line strings (which would otherwise not be checked until runtime).

As a result of a previous discussion, `--ui=gui` forces GUI mode without any checks whether the environment support graphics. Autodetection is available if no `--ui=` option is passed. The semantics of the `install` option is preserved, i.e. if present the launcher will just install the distro and quit. No shell in the end. Autointall option is only available with the `install` option, with the assumption that an automated installation should quit on exit, instead of launching a shell for user interaction.

The diagrams below summarize the command line options affected by this pull request:

![WSL Launcher Command Line Reference](https://user-images.githubusercontent.com/11138291/163391317-9f33bcb8-48b5-48ac-8305-4dba057de938.png)

![WSL Launcher Command Line Reference (1)](https://user-images.githubusercontent.com/11138291/163391333-ba5c623d-7abe-4596-952d-4ab4dbbb9663.png)

