### PR TITLE
Disables autoinstall feature

### DIFF
--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -64,7 +64,10 @@ namespace Oobe
             wprintf(L"Unpacking is complete!\n");
             HRESULT hr =
               std::visit(internal::overloaded{
-                           [&](AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
+                           [&](AutoInstall& option) {
+                               wprintf(L"Automatic installation is not supported by this version.\n");
+                               return E_NOTIMPL;
+                           },
                            [&](InstallDefault& option) { return impl_.do_install(Mode::AutoDetect); },
                            [&](InstallOnlyDefault& option) { return impl_.do_install(Mode::AutoDetect); },
                            [&](InteractiveInstallOnly<OobeGui>& option) { return impl_.do_install(Mode::Gui); },

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -108,8 +108,6 @@ Usage:
         Install the distribution and do not launch the shell when complete.
           --root
               Do not create a user account and leave the default user set to root.
-          --autoinstall <AUTOINSTALL-FILE-PATH>
-              Reads information from an YAML file to automatically configure the distribution.
 
     --ui=[gui/tui/none]
         Runs the Out of the Box Experience installer user interface to perform the final setup, unless the option [none] is passed.


### PR DESCRIPTION
When I finally got to test the autoinstall feature end to end in WSL I got a stack trace in early commands due systemd-cat failing.

It’s technically possible to leverage our systemd support implementation to run Subiquity under systemd’s namespace just using the launcher, but that results in crashes due shared library incompatibilities similar to what we experienced with APT.

That would require changing Subiquity controllers involved with autoinstallation that perform `subprocess.run()` to pass a suitable environment. It seems too late to perform that.

For reference, that set of changes presented below in the `installer_controller.h` code that handles the autoinstallation produces the effect picture in the screenshots:

```diff
diff --git a/DistroLauncher/installer_controller.h b/DistroLauncher/installer_controller.h
index 56fd591..10f2158 100644
--- a/DistroLauncher/installer_controller.h
+++ b/DistroLauncher/installer_controller.h
@@ -200,9 +200,20 @@ namespace Oobe
                 std::wstring cli;
                 StateVariant on_event(typename Events::BlockOnInstaller /*unused*/)
                 {
-                    if (auto exitCode = Policy::do_launch_sync(cli.c_str()); exitCode != 0) {
+                    DWORD exitCode;
+                    HANDLE child = nullptr;
+                    HRESULT hr = g_wslApi.WslLaunchInteractive(
+                      L"printf \"[boot]\ncommand=/usr/libexec/wsl-systemd\n\" > /etc/wsl.conf", FALSE, &exitCode);
+                    std::wstring shutdownCmd{L"wsl -t "};
+                    shutdownCmd.append(DistributionInfo::Name);
+                    _wsystem(shutdownCmd.c_str());
+                    auto command = Oobe::WrapCommand(cli);
+                    if (auto exitCode = Policy::do_launch_sync(command.c_str()); exitCode != 0) {
                         return UpstreamDefaultInstall{E_FAIL};
                     }
+                    std::wstring filepath{WslPathPrefix()};
+                    filepath.append(L"/etc/wsl.conf");
+                    std::filesystem::remove(filepath);
                     Policy::handle_exit_status();
                     return Success{};
                 }
```

![image](https://user-images.githubusercontent.com/11138291/164294378-eee80dd7-ade8-4235-b36e-6485b3ba437d.png)

![image](https://user-images.githubusercontent.com/11138291/164294436-12151292-5578-4e2b-89a2-4eb27c007a1a.png)

