### PR TITLE
Hide console only if it's dedicated to the launcher process

### DIFF
--- a/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.UbuntuDev.AppID.Dev" Version="4.10.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--from-start-menu-or-store">
       <uap:VisualElements DisplayName="UbuntuDev.FullName.Dev" Description="UbuntuDev.FullName.Dev on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--from-start-menu-or-store">
+    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
       <uap:VisualElements DisplayName="UbuntuDev.FullName.Dev" Description="UbuntuDev.FullName.Dev on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
@@ -125,6 +125,39 @@ namespace Oobe::internal
         ASSERT_TRUE(std::holds_alternative<InstallDefault>(opts));
     }
 
+    // Tests the ManifestMatchedInstall and combinations with it.
+    TEST(ExtendedCliParserTests, StoreStartMenuInvocation)
+    {
+        std::vector<std::wstring_view> args{ARG_EXT_UAP10_PARAMETERS};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<ManifestMatchedInstall>(opts));
+        ASSERT_TRUE(args.empty());
+    }
+
+    TEST(ExtendedCliParserTests, InvalidCombinationWithManifestMatched1)
+    {
+        std::vector<std::wstring_view> args{L"install", ARG_EXT_UAP10_PARAMETERS};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(args.size(), 1);
+    }
+
+    TEST(ExtendedCliParserTests, InvalidCombinationWithManifestMatched2)
+    {
+        std::vector<std::wstring_view> args{L"install", ARG_EXT_INSTALLER_GUI, ARG_EXT_UAP10_PARAMETERS};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(args.size(), 1);
+    }
+
+    TEST(ExtendedCliParserTests, InvalidCombinationWithManifestMatched3)
+    {
+        std::vector<std::wstring_view> args{L"config", ARG_EXT_UAP10_PARAMETERS};
+        auto opts = parseExtendedOptions(args);
+        ASSERT_TRUE(std::holds_alternative<std::monostate>(opts));
+        ASSERT_EQ(args.size(), 1);
+    }
+
     // Tests whether the upstream options remain preserved:
     TEST(ExtendedCliParserTests, InstallRootIsUpstream)
     {

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -38,6 +38,11 @@ namespace Oobe
             return std::holds_alternative<internal::Reconfig>(arg);
         }
 
+        bool canHideConsole() const
+        {
+            return std::holds_alternative<internal::ManifestMatchedInstall>(arg);
+        }
+
       public:
         /// Returns true if the command line parsing doesn't require running the OOBE.
         /// That implies partial command line parsing, with the required actions deferred to the upstream code.
