### PR TITLE
Keep last store visibility state

### DIFF
--- a/meta/SBConfig.json
+++ b/meta/SBConfig.json
@@ -23,8 +23,6 @@
     "appSubmission": {
         "targetPublishMode": "Manual",
 
-        "visibility": "Private",
-
         "allowTargetFutureDeviceFamilies": {
             "Xbox": false,
             "Team": false,


### PR DESCRIPTION
This prevents making every new update for people only having the link.
We keep previous app state.