### PR TITLE
Ensures OOBE will be presented on top on Reconfig.

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/InstallerControllerTestPolicies.h
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/InstallerControllerTestPolicies.h
@@ -139,6 +139,65 @@ namespace Oobe
 
     const wchar_t* EverythingWorksPolicy::OobeCommand = cmd;
 
+    struct EverythingWorksTuiPolicy
+    {
+        static const wchar_t* OobeCommand;
+
+        static bool is_oobe_available()
+        {
+            return true;
+        }
+
+        static std::wstring prepare_prefill_info()
+        {
+            return L"";
+        }
+
+        static bool must_run_in_text_mode()
+        {
+            return true;
+        }
+
+        static void handle_exit_status()
+        { }
+
+        static bool copy_file_into_distro(const std::filesystem::path& from, const std::wstring& to)
+        {
+            return true;
+        }
+
+        static bool poll_success(const wchar_t* command, int repeatTimes, HANDLE monitoredProcess)
+        {
+            return true;
+        }
+
+        static DWORD consume_process(HANDLE process, DWORD timeout)
+        {
+            return 0;
+        }
+
+        static HANDLE start_installer_async(const wchar_t* command,
+                                            const wchar_t* watcher = L"ss -lx | grep subiquity &>/dev/null")
+        {
+            return GetStdHandle(STD_OUTPUT_HANDLE);
+        }
+
+        static DWORD do_launch_sync(const wchar_t* cli)
+        {
+            return 0;
+        }
+
+        static HWND try_hiding_installer_window(int repeatTimes)
+        {
+            return static_cast<HWND>(GetStdHandle(STD_OUTPUT_HANDLE));
+        }
+
+        static void show_window(HWND window)
+        { }
+    };
+
+    const wchar_t* EverythingWorksTuiPolicy::OobeCommand = cmd;
+
     struct FailsToLaunchPolicy
     {
         static const wchar_t* OobeCommand;

--- a/DistroLauncher-Tests/DistroLauncher-Tests/InstallerControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/InstallerControllerTests.cpp
@@ -86,6 +86,18 @@ namespace Oobe
         using Controller = InstallerController<EverythingWorksPolicy>;
         Controller controller{};
         auto ok = controller.sm.addEvent(Controller::Events::Reconfig{});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::PreparedGui>());
+        controller.sm.addEvent(Controller::Events::StartInstaller{});
+        // opportunity for the application to react and ensure the context is ready for user interaction.
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Ready>());
+        controller.sm.addEvent(Controller::Events::BlockOnInstaller{});
+        ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Success>());
+    }
+    TEST(InstallerControllerTests, HappyReconfigTui)
+    {
+        using Controller = InstallerController<EverythingWorksTuiPolicy>;
+        Controller controller{};
+        auto ok = controller.sm.addEvent(Controller::Events::Reconfig{});
         ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Success>());
     }
     TEST(InstallerControllerTests, HappyInteractiveInstall)


### PR DESCRIPTION
Previously OOBE GUI placement was controlled by WSLG only. Sometimes it appeared behind other random windows.
With this change we leverage the same mechanisms used for interactive install to ensure the OOBE GUI will appear on top.
That requires breaking the reconfig in more states if GUI mode, reusing the same states related to the interactive install, 
maximizing reuse of the state machine components.

TUI reconfig remains unchanged.

Tests and comments were revised to reflect those changes as well.