### PR TITLE
Reduces the chance of not finding the GUI window

### DIFF
--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -75,6 +75,8 @@ namespace Oobe
             // element and the clickable area.
 
             // Win32Utils::center_window(window);
+            ShowWindow(window, SW_MINIMIZE);
+            Sleep(50);
             ShowWindow(window, SW_RESTORE);
         }
         // Repeatedly launches asynchronously the [command] up to [repeatTimes] until it succeeds.

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -76,7 +76,8 @@ namespace Oobe
 
             // Win32Utils::center_window(window);
             ShowWindow(window, SW_MINIMIZE);
-            Sleep(50);
+            constexpr auto shortSleep = 50;
+            Sleep(shortSleep);
             ShowWindow(window, SW_RESTORE);
         }
         // Repeatedly launches asynchronously the [command] up to [repeatTimes] until it succeeds.

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -43,7 +43,7 @@ namespace Oobe
         {
             // attempt to find the window by class "RAIL_WINDOW" and flutterCaption "Ubuntu WSL (UbuntuPreview)".
             // it appears before Subiquity is ready.
-            constexpr auto fastSleepFor = 10;
+            constexpr auto fastSleepFor = 20;
             HWND rdpWindow = nullptr;
             std::array<std::wstring, 2> possibleCaptions{L"Ubuntu WSL (", L"[WARN:COPY MODE] Ubuntu WSL ("};
             std::for_each(possibleCaptions.begin(), possibleCaptions.end(), [](auto& caption) {


### PR DESCRIPTION
Reported that sometimes the OOBE GUI window appeared behind other random windows.
We cannot control where WSLG will render any Linux window, but once we find it, we can control its placement.
The reported issue was due the routine that attempts to find the GUI window was timing out.
This increases the time out duration. Moving that window is also an option, but it may mess with WSLG recognition of the window controls, so let's take the easy path for now.