### PR TITLE
Fix GUI support autodetection

### DIFF
--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -226,7 +226,7 @@ namespace Oobe
 
             // unexpected transition occurred here?
             if (!ok.has_value()) {
-                return E_FAIL;
+                return hr;
             }
 
             std::visit(internal::overloaded{

--- a/DistroLauncher/installer_controller.h
+++ b/DistroLauncher/installer_controller.h
@@ -157,19 +157,20 @@ namespace Oobe
                     std::wstring commandLine{Policy::OobeCommand};
                     commandLine += Policy::prepare_prefill_info();
 
-                    // OOBE runs GUI by default, unless command line option --text is set.
                     auto uiMode = event.ui;
-                    switch (uiMode) {
-                    case Mode::AutoDetect:
+                    if (uiMode == Mode::AutoDetect) {
                         if (Policy::must_run_in_text_mode()) {
                             uiMode = Mode::Text;
                         } else {
                             uiMode = Mode::Gui;
                         }
-                        [[fallthrough]]; // no breaks to avoid code repetition.
+                    }
+
+                    switch (uiMode) {
                     case Mode::Gui:
                         return PreparedGui{commandLine};
                     case Mode::Text:
+                        // OOBE runs GUI by default, unless command line option --text is set.
                         commandLine.append(L" --text");
                         return PreparedTui{commandLine};
                     }


### PR DESCRIPTION
In attempt to void nested-if clauses I made a silly mistake in the switch statement causing it to slip through into Mode::Gui case without actually reading the updated value inside the variable uiMode.

Also, a small change in the ApplicationStrategy.cpp to ensure the failing HRESULT will be preserved for the ARM64 platform as we did previously for the x64.
