### PR TITLE
Enables checking if localhost forwarding is disabled

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
@@ -147,7 +147,33 @@ command = /usr/libexec/wsl-systemd
 
 )"};
             std::wstringstream fakeFile{buffer};
-            ASSERT_TRUE((fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+            ASSERT_TRUE(ini_find_value(fakeFile, L"boot", L"command", L"/usr/libexec/wsl-systemd"));
+        }
+        TEST(IniFindValueTests, LocalhostForwarding)
+        {
+            std::wstring buffer{LR"([wsl2]
+# Turn off default connection to bind WSL 2 localhost to Windows localhost
+localhostforwarding=true
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_FALSE(ini_find_value(fakeFile, L"wsl2", L"localhostforwarding", L"false"));
+        }
+        TEST(IniFindValueTests, LocalhostForwarding2)
+        {
+            std::wstring buffer{LR"([wsl2]
+# Turn off default connection to bind WSL 2 localhost to Windows localhost
+localhostforwarding=false
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_TRUE(ini_find_value(fakeFile, L"wsl2", L"localhostforwarding", L"false"));
+        }
+        TEST(IniFindValueTests, LocalhostForwarding3)
+        {
+            std::wstring buffer{LR"([wsl2]
+# Turn off default connection to bind WSL 2 localhost to Windows localhost
+)"};
+            std::wstringstream fakeFile{buffer};
+            ASSERT_FALSE(ini_find_value(fakeFile, L"wsl2", L"localhostforwarding", L"false"));
         }
     }
 }

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -82,6 +82,22 @@ namespace Oobe::internal
         return isX11UnixSocketMounted();
     }
 
+    bool isLocalhostForwardingEnabled(const std::filesystem::path& wslConfig)
+    {
+        if (!std::filesystem::exists(wslConfig)) {
+            return true; // enabled by default.
+        }
+
+        std::wifstream config;
+        config.open(wslConfig.wstring(), std::ios::beg);
+        if (config.fail()) {
+            return false; // unsure whether the user disabled or not.
+        }
+
+        bool isDisabled = ini_find_value(config, L"wsl2", L"localhostforwarding", L"false");
+        return !isDisabled;
+    }
+
     namespace
     {
         // Returns true if the WSL successfully launches a list

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -43,6 +43,12 @@ namespace Oobe::internal
     bool ini_find_value(std::wistream& ini, std::wstring_view section, std::wstring_view key,
                         std::wstring_view valueContains);
 
+    /// Returns true if ports bound to wildcard or localhost in the WSL 2 VM should be connectable from the host via
+    /// localhost:port.
+    /// See
+    /// <https://docs.microsoft.com/en-us/windows/wsl/wsl-config#:~:text=WSL%202%20VM.-,localhostForwarding,-boolean>
+    bool isLocalhostForwardingEnabled(const std::filesystem::path& wslConfig);
+
 }
 
 namespace Oobe

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "stdafx.h"
+#include <ShlObj_core.h>
 
 namespace Win32Utils
 {
@@ -212,6 +213,19 @@ namespace Win32Utils
     {
         static const auto build = read_build_from_registry();
         return build;
+    }
+
+    std::filesystem::path homedir()
+    {
+        wchar_t* pathStr = nullptr;
+        auto hRes = SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_DEFAULT, nullptr, &pathStr);
+        // Ensures the memory allocated by the SHGetKnownFolderPath gets cleaned in the end of the scope no matter what.
+        // Simpler than writing a class just for that.
+        std::unique_ptr<wchar_t, decltype(&::CoTaskMemFree)> scope_guard{pathStr, ::CoTaskMemFree};
+        if (FAILED(hRes)) {
+            return std::filesystem::path();
+        }
+        return std::filesystem::path(pathStr);
     }
 
     std::filesystem::path thisAppRootdir()

--- a/DistroLauncher/Win32Utils.h
+++ b/DistroLauncher/Win32Utils.h
@@ -46,6 +46,9 @@ namespace Win32Utils
     /// Returns the operating system build number or 0 on failure.
     DWORD os_build_number();
 
+    /// Returns the current user's profile directory path or the empty path on failure.
+    std::filesystem::path homedir();
+
     /// Returns this app's directory or the empty path on failure.
     std::filesystem::path thisAppRootdir();
 }


### PR DESCRIPTION
That feature enables binding WSL 2 localhost to Windows localhost, thus enabling transparent connection through TCP where the client is running on the host while the server is running inside the WSL 2 distro, scenario expected by our OOBE. For security reasons, only localhost can connect to the server, thus this information is crucial.

That feature is enabled by default, but can be manually disabled by tweaking the `~\.wslconfig` file, which is a per-user configuration file that affects all distros running in the scope of the referred Windows user.

So to be able to read that configuration value we need to:

1. Find the user's home path;
2. Parse the file (ini parsing has been previously implemented)
3. look for the value of the entry [wsl2.localhostForwarding].

This will be used later in an upper level to determine whether we can run the OOBE on Windows or not. 

[Check the WSL docs](https://docs.microsoft.com/en-us/windows/wsl/wsl-config#:~:text=WSL%202%20VM.-,localhostForwarding,-boolean) for further information.