### PR TITLE
Replace \\wsl$ or \\wsl.localhost path prefix with a function call

### DIFF
--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -45,21 +45,15 @@ namespace Oobe
 
     namespace
     {
-        static const char* launcherCommandFilePath{"/run/launcher-command"};
+        static const wchar_t* const launcherCommandFilePath{L"/run/launcher-command"};
         VoidResult act(const KeyValuePairs& cmds);
         VoidResult config(const KeyValuePairs& cmds);
     }
 
     void ExitStatusHandling()
     {
-        std::string prefixedFilePath{"\\\\wsl.localhost\\"};
-        auto distroName = Win32Utils::wide_string_to_utf8(DistributionInfo::Name);
-        // That should never fail, but if that happens it is a real bug.
-        if (!distroName.has_value()) {
-            wprintf(distroName.error().c_str());
-            return;
-        }
-        prefixedFilePath.append(distroName.value());
+        std::wstring prefixedFilePath{WslPathPrefix()};
+        prefixedFilePath.append(DistributionInfo::Name);
         prefixedFilePath.append(launcherCommandFilePath);
         std::ifstream launcherCmdFile;
         if (!std::filesystem::exists(prefixedFilePath)) {

--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -143,7 +143,7 @@ namespace Oobe
 
             auto f = capabilities.find(action);
             if (f == capabilities.end()) {
-                return nonstd::make_unexpected(std::domain_error(action));
+                return nonstd::make_unexpected(std::runtime_error(action));
             }
 
             auto res = f->second();

--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -46,7 +46,7 @@ namespace Oobe
 
     namespace
     {
-        static const wchar_t* const launcherCommandFilePath{L"/run/launcher-command"};
+        const wchar_t* const launcherCommandFilePath{L"/run/launcher-command"};
         VoidResult act(const KeyValuePairs& cmds);
         VoidResult config(const KeyValuePairs& cmds);
     }

--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -18,7 +18,8 @@
 #include "stdafx.h"
 #include <filesystem>
 
-namespace Helpers {
+namespace Helpers
+{
     // TODO: find a better place for this function. Inside Win32Utils, probably. Useful for dealing with std:exception.
     void PrintFromUtf8(const char* msg)
     {
@@ -85,7 +86,6 @@ namespace Oobe
         launcherCmdFile.close();
         // We don't want that file existing after actions were taken.
         std::filesystem::remove(prefixedFilePath);
-
     }
 
     namespace
@@ -103,7 +103,7 @@ namespace Oobe
             VoidResult rebootDistro();
             VoidResult shutdownDistro();
         };
-        using Action = VoidResult(*)();
+        using Action = VoidResult (*)();
         const std::unordered_map<std::string_view, Action> capabilities{{"reboot", &Actions::rebootDistro},
                                                                         {"shutdown", &Actions::shutdownDistro}};
 
@@ -169,7 +169,7 @@ namespace Oobe
             auto hr = g_wslApi.WslConfigureDistribution(default_uid, WSL_DISTRIBUTION_FLAGS_DEFAULT);
             if (FAILED(hr)) {
                 return nonstd::make_unexpected(std::runtime_error(
-                    "Could not configure distro to the new default UID: " + std::to_string(default_uid)));
+                  "Could not configure distro to the new default UID: " + std::to_string(default_uid)));
             }
 
             return VoidResult();

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -84,9 +84,9 @@ namespace DistributionInfo
             return commandLine;
         }
 
-        // Write it to a file inside \\wsl.localhost distro filesystem.
+        // Write it to a file inside the distribution filesystem.
         const std::wstring prefillFileNameDest = L"/var/tmp/prefill-system-setup.yaml";
-        const std::wstring wslPrefix = L"\\\\wsl.localhost\\" + DistributionInfo::Name;
+        const std::wstring wslPrefix = Oobe::WslPathPrefix() + DistributionInfo::Name;
         std::ofstream prefillFile;
         // Mixing slashes and backslashes that way is not a problem for Windows.
         prefillFile.open(wslPrefix + prefillFileNameDest, std::ios::ate);

