### PR TITLE
This app rootdir

### DIFF
--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -84,16 +84,7 @@ namespace Oobe
     {
         std::filesystem::path splashPath()
         {
-            const wchar_t* splashName = L"ubuntu_wsl_splash.exe";
-            TCHAR launcherName[MAX_PATH];
-            DWORD fnLength = GetModuleFileName(nullptr, launcherName, MAX_PATH);
-            if (fnLength == 0) {
-                return splashName;
-            }
-            std::filesystem::path splashPath{std::wstring_view{launcherName, fnLength}};
-            splashPath.replace_filename(splashName);
-
-            return splashPath;
+            return Win32Utils::thisAppRootdir() / L"ubuntu_wsl_splash.exe";
         }
     } // namespace.
 

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -213,4 +213,17 @@ namespace Win32Utils
         static const auto build = read_build_from_registry();
         return build;
     }
+
+    std::filesystem::path thisAppRootdir()
+    {
+        TCHAR launcherName[MAX_PATH];
+        DWORD fnLength = GetModuleFileName(nullptr, launcherName, MAX_PATH);
+        if (fnLength == 0) {
+            return std::filesystem::path();
+        }
+        std::filesystem::path exePath{std::wstring_view{launcherName, fnLength}};
+        exePath.remove_filename();
+
+        return exePath;
+    }
 } // namespace Win32Utils

--- a/DistroLauncher/Win32Utils.h
+++ b/DistroLauncher/Win32Utils.h
@@ -46,4 +46,6 @@ namespace Win32Utils
     /// Returns the operating system build number or 0 on failure.
     DWORD os_build_number();
 
+    /// Returns this app's directory or the empty path on failure.
+    std::filesystem::path thisAppRootdir();
 }


### PR DESCRIPTION
Currently the splash executable (the slide show) is located inside the appx directory at the same level as the launcher. Soon we'll have the new OOBE located in the same directory, but a different filename. The patch feature being drafted in #217 will likely store files in a subdirectory as well. So, to avoid duplication, this PR extracts the logic to find this app root directory into it's own function, so we can append subdirectories and filenames as we wish.

The usage is illustrated in the `ApplicationStrategy.cpp` where we locate the `ubuntu_wsl_splash.exe` relative to that path.