### PR TITLE
Added exit status handling before launching

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -121,6 +121,9 @@ int wmain(int argc, wchar_t const *argv[])
         exitCode = SUCCEEDED(hr) ? 0 : 1;
     }
 
+    // Check and run any pre-launch instruction
+    Oobe::ExitStatusHandling();
+
     // Parse the command line arguments.
     if ((SUCCEEDED(hr)) && (!installOnly)) {
         if (arguments.empty()) {


### PR DESCRIPTION
### Motivation
After upgrading Ubuntu Desktop, `ubuntu-release-upgrade` reboots the system.
In WSL this is not possible because there is no `systemd`.

### Solution
The package will set up `/run/launcher-command` to instruct the launcher to reboot on next launch.
As such, the launcher must now read this file before launching, and reboot if instructed so.
Otherwise, it continues as always.

### Status
Will stay in draft until I finish upgrading `ubuntu-release-upgrade`.