### PR TITLE
QA is cancelled when a new commit is pushed

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -5,6 +5,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: QA-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   pull_request_id: ${{ github.event.pull_request.number }}
   INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When you push twice in a row, CI jobs run twice. The runs for the old commits are redundant.

The biggest effect is that the Github commenter will start spamming threads when you push two commits in a row (for instance when you accept more than one of its suggestions).

This PR changes it so that, in pull requests, a newer commit will cancel old QA runs. If necessary I can also apply it to `build` and `run-tests`, but these are less anoying.