### PR TITLE
Avoid building CI matrix when there is no distro to build

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -68,6 +68,10 @@ jobs:
             wsl-builder/lp-distro-info > /tmp/all-releases.csv
             go build ./wsl-builder/prepare-build
             builds_config="$(./prepare-build build-github-matrix /tmp/all-releases.csv)"
+            if [ "${builds_config}" == "null" ]; then
+              echo "No active application to build"
+              exit 0
+            fi
             builds="{\"include\":${builds_config}}"
           fi
 

--- a/wsl-builder/prepare-build/buildGHMatrix.go
+++ b/wsl-builder/prepare-build/buildGHMatrix.go
@@ -21,7 +21,7 @@ func buildGHMatrix(csvPath, metaPath string) error {
 		return err
 	}
 
-	allBuilds := make([]matrixElem, 0)
+	var allBuilds []matrixElem
 	// List which releases we should try building
 	for _, r := range releasesInfo {
 		if !r.ShouldBuild {


### PR DESCRIPTION
This ensure that we don’t have Includes: [] which is not supported by
GitHub Actions: "At least one vector element is required".