### PR TITLE
Try fixing dailies with no development releases

### DIFF
--- a/wsl-builder/prepare-build/buildGHMatrix.go
+++ b/wsl-builder/prepare-build/buildGHMatrix.go
@@ -21,7 +21,7 @@ func buildGHMatrix(csvPath, metaPath string) error {
 		return err
 	}
 
-	var allBuilds []matrixElem
+	allBuilds := make([]matrixElem, 0)
 	// List which releases we should try building
 	for _, r := range releasesInfo {
 		if !r.ShouldBuild {


### PR DESCRIPTION
As we are in a particular state with no release to build at all, then
the slice of matrixEleme is deserialized to null, which is json
compatible.
It seems that GitHub Actions don’t like that and still expect an
iterable.

Consequently, this is a tentative fix to set it to an empty slice
instead of nil, so that GitHub Action could try iterating over it and do
nothing.