### PR TITLE
Demote userinfo errors

### DIFF
--- a/DistroLauncher/WindowsUserInfo.cpp
+++ b/DistroLauncher/WindowsUserInfo.cpp
@@ -17,11 +17,14 @@
 
 #include "stdafx.h"
 
-namespace DistributionInfo {
+namespace DistributionInfo
+{
     // Implementation details.
-    namespace {
+    namespace
+    {
         // WindowsUserInfo holds together the user information retrieved from Win32 API's.
-        struct WindowsUserInfo {
+        struct WindowsUserInfo
+        {
             std::wstring userName;
             std::wstring realName;
             std::wstring localeName;
@@ -31,7 +34,8 @@ namespace DistributionInfo {
 
         // PrintLastError converts the last error code from Win32 API's into
         // an error message.
-        inline void PrintLastError() {
+        inline void PrintLastError()
+        {
             HRESULT error = HRESULT_FROM_WIN32(GetLastError());
             Helpers::PrintErrorMessage(error);
         }
@@ -40,21 +44,22 @@ namespace DistributionInfo {
         // because of such small feature, which would be an overkill. Shall the need
         // for more YAML manipulation in the DistroLauncher arise, thus function should
         // be changed to use a proper YAML manipulation library, such as yaml-cpp.
-        std::string WindowsUserInfo::toYamlUtf8() const {
+        std::string WindowsUserInfo::toYamlUtf8() const
+        {
             std::wstring fullYaml;
 
             if (!localeName.empty()) {
                 fullYaml += L"Welcome:\n  lang: " + localeName + L'\n';
-                }
+            }
 
             if (!realName.empty() || !userName.empty()) {
                 fullYaml += L"WSLIdentity:\n";
 
-            if (!realName.empty()) {
+                if (!realName.empty()) {
                     fullYaml += L"  realname: " + realName + L'\n';
-            }
+                }
 
-            if (!userName.empty()) {
+                if (!userName.empty()) {
                     fullYaml += L"  username: " + userName + L'\n';
                 }
             }
@@ -72,7 +77,8 @@ namespace DistributionInfo {
 
         // QueryWindowsUserInfo queries Win32 API's to provide launcher with locale, user real and login names.
         // Those pieces of information will be used in the Ubuntu OOBE to enhance the UX.
-        WindowsUserInfo QueryWindowsUserInfo() {
+        WindowsUserInfo QueryWindowsUserInfo()
+        {
             DistributionInfo::WindowsUserInfo userInfo;
             const int size = LOCALE_NAME_MAX_LENGTH;
             WCHAR loc[size];
@@ -82,7 +88,7 @@ namespace DistributionInfo {
             if (result == 0) {
                 PrintLastError();
             } else {
-                std::wstring_view view{loc,result};
+                std::wstring_view view{loc, result};
                 std::size_t dashPos = view.find_first_of('-');
                 if (dashPos > 0 && dashPos < result) {
                     loc[dashPos] = '_';
@@ -97,7 +103,7 @@ namespace DistributionInfo {
             if (ret == 0) {
                 PrintLastError();
             } else {
-                userInfo.realName = std::wstring{userRealName,nSize};
+                userInfo.realName = std::wstring{userRealName, nSize};
             }
 
             nSize = size;
@@ -105,7 +111,7 @@ namespace DistributionInfo {
             if (ret == 0) {
                 PrintLastError();
             } else {
-                std::wstring_view samView{userRealName,nSize};
+                std::wstring_view samView{userRealName, nSize};
                 std::wstring_view justTheUserName = samView.substr(samView.find_first_of('\\') + 1, samView.length());
                 userInfo.userName = std::wstring{justTheUserName};
             }
@@ -118,7 +124,8 @@ namespace DistributionInfo {
     // GetPrefillInfoInYaml exports Windows User Information as an YAML UTF-8
     // encoded string.
     // This is the only symbol visible outside of this translation unit.
-    std::string GetPrefillInfoInYaml() {
+    std::string GetPrefillInfoInYaml()
+    {
         WindowsUserInfo userInfo = DistributionInfo::QueryWindowsUserInfo();
         return userInfo.toYamlUtf8();
     } // std::wstring GetPrefillInfoInYaml().

--- a/DistroLauncher/WindowsUserInfo.cpp
+++ b/DistroLauncher/WindowsUserInfo.cpp
@@ -37,7 +37,7 @@ namespace DistributionInfo
         inline void PrintLastError()
         {
             HRESULT error = HRESULT_FROM_WIN32(GetLastError());
-            Helpers::PrintErrorMessage(error);
+            wprintf(L"Recovering user information failed with the code: %lx\n", error);
         }
 
         // toYaml hand-codes the YAML generation to avoid adding a lib just


### PR DESCRIPTION
Most of this PR is reformattings to avoid unrelated linting complaints.

The important point of it is the following change:

```diff
        inline void PrintLastError()
        {
            HRESULT error = HRESULT_FROM_WIN32(GetLastError());
-            Helpers::PrintErrorMessage(error);
+            wprintf(L"Recovering user information failed with the code: %lx\n", error);
        }
```

The rest is details.

This avoids the message to appear with the "Error: " prefix, thus reducing its level of importance. In fact, this is used for when GetUserNameEx and GetUserLocale functions fail, which is not a big thing.

Since this call `BOOLEAN ret = GetUserNameExW(EXTENDED_NAME_FORMAT::NameDisplay, userRealName, &nSize);` is the offeding one due the VM user not being fully setup in a domain with its detailed name registered, a second attempt is done by trying to read `NameGivenName` and `NameSurname`. Not a big fix, though.

![image](https://user-images.githubusercontent.com/11138291/164055558-3ba4aa0c-dd31-49a5-b004-f82801e2bd73.png)

The code was becoming messy with nested-if clauses, so I decided to take this out in a new function called `GetUserDisplayName()` and to preserve the symetry, I extracted a `GetUserRealName()` as well.