### PR TITLE
Fix build error due Mode undeclared for ARM64

### DIFF
--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -217,9 +217,9 @@ namespace Oobe
 
     HRESULT NoSplashStrategy::do_install(Mode ui)
     {
-        std::array<InstallerController<>::Event, 3> eventSequence{
-          InstallerController<>::Events::InteractiveInstall{Mode ui}, InstallerController<>::Events::StartInstaller{},
-          InstallerController<>::Events::BlockOnInstaller{}};
+        std::array<InstallerController<>::Event, 3> eventSequence{InstallerController<>::Events::InteractiveInstall{ui},
+                                                                  InstallerController<>::Events::StartInstaller{},
+                                                                  InstallerController<>::Events::BlockOnInstaller{}};
         HRESULT hr = E_NOTIMPL;
         for (auto& ev : eventSequence) {
             auto ok = installer.sm.addEvent(ev);

--- a/DistroLauncher/ApplicationStrategy.h
+++ b/DistroLauncher/ApplicationStrategy.h
@@ -90,6 +90,7 @@ namespace Oobe
 
 namespace Oobe
 {
+    using Mode = InstallerController<>::Mode;
     // This strategy fulfills the essential API required to run the OOBE without the complexity required by the
     // synchronization of the slide show. That separation is necessary because Flutter is not supported on Windows
     // ARM64. See: https://github.com/flutter/flutter/issues/62597


### PR DESCRIPTION
The `using Mode = InstallerController<>::Mode;` statement was available only for x64. My bad. This fixes it and a related mistake in the cpp file as well.