### PR TITLE
Enable github to jira bug synchronization

### DIFF
--- a/.github/workflows/sync-gh-jira.yaml
+++ b/.github/workflows/sync-gh-jira.yaml
@@ -1,0 +1,11 @@
+name: Sync GitHub issues to Jira
+on: [issues, issue_comment]
+jobs:
+  sync-issues:
+    name: Sync issues to Jira
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ubuntu/sync-issues-github-jira@v1
+      with:
+        webhook-url: ${{ secrets.JIRA_WEBHOOK_URL }}
+        component: 'WSL'


### PR DESCRIPTION
Use a default "jira" tag to import bugs to our Jira instance.