### PR TITLE
Prefers server-status over OOBE exit code

### DIFF
--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -153,6 +153,9 @@ namespace Oobe
                 GetExitCodeProcess(process, &exitCode);
             }
 
+            [[maybe_unused]] DWORD clearExitCode = 0;
+            g_wslApi.WslLaunchInteractive(L"clear", FALSE, &clearExitCode);
+
             return exitCode;
         }
 

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -147,15 +147,12 @@ namespace Oobe
                 return exitCode;
             }
 
-            GetExitCodeProcess(process, &exitCode);
-            // The Flutter installer exits 0 on some crashes.
-            // And sometimes reports crash even though Subiquity has finished. This gets fixed in [UDI PR
-            // 786](https://github.com/canonical/ubuntu-desktop-installer/pull/786)
-            if (exitCode == 0) {
-                g_wslApi.WslLaunchInteractive(L"grep -E 'EXITED|DONE' /run/subiquity/server-state", FALSE, &exitCode);
-                DWORD clearExitCode;
-                g_wslApi.WslLaunchInteractive(L"clear", FALSE, &clearExitCode);
+            // Whether the OOBE exit code is 0 or not, what trully matters is whether Subiquity finished its job:
+            g_wslApi.WslLaunchInteractive(L"grep -E 'EXITED|DONE' /run/subiquity/server-state", FALSE, &exitCode);
+            if (exitCode != 0) {
+                GetExitCodeProcess(process, &exitCode);
             }
+
             return exitCode;
         }
 


### PR DESCRIPTION
Windows 11 build 22598 users reported GUI mode installation reported failed but the background tasks had succeeded.
Thus, when applying the fallback with the same username, that method also failed.
OOBE is returning a failed exit code, but Subiquity concluded its work.
This ensures to return 0 if server-state is successful.
Returns OOBE error code otherwise.

Yet, further investigation on the OOBE side is required to understand why it's reporting failure if the installation completed and what is the relationship between the latest Windows and WSL updates and the OOBE reporting failure.

Fixes #180