### PR TITLE
Fix no-return lambda warning

### DIFF
--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -160,6 +160,8 @@ namespace Oobe
             case Win32Utils::WinVersion::Win11:
                 return L"\\\\wsl.localhost\\";
             }
+            assert("Unsupported Windows version.", false);
+            __assume(0); // Unreachable
         }(Win32Utils::os_version());
 
         return prefix;

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -157,8 +157,8 @@ namespace Oobe
             switch (version) {
             case Win32Utils::WinVersion::Win10:
                 return L"\\\\wsl$\\";
-            /*case Win32Utils::WinVersion::Win11:
-                return L"\\\\wsl.localhost\\";*/
+            case Win32Utils::WinVersion::Win11:
+                return L"\\\\wsl.localhost\\";
             }
             assert(false && "Unsupported Windows version.");
             __assume(0); // Unreachable

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -157,10 +157,10 @@ namespace Oobe
             switch (version) {
             case Win32Utils::WinVersion::Win10:
                 return L"\\\\wsl$\\";
-            case Win32Utils::WinVersion::Win11:
-                return L"\\\\wsl.localhost\\";
+            /*case Win32Utils::WinVersion::Win11:
+                return L"\\\\wsl.localhost\\";*/
             }
-            assert("Unsupported Windows version.", false);
+            assert(false && "Unsupported Windows version.");
             __assume(0); // Unreachable
         }(Win32Utils::os_version());
 


### PR DESCRIPTION
There is a lambda that we know always returns a value, but the compiler is unaware of this.

This fix adds a sanity test to ensure it trully never happens (in debug mode), and tells the compiler so in Release mode.