--- a/DistroLauncher/OobeDefs.h
+++ b/DistroLauncher/OobeDefs.h
@@ -20,5 +20,5 @@
 namespace Oobe
 {
     using KeyValuePairs = std::unordered_map<std::string, std::any>;
-    using VoidResult = nonstd::expected<void, std::exception>;
+    using VoidResult = nonstd::expected<void, std::runtime_error>;
 }

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -151,7 +151,17 @@ namespace Oobe
 
     const wchar_t* WslPathPrefix()
     {
-        static const wchar_t* prefix = Win32Utils::os_version() == 10 ? L"\\\\wsl$\\" : L"\\\\wsl.localhost\\";
+        // This seams more readable than a ternary operator expression, specially if future OS versions require a
+        // different path prefix.
+        static const wchar_t* prefix = [](auto version) {
+            switch (version) {
+            case Win32Utils::WinVersion::Win10:
+                return L"\\\\wsl$\\";
+            case Win32Utils::WinVersion::Win11:
+                return L"\\\\wsl.localhost\\";
+            }
+        }(Win32Utils::os_version());
+
         return prefix;
     }
 }

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -148,4 +148,10 @@ namespace Oobe
         command.append(intendedCommand);
         return command;
     }
+
+    const wchar_t* WslPathPrefix()
+    {
+        static const wchar_t* prefix = Win32Utils::os_version() == 10 ? L"\\\\wsl$\\" : L"\\\\wsl.localhost\\";
+        return prefix;
+    }
 }

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -110,7 +110,7 @@ namespace Oobe::internal
     // Returns true if /etc/wsl.conf file contains the boot command to activate systemd.
     bool is_systemd_enabled()
     {
-        std::wstring wslConfPath{L"\\\\wsl.localhost\\"};
+        std::wstring wslConfPath{WslPathPrefix()};
         wslConfPath.append(DistributionInfo::Name);
         wslConfPath.append(L"/etc/wsl.conf");
         std::wifstream wslConf;

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -42,9 +42,13 @@ namespace Oobe::internal
     /// This is intended to be called once, thus no caching.
     bool ini_find_value(std::wistream& ini, std::wstring_view section, std::wstring_view key,
                         std::wstring_view valueContains);
+
 }
 
 namespace Oobe
 {
     std::wstring WrapCommand(std::wstring_view intendedCommand);
+
+    // Returns the preferred file path prefix to access files inside the Linux file system.
+    const wchar_t* WslPathPrefix();
 }

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -164,9 +164,11 @@ namespace Win32Utils
 
     DWORD read_build_from_registry()
     {
+        constexpr auto REGBUFSIZE = 20;
+        DWORD bufSize = REGBUFSIZE;
+        wchar_t buffer[REGBUFSIZE] = {0};
         DWORD valueType = 0;
-        DWORD bufSize = 20;
-        wchar_t buffer[20] = {0};
+        // NOLINTNEXTLINE(performance-no-int-to-ptr) - Win32 default HKEY's are pointers converted from integer values.
         auto res = RegGetValue(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
                                L"CurrentBuildNumber", RRF_RT_REG_SZ, &valueType, static_cast<void*>(buffer), &bufSize);
         if (res != ERROR_SUCCESS) {

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -162,4 +162,41 @@ namespace Win32Utils
         return target.place(window, SWP_SHOWWINDOW);
     }
 
+    DWORD read_build_from_registry()
+    {
+        DWORD valueType = 0;
+        DWORD bufSize = 20;
+        wchar_t buffer[20] = {0};
+        auto res = RegGetValue(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+                               L"CurrentBuildNumber", RRF_RT_REG_SZ, &valueType, static_cast<void*>(buffer), &bufSize);
+        if (res != ERROR_SUCCESS) {
+            return 0;
+        }
+        std::wstring readValue(buffer, bufSize);
+        DWORD build = 0;
+        try {
+            build = std::stoul(readValue);
+        } catch (const std::invalid_argument& ex) {
+            std::cerr << ex.what() << '\n';
+            return 0;
+        } catch (const std::out_of_range& ex) {
+            std::cerr << ex.what() << '\n';
+            return 0;
+        }
+
+        return build;
+    }
+
+    DWORD os_version()
+    {
+        // lets presume windows 10 on error.
+        static DWORD version = os_build_number() >= 22000 ? 11 : 10;
+        return version;
+    }
+
+    DWORD os_build_number()
+    {
+        static DWORD build = read_build_from_registry();
+        return build;
+    }
 } // namespace Win32Utils

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -189,16 +189,28 @@ namespace Win32Utils
         return build;
     }
 
