### PR TITLE
Build windows app package on PR

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -1,0 +1,80 @@
+name: Build windows package
+on:
+  pull_request:
+
+jobs:
+  build-wsl:
+    name: Build
+    runs-on: windows-latest
+    env:
+      rootfs64: 'http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64-wsl.rootfs.tar.gz'
+      workDir: 'C:/Temp/builddir'
+    steps:
+      - name: Checkout WSL
+        uses: actions/checkout@v3
+        with:
+          # we need to use a subdirectory as we can't move back base GITHUB_WORKSPACE directory
+          path: repo
+      - name: Copy under workDir (which has more space to build the package)
+        shell: bash
+        run: |
+          mkdir -p $(dirname ${{ env.workDir }})
+          mv ${GITHUB_WORKSPACE}/repo ${{ env.workDir }}
+          cd ${{ env.workDir }}
+          git checkout "${GITHUB_SHA}"
+          git submodule update --init --recursive
+      - name: Setup x64 rootfs
+        working-directory: ${{ env.workDir }}
+        shell: powershell
+        run: |
+          mkdir x64/
+          $client = new-object System.Net.WebClient
+          $client.DownloadFile("${{ env.rootfs64}}","x64/install.tar.gz")
+      - name: Setup MSBuild (PATH)
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Install certificate
+        shell: powershell
+        working-directory: ${{ env.workDir }}
+        run: |
+          New-Item -ItemType directory -Path certificate
+          Set-Content -Path certificate\certificate.txt -Value '${{ secrets.CERTIFICATE }}'
+          certutil -decode certificate\certificate.txt certificate\certificate.pfx
+
+          $pwd = ConvertTo-SecureString  '${{ secrets.CERTIFICATE_PASSWORD }}' -AsPlainText -Force
+          Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:LocalMachine\Trust -FilePath certificate\certificate.pfx
+          Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:CurrentUser\My -FilePath certificate\certificate.pfx
+      - name: Check if packaging the splash app is necessary
+        working-directory: ${{ env.workDir }}
+        shell: bash
+        run: |
+          BUILD_TREE_HASH=$(sha256sum DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
+          META_TREE_HASH=$(sha256sum meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
+          if [ ${BUILD_TREE_HASH} != ${META_TREE_HASH} ]; then
+            echo "withFlutterSplash=true" >> $GITHUB_ENV
+          else
+            echo "Skipping Flutter steps due hashes comparing equal:"
+            echo "    Build tree:  ${BUILD_TREE_HASH}. Meta tree: ${META_TREE_HASH}"
+          fi
+      - uses: subosito/flutter-action@v2
+        if: ${{ env.withFlutterSplash == 'true' }}
+        with:
+          channel: stable
+      - name: Build the splash screen
+        working-directory: ${{ env.workDir }}
+        if: ${{ env.withFlutterSplash == 'true' }}
+        run: |
+          flutter config --enable-windows-desktop
+          cp "DistroLauncher/images/icon.ico" "ubuntu-wsl-splash/windows/runner/resources/app_icon.ico"
+          cd "ubuntu-wsl-splash"
+          flutter gen-l10n
+          flutter build windows --release
+      - name: Build Bundle
+        working-directory: ${{ env.workDir }}
+        run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal
+      - name: Allow downloading sideload appxbundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: sideload-build
+          path: |
+            ${{ env.workDir }}/AppPackages/Ubuntu/Ubuntu_*/*
+          retention-days: 7

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -23,10 +23,11 @@ jobs:
           cd ${{ env.workDir }}
           git checkout "${GITHUB_SHA}"
           git submodule update --init --recursive
-      - name: Setup x64 rootfs
+      - name: Download rootfs and configure project to only build x64
         working-directory: ${{ env.workDir }}
         shell: powershell
         run: |
+          Set-Content -Path "DistroLauncher.sln" -Value (get-content -Path "DistroLauncher.sln" | Select-String -Pattern 'ARM64' -NotMatch)
           mkdir x64/
           $client = new-object System.Net.WebClient
           $client.DownloadFile("${{ env.rootfs64}}","x64/install.tar.gz")


### PR DESCRIPTION
Use for now a static rootfs, do not do any other change, and pull
everything to latest.
This ensures we can always build before merging our windows app package
and attach it to the PR to sideload, without any further change.