### PR TITLE
Makes use of more specific HRESULTS in installer_controller

### DIFF
--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -181,7 +181,7 @@ namespace Oobe
             // unexpected transition occurred here?
             if (!ok.has_value()) {
                 do_close_splash();
-                return E_FAIL;
+                return hr;
             }
 
             std::visit(internal::overloaded{

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -85,8 +85,8 @@ namespace Oobe
         {
             using defer = std::unique_ptr<std::remove_pointer_t<HANDLE>, decltype(&::CloseHandle)>;
             constexpr DWORD watcherTimeout = 1000; // ms
-            constexpr auto initialDelay = 3e3F;
-            constexpr auto delayRatio = 0.65F;
+            constexpr auto initialDelay = 4e3F;
+            constexpr auto delayRatio = 0.85F;
 
             HANDLE sslxProcess;
             DWORD sslxExitCode;


### PR DESCRIPTION
And ensures the HRESULT value returning from a failed operation is preserved. Also increases the overall duration of the function  `poll_success()` to decrease he likelyhood of it causing an OOBE crash on slower machines.