### PR TITLE
Created class to deal with interprocess syncronization

### DIFF
--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="extended_messages.h" />
     <ClInclude Include="installer_controller.h" />
     <ClInclude Include="installer_policy.h" />
+    <ClInclude Include="named_mutex.h" />
     <ClInclude Include="not_null.h" />
     <ClInclude Include="OOBE.h" />
     <ClInclude Include="DistributionInfo.h" />
@@ -171,6 +172,7 @@
     <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="DistroLauncher.cpp" />
     <ClCompile Include="local_named_pipe.cpp" />
+    <ClCompile Include="named_mutex.cpp" />
     <ClCompile Include="OOBE.cpp" />
     <ClCompile Include="ProcessRunner.cpp" />
     <ClCompile Include="find_main_thread_window.cpp" />

--- a/DistroLauncher/DistroLauncher.vcxproj.filters
+++ b/DistroLauncher/DistroLauncher.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="OOBE.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="named_mutex.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DistroLauncher.cpp">
@@ -57,6 +60,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="WindowsUserInfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="named_mutex.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DistroLauncher/named_mutex.cpp
+++ b/DistroLauncher/named_mutex.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+
+DWORD NamedMutex::create() noexcept
+{
+    mutex_handle = CreateMutex(NULL, FALSE, mutex_name.c_str());
+    if (!mutex_handle) {
+        const auto error = GetLastError();
+        return error ? error : ~0; // Ensuring return value is always != 0 when mutex_handle is nullptr
+    }
+    return 0;
+}
+
+DWORD NamedMutex::destroy() noexcept
+{
+    if (mutex_handle) {
+        return CloseHandle(mutex_handle);
+    }
+    return 0;
+}
+
+DWORD NamedMutex::wait_and_acquire() noexcept
+{
+    if (!mutex_handle) {
+        DWORD success = create();
+        if (success != 0) {
+            return success;
+        }
+    }
+    __assume(mutex_handle);
+    return WaitForSingleObject(mutex_handle, 1000);
+}
+
+DWORD NamedMutex::release() noexcept
+{
+    return ReleaseMutex(mutex_handle);
+}

--- a/DistroLauncher/named_mutex.h
+++ b/DistroLauncher/named_mutex.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "stdafx.h"
+
+/*
+ *  Abstract
+ *  --------
+ *  A RAII class to deal with Windows inter-process synchronization.
+ *
+ *  Usage
+ *  --------
+ *  Best is to create a single NamedMutex as a static variable. If you believe
+ *  it's not going to be used in most executions, then use
+ *  ```
+ *  static my_mutex = NamedMutex("unique_identifyier", true);
+ *  ```
+ *  to enable lazy initialization. Otherwise, use
+ *  ```
+ *  static my_mutex = NamedMutex("unique_identifyier");
+ *  ```
+ *
+ *  In order to acquire a lock, you have two options.
+ *  Use the first one unless you've got a good reason not to.
+ *   1. Use a lambda wrapper:
+ *      ```
+ *      DWORD response = my_mutex.Run([](){
+ *          // do stuff
+ *      });
+ *      if(response != 0) {
+ *          throw "Oh, no!";
+ *      }
+ *      ```
+ *
+ *   2. Use a scope guard:
+ *      ```
+ *      NamedMutex::Guard scope_guard = my_mutex.get();
+ *      if(scope_guard.ok()) {
+ *          // do stuff
+ *      } else {
+ *          throw "Oh, no!";
+ *      }
+ *      ```
+ *      Be careful! If your program throws and it's not caught,
+ *      your mutex may not be released. Option 1 takes care of
+ *      this automatically, hence why it's recommended.
+ */
+class NamedMutex
+{
+  public:
+    NamedMutex() = delete;
+    NamedMutex(NamedMutex&) = delete;
+    NamedMutex(NamedMutex&&) = delete;
+
+    /// Some mutexes are almost never used. This makes for an easy optimization by not initializing them unless needed.
+    NamedMutex(std::wstring name, bool lazy_init = false) :
+        mutex_handle(nullptr), mutex_name(L"WSL_" + DistributionInfo::Name + L"_" + name)
+    {
+        if (!lazy_init) {
+            create();
+        }
+    }
+
+    ~NamedMutex()
+    {
+        destroy();
+    }
+
+    class Guard
+    {
+      public:
+        constexpr Guard() noexcept : parent_(nullptr), response_(0)
+        { }
+
+        Guard(NamedMutex& parent) noexcept : parent_(&parent), response_(parent.wait_and_acquire())
+        { }
+
+        Guard(Guard& other) = delete;
+        Guard(Guard&& other) noexcept : Guard()
+        {
+            *this = Guard(std::move(other));
+        }
+
+        ~Guard() noexcept
+        {
+            if (ok()) {
+                parent_->release();
+            }
+        }
+
+        Guard& operator=(Guard&& other) noexcept
+        {
+            std::swap(parent_, other.parent_);
+            std::swap(response_, other.response_);
+            return *this;
+        }
+
+        bool ok() const noexcept
+        {
+            return parent_ && (response_ == WAIT_OBJECT_0);
+        }
+
+        DWORD why() const noexcept
+        {
+            return response_;
+        }
+
+      private:
+
+        NamedMutex* parent_;
+        DWORD response_;
+
+        friend class NamedMutex;
+    };
+
+    Guard get()
+    {
+        return Guard(*this);
+    }
+
+    template <typename Callable> DWORD Run(Callable f)
+    {
+        try {
+            if (DWORD failure = wait_and_acquire(); failure) {
+                return failure;
+            }
+            f();
+        } catch (std::exception except) {
+            release();
+            throw except;
+        }
+
+        return release();
+    }
+
+  private:
+    HANDLE mutex_handle;
+    std::wstring mutex_name;
+
+    DWORD create() noexcept;
+    DWORD destroy() noexcept;
+    DWORD wait_and_acquire() noexcept;
+    DWORD release() noexcept;
+};

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -52,6 +52,7 @@
 #include "Win32Utils.h"
 #include "ApplicationStrategy.h"
 #include "Application.h"
+#include "named_mutex.h"
 // Message strings compiled from .MC file.
 #include "messages.h"
 #include "extended_messages.h"


### PR DESCRIPTION
Abstract
--------
A RAII class to deal with Windows inter-process synchronization.

Usage
--------
Best is to create a single NamedMutex as a static variable. If you believe it's not going to be used in most executions, it is a good idea to enable lazy initialization:
```c++
static auto my_mutex = NamedMutex("unique_identifyier", true);
```
Otherwise, use:
```c++
static auto my_mutex = NamedMutex("unique_identifyier");
```
These constructors obtain a handle to the Mutex, but do not acquire a lock. In order to do so, you have two options. Use the first one unless you've got a good reason not to.
 1. Use the monadic interface:
    ```c++
    my_mutex.lock()
      .and_then([]() {
          // do stuff
      })
      .or_else([] {
          // panic
      });
    ```
    Note that the ordering of the functions doesn't matter,
    and both are optional and repeatable.

 2. Use a scope guard:
    ```c++
    NamedMutex::Lock scope_guard = my_mutex.lock();
    if(scope_guard.ok()) {
        // do stuff
    } else {
        // panic
    }
    ```
    Be careful! If your program throws before the Guard goes out of scope, and it's not caught, your mutex may not be released. Option 1 takes care of this automatically, hence why it's recommended.