### PR TITLE
Added check around optional splash access

### DIFF
--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -150,8 +150,7 @@ namespace Oobe
 
     void SplashEnabledStrategy::do_toggle_splash()
     {
-        if (splash.has_value())
-        {
+        if (splash.has_value()) {
             splash.value().sm.addEvent(SplashController<>::Events::ToggleVisibility{});
         }
     }

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -150,7 +150,10 @@ namespace Oobe
 
     void SplashEnabledStrategy::do_toggle_splash()
     {
-        splash.value().sm.addEvent(SplashController<>::Events::ToggleVisibility{});
+        if (splash.has_value())
+        {
+            splash.value().sm.addEvent(SplashController<>::Events::ToggleVisibility{});
+        }
     }
 
     void SplashEnabledStrategy::do_show_console()


### PR DESCRIPTION
### Motivation
When using a rootfs corresponding to Ubuntu 20.04 LTS, a `std::bad_optional_access` exception is thrown.

### Changes
This is fixed by adding a check around it.