### PR TITLE
Prevents running the build workflow on draft PRs

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -1,11 +1,17 @@
 name: Build windows package
 on:
   pull_request:
+    types:
+        - opened
+        - reopened
+        - synchronize
+        - ready_for_review
 
 jobs:
   build-wsl:
     name: Build
     runs-on: windows-latest
+    if: ${{ !github.event.pull_request.draft }}
     env:
       rootfs64: 'http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64-wsl.rootfs.tar.gz'
       workDir: 'C:/Temp/builddir'


### PR DESCRIPTION
That workflow is quite slow, due the need to download and package a real rootfs.
We need to figure out ways to make it faster, but in the meanwhile, let's skip it for draft PR's until they are marked as ready for review.