@@ -65,6 +70,7 @@ namespace Oobe
             HRESULT hr =
               std::visit(internal::overloaded{
                            [&](AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
+                           [&](ManifestMatchedInstall& option) { return impl_.do_install(Mode::AutoDetect); },
                            [&](InstallDefault& option) { return impl_.do_install(Mode::AutoDetect); },
                            [&](InstallOnlyDefault& option) { return impl_.do_install(Mode::AutoDetect); },
                            [&](InteractiveInstallOnly<OobeGui>& option) { return impl_.do_install(Mode::Gui); },
@@ -104,7 +110,7 @@ namespace Oobe
             if (isAutoInstall() || shouldSkipInstaller()) {
                 return;
             }
-            impl_.do_run_splash();
+            impl_.do_run_splash(canHideConsole());
         }
     };
 }

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -155,6 +155,9 @@ namespace Oobe
 
     void SplashEnabledStrategy::do_show_console()
     {
+        if (!console.has_value()) {
+            return;
+        }
         std::unique_lock<std::timed_mutex> guard{consoleGuard, std::defer_lock};
         using namespace std::chrono_literals;
         constexpr auto tryLockTimeout = 5s;

--- a/DistroLauncher/ApplicationStrategy.h
+++ b/DistroLauncher/ApplicationStrategy.h
@@ -77,7 +77,7 @@ namespace Oobe
         HRESULT do_reconfigure();
 
         /// Triggers the console redirection and launch the splash screen application.
-        void do_run_splash();
+        void do_run_splash(bool hideConsole = false);
 
         SplashEnabledStrategy();
         ~SplashEnabledStrategy() = default;
@@ -100,7 +100,7 @@ namespace Oobe
 
         /// Prints to the console an error message informing that this platform doesn't support running the splash
         /// screen.
-        void do_run_splash()
+        void do_run_splash(bool hideConsole = false)
         {
             wprintf(L"This device architecture doesn't support running the splash screen.\n");
         }

--- a/DistroLauncher/console_service.h
+++ b/DistroLauncher/console_service.h
@@ -161,9 +161,12 @@ namespace Win32Utils
 
         bool showConsoleWindow(HWND topWindow) const
         {
-            if (auto res = Win32Utils::resize_to(window_, topWindow); res != 0) {
-                Helpers::PrintErrorMessage(HRESULT_FROM_WIN32(res));
+            if (IsWindowVisible(topWindow) == TRUE) {
+                if (auto res = Win32Utils::resize_to(window_, topWindow); res != 0) {
+                    Helpers::PrintErrorMessage(HRESULT_FROM_WIN32(res));
+                }
             }
+
             // If the window was previously visible, the return value is nonzero.
             // If the window was previously hidden, the return value is zero.
             return ShowWindow(window_, SW_SHOWNORMAL) == FALSE;

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -54,6 +54,11 @@ namespace Oobe::internal
 
     Opts parse(const std::vector<std::wstring_view>& arguments)
     {
+        // launcher.exe --hide-console - Windows Shell GUI invocation as declared in the appxmanifest. Hides the
+        // console, runs the OOBE (auto detect graphics support) and brings the shell at the end.
+        if (auto result = tryParse<ManifestMatchedInstall>(arguments); result.has_value()) {
+            return result.value();
+        }
         // launcher.exe - Runs the OOBE (auto detect graphics support) and brings the shell at the end.
         if (auto result = tryParse<InstallDefault>(arguments); result.has_value()) {
             return result.value();

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -115,11 +115,20 @@ namespace Oobe::internal
     Opts parseExtendedOptions(std::vector<std::wstring_view>& arguments)
     {
         Opts options{parse(arguments)};
+
         // Erasing the extended command line options to avoid confusion in the upstream code.
         auto it = std::remove_if(arguments.begin(), arguments.end(), [](auto arg) {
             return std::find(allExtendedArgs.begin(), allExtendedArgs.end(), arg) != allExtendedArgs.end();
         });
         arguments.erase(it, arguments.end());
+
+#ifdef UNSUPPORTED_EXTENDED_CLI
+        if (shouldWarnUnsupported(options)) {
+            wprintf(L"Warning: ignoring command line options invalid for this Ubuntu release.\n");
+        }
+        return {};
+#else
         return options;
+#endif // UNSUPPORTED_EXTENDED_CLI
     }
 }

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -84,10 +84,19 @@ namespace Oobe::internal
 
     // InteractiveInstallOnly<SkipInstaller> and InteractiveInstallShell<SkipInstaller> are actually std::monostate,
     // i.e. both go to upstream resolution.
-    using Opts = std::variant<std::monostate, AutoInstall, ManifestMatchedInstall, InstallDefault, InstallOnlyDefault,
-                              InteractiveInstallOnly<OobeGui>, InteractiveInstallOnly<OobeTui>,
-                              InteractiveInstallShell<OobeGui>, InteractiveInstallShell<OobeTui>, Reconfig>;
-
+    // clang-format off
+    // [clang-format appears to have trouble with long declarations like the following.]
+    using Opts = std::variant<std::monostate, // The upstream command line parsing effects.
+                              AutoInstall,
+                              ManifestMatchedInstall,
+                              InstallDefault,
+                              InstallOnlyDefault,
+                              InteractiveInstallOnly<OobeGui>,
+                              InteractiveInstallOnly<OobeTui>,
+                              InteractiveInstallShell<OobeGui>,
+                              InteractiveInstallShell<OobeTui>,
+                              Reconfig>;
+    // clang-format on
     /// Parses a vector of command line arguments according to the extended command line options declared above. The
     /// extended options are removed from the original vector as a side effect to avoid confusing the "upstream command
     /// line parsing" routines. Notice that argv[0], i.e. the program name, is presumed not to be part of the arguments

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -93,4 +93,14 @@ namespace Oobe::internal
     /// line parsing" routines. Notice that argv[0], i.e. the program name, is presumed not to be part of the arguments
     /// vector. See DistroLauncher.cpp main() function.
     Opts parseExtendedOptions(std::vector<std::wstring_view>& arguments);
+
+    /// Returns true if the command line parsing result is invalid for the case when the extended CLI is unsupported
+    /// (the case for older releases).
+    inline bool shouldWarnUnsupported(const Opts& options)
+    {
+        // [ARG_EXT_UAP10_PARAMETERS] must be accepted in the old releases, even though it will be jsut discarded,
+        // thus we should not warn for this case. The same stands for the empty CLI case.
+        return !(std::holds_alternative<ManifestMatchedInstall>(options) ||
+                 std::holds_alternative<InstallDefault>(options));
+    }
 }

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -109,7 +109,10 @@ namespace Oobe::internal
     {
         // [ARG_EXT_UAP10_PARAMETERS] must be accepted in the old releases, even though it will be jsut discarded,
         // thus we should not warn for this case. The same stands for the empty CLI case.
-        return !(std::holds_alternative<ManifestMatchedInstall>(options) ||
-                 std::holds_alternative<InstallDefault>(options));
+        bool noWarnIf = std::holds_alternative<ManifestMatchedInstall>(options) ||
+                        std::holds_alternative<InstallDefault>(options) ||
+                        std::holds_alternative<std::monostate>(options);
+
+        return !noWarnIf;
     }
 }

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -20,11 +20,12 @@
 #define ARG_EXT_INSTALLER_TUI     ARG_EXT_ENABLE_INSTALLER L"tui"
 #define ARG_EXT_DISABLE_INSTALLER ARG_EXT_ENABLE_INSTALLER L"none"
 #define ARG_EXT_AUTOINSTALL       L"--autoinstall"
+#define ARG_EXT_UAP10_PARAMETERS  L"--from-start-menu-or-store"
 
 namespace Oobe::internal
 {
     static constexpr std::array allExtendedArgs{ARG_EXT_AUTOINSTALL, ARG_EXT_DISABLE_INSTALLER, ARG_EXT_INSTALLER_GUI,
-                                                ARG_EXT_INSTALLER_TUI};
+                                                ARG_EXT_INSTALLER_TUI, ARG_EXT_UAP10_PARAMETERS};
     // compile-time array concatenation.
     template <typename T, std::size_t SizeA, std::size_t SizeB>
     constexpr std::array<T, SizeA + SizeB> join(const std::array<T, SizeA>& a, const std::array<T, SizeB>& b)
@@ -56,6 +57,10 @@ namespace Oobe::internal
     {
         static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_INSTALLER_TUI};
     };
+    struct ManifestMatchedInstall // matches the invocation declared in the .appxmanifest.
+    {
+        static constexpr std::array<std::wstring_view, 1> requirements{ARG_EXT_UAP10_PARAMETERS};
+    };
     struct InstallDefault
     {
         static constexpr std::array<std::wstring_view, 0> requirements{};
@@ -79,7 +84,7 @@ namespace Oobe::internal
 
     // InteractiveInstallOnly<SkipInstaller> and InteractiveInstallShell<SkipInstaller> are actually std::monostate,
     // i.e. both go to upstream resolution.
-    using Opts = std::variant<std::monostate, AutoInstall, InstallDefault, InstallOnlyDefault,
+    using Opts = std::variant<std::monostate, AutoInstall, ManifestMatchedInstall, InstallDefault, InstallOnlyDefault,
                               InteractiveInstallOnly<OobeGui>, InteractiveInstallOnly<OobeTui>,
                               InteractiveInstallShell<OobeGui>, InteractiveInstallShell<OobeTui>, Reconfig>;
 

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -20,7 +20,7 @@
 #define ARG_EXT_INSTALLER_TUI     ARG_EXT_ENABLE_INSTALLER L"tui"
 #define ARG_EXT_DISABLE_INSTALLER ARG_EXT_ENABLE_INSTALLER L"none"
 #define ARG_EXT_AUTOINSTALL       L"--autoinstall"
-#define ARG_EXT_UAP10_PARAMETERS  L"--from-start-menu-or-store"
+#define ARG_EXT_UAP10_PARAMETERS  L"--hide-console"
 
 namespace Oobe::internal
 {

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu" Version="2004.4.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu" Executable="ubuntu.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="ubuntu" Executable="ubuntu.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
       <uap:VisualElements DisplayName="Ubuntu" Description="Ubuntu on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--from-start-menu-or-store">
+    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
       <uap:VisualElements DisplayName="Ubuntu 18.04.5 LTS" Description="Ubuntu 18.04.5 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu18.04LTS" Version="1804.5.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--from-start-menu-or-store">
       <uap:VisualElements DisplayName="Ubuntu 18.04.5 LTS" Description="Ubuntu 18.04.5 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher/extended_messages.h
@@ -1,1 +1,2 @@
 #pragma once
+#define UNSUPPORTED_EXTENDED_CLI

--- a/meta/Ubuntu18.04LTS/src/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu18.04LTS/src/DistroLauncher/extended_messages.h
@@ -1,1 +1,2 @@
 #pragma once
+#define UNSUPPORTED_EXTENDED_CLI

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu20.04LTS" Version="2004.4.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--from-start-menu-or-store">
       <uap:VisualElements DisplayName="Ubuntu 20.04.4 LTS" Description="Ubuntu 20.04.4 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--from-start-menu-or-store">
+    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
       <uap:VisualElements DisplayName="Ubuntu 20.04.4 LTS" Description="Ubuntu 20.04.4 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher/extended_messages.h
@@ -1,1 +1,2 @@
 #pragma once
+#define UNSUPPORTED_EXTENDED_CLI

--- a/meta/Ubuntu20.04LTS/src/DistroLauncher/extended_messages.h
+++ b/meta/Ubuntu20.04LTS/src/DistroLauncher/extended_messages.h
@@ -1,1 +1,2 @@
 #pragma once
+#define UNSUPPORTED_EXTENDED_CLI

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu22.04LTS" Version="2204.0.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu2204" Executable="ubuntu2204.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="ubuntu2204" Executable="ubuntu2204.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
       <uap:VisualElements DisplayName="Ubuntu 22.04 LTS" Description="Ubuntu 22.04 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.UbuntuPreview" Version="2210.0.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntupreview" Executable="ubuntupreview.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="ubuntupreview" Executable="ubuntupreview.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
       <uap:VisualElements DisplayName="Ubuntu (Preview)" Description="Ubuntu (Preview) on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>


### PR DESCRIPTION
This PR is somewhat opinionated, so I'd expect some pushback.

The current implementation hides the console window unconditionally, behavior which drove issue #176 .

Ideally the console window should be hidden if it was only opened for the solely purpose of invoking the launcher to install the distribution, which is the case when the user launches it from start menu or from the store, right after installing the app. It could also be launched from the `Run` dialog (I don't know a better name for that, the one we get when we hit Super+R). In that case the user could pass an arbitrary combination of command line arguments and still a console window would be opened dedicated to the launcher process.

In contrast, not even for the empty command line case we would want to hide the console window if the user is doing something else in another tab of the Windows terminal, for instance.

There is not a clear way to detect that. Nor could I find a Win32 API call that could satisfy my inquiry about how is the launcher being launched.

The method I chose for this is: detect the current position of the console screen buffer cursor. If it matches the origin, thus we have our own dedicated window and we can and should hide it. Otherwise, user was doing something else and we better not disturb her. 

This only works if no console output is done before invoking the constructor of the `SplashEnabledStrategy` member of the `Application` class. This is easily achievable because the app object is created early in `main()` and its first member to be initialized is the strategy, which in turn calls the function responsible for memoizing whether at that moment the console cursor was at `{0,0}` as its first duty during construction (`launchedInDedicatedConsole()`). This sequencing is ensured by the order in which the members are declared inside the classes `Application<>` and `SplashEnabledStrategy`.

```cpp

int wmain(int argc, wchar_t const *argv[])
{
    // Update the title bar of the console window.
    SetConsoleTitleW(DistributionInfo::WindowTitle.c_str());

    // Initialize a vector of arguments.
    std::vector<std::wstring_view> arguments;
    for (int index = 1; index < argc; index += 1) {
        arguments.push_back(argv[index]);
    }

    Oobe::Application<> app(arguments);
``` 

I'm writting that much because, although this works I don't know when in the future somebody well intentioned would stick a printf between those calls and ruin the algorithm. Since the function `launchedInDedicatedConsole()`memoizes its return value once called for the first time, we could drop at call to it as the first line of `main()`. It would look wierd and increase slightly the diff to upstream, so I avoided that path. I considered creating a static global constant to force run this function before main(), but then I think we cannot ensure not falling into the static initialization order fiasco, since I don't know for sure whether our static globals would be initialized before or after the console handles being assigned to our process by the operating system, required to check whether the console is at the origin or at some offset.

For now the alternative I'm considering is iterating through all opened process to find the launcher parent's name and decide whether the console should be hidden or not based on that. Seems less performant and more fragile, thus not my first option.

I'm open to discussion and better ideas. Otherwise, this closes #176 .