-    DWORD os_version()
+    WinVersion from_build_number(DWORD buildNo)
     {
+        // Note for future self: augment this from the top on newer OS version releases.
+        if (buildNo >= static_cast<DWORD>(WinVersion::Win11)) {
+            return WinVersion::Win11;
+        }
+        if (buildNo >= static_cast<DWORD>(WinVersion::Win10)) {
+            return WinVersion::Win10;
+        }
         // lets presume windows 10 on error.
-        static DWORD version = os_build_number() >= 22000 ? 11 : 10;
+        return WinVersion::Win10;
+    }
+
+    WinVersion os_version()
+    {
+        static const auto version = from_build_number(os_build_number());
         return version;
     }
 
     DWORD os_build_number()
     {
-        static DWORD build = read_build_from_registry();
+        static const auto build = read_build_from_registry();
         return build;
     }
 } // namespace Win32Utils

--- a/DistroLauncher/Win32Utils.h
+++ b/DistroLauncher/Win32Utils.h
@@ -32,8 +32,16 @@ namespace Win32Utils
     /// Returns 0 on success.
     DWORD resize_to(HWND window, HWND topWindow);
 
+    // Enumeration class that give named constants referring to the operating system version according to the first
+    // build number.
+    enum class WinVersion
+    {
+        Win10 = 10240,
+        Win11 = 22000,
+    };
+
     /// Returns the operating system version. Assumes Windows 10 or higher.
-    DWORD os_version();
+    WinVersion os_version();
 
     /// Returns the operating system build number or 0 on failure.
     DWORD os_build_number();

--- a/DistroLauncher/Win32Utils.h
+++ b/DistroLauncher/Win32Utils.h
@@ -31,4 +31,11 @@ namespace Win32Utils
     /// Resizes [window] to be equal in size and placement to [topWindow] while preserving [topWindow] on top.
     /// Returns 0 on success.
     DWORD resize_to(HWND window, HWND topWindow);
+
+    /// Returns the operating system version. Assumes Windows 10 or higher.
+    DWORD os_version();
+
+    /// Returns the operating system build number or 0 on failure.
+    DWORD os_build_number();
+
 }

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -31,7 +31,7 @@ namespace Oobe
 
         static bool copy_file_into_distro(const std::filesystem::path& from, const std::wstring& to)
         {
-            std::wstring wslPrefixedDest = L"\\\\wsl.localhost\\" + DistributionInfo::Name;
+            std::wstring wslPrefixedDest = WslPathPrefix() + DistributionInfo::Name;
             wslPrefixedDest.append(to);
             std::filesystem::path realDest{wslPrefixedDest};
             std::error_code ec;


### PR DESCRIPTION
The result of the function call depends on the operating system version, which is obtained by reading the build number from the registry.

To avoid linting complains, some reformattings were done in `ExitStatus.cpp`. Since we are touching that file, the function `ExitStatusHandling()` was slightly simplified since the experimentation has shown that we can use wide characters in file paths to open files in the Linux file system. To simplify it further, I unified the return type of the error handling code into one single kind of exception to avoid slicing when returning errors.