### PR TITLE
Better testing proposal

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -65,6 +65,23 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\DistroLauncher\ApplicationStrategy.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\DistributionInfo.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\ExitStatus.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\exit_status_parser.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\extended_cli_parser.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\find_main_thread_window.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\Helpers.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\ini_find_value.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\local_named_pipe.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\named_mutex.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\OOBE.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\ProcessRunner.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\stdafx.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\Win32Utils.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\WindowsUserInfo.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\WslApiLoader.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\WSLInfo.cpp" />
     <ClCompile Include="ConsoleServiceTests.cpp" />
     <ClCompile Include="ExtendedCliParserTests.cpp" />
     <ClCompile Include="InstallerControllerTests.cpp" />
@@ -125,7 +142,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>$(SharedPchDir)stdafx.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(SharedPchDir)stdafx.obj;%(AdditionalDependencies);onecore.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -74,7 +74,6 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="..\..\DistroLauncher\Helpers.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ini_find_value.cpp" />
     <ClCompile Include="..\..\DistroLauncher\local_named_pipe.cpp" />
-    <ClCompile Include="..\..\DistroLauncher\named_mutex.cpp" />
     <ClCompile Include="..\..\DistroLauncher\OOBE.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ProcessRunner.cpp" />
     <ClCompile Include="..\..\DistroLauncher\stdafx.cpp" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\DistroLauncher\ApplicationStrategy.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\DistributionInfo.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\exit_status_parser.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\ExitStatus.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\extended_cli_parser.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\find_main_thread_window.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\Helpers.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\ini_find_value.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\local_named_pipe.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\ProcessRunner.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\OOBE.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\stdafx.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\Win32Utils.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\WindowsUserInfo.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\WslApiLoader.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\WSLInfo.cpp">
+      <Filter>DistroSources</Filter>
+    </ClCompile>
+    <ClCompile Include="ConsoleServiceTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="ExitStatusParserTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="ExtendedCliParserTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="IniFindValueTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="InstallerControllerTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="LocalNamedPipeTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="SplashControllerTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+    <ClCompile Include="StateMachineTests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="InstallerControllerTestPolicies.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="TestSources">
+      <UniqueIdentifier>{f981c0b6-1b19-4d9b-aa3c-cd3684d8af88}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="DistroSources">
+      <UniqueIdentifier>{c6954f59-9f21-4dd8-a33d-693e8797d882}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExitStatusParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExitStatusParserTests.cpp
@@ -10,7 +10,7 @@ namespace Oobe
         TEST(ExitStatusParserTests, GoodFileShouldPass)
         {
             std::string buffer{
-R"(# That's the shape of the file left by the OOBE (with some errors introduced just for testing).
+              R"(# That's the shape of the file left by the OOBE (with some errors introduced just for testing).
 key1=Value1
 action = reboot
   # Comment here

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExitStatusParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExitStatusParserTests.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "gtest/gtest.h"
-#include "exit_status_parser.cpp"
 
 namespace Oobe
 {

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ExtendedCliParserTests.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "gtest/gtest.h"
-#include "extended_cli_parser.cpp"
 
 namespace Oobe::internal
 {

--- a/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "gtest/gtest.h"
 
-
 // The assertions below derive from real life experiments in WSL.
 namespace Oobe
 {

--- a/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/IniFindValueTests.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "gtest/gtest.h"
 
-#include "ini_find_value.cpp"
 
 // The assertions below derive from real life experiments in WSL.
 namespace Oobe

--- a/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "gtest/gtest.h"
 #include "local_named_pipe.h"
-#include "local_named_pipe.cpp"
 
 namespace Win32Utils
 {

--- a/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/LocalNamedPipeTests.cpp
@@ -79,7 +79,8 @@ namespace Win32Utils
                 return nullptr;
             }
             explicit FakePipe(bool inheritRead, bool inheritWrite, const wchar_t* name)
-            { }
+            {
+            }
         };
 
         auto failure = makeNamedPipe<FakePipe>(false, false, L"GoodPipe");

--- a/DistroLauncher-Tests/DistroLauncher-Tests/main.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/main.cpp
@@ -2,6 +2,10 @@
 #include <cstdio>
 #include "gtest/gtest.h"
 
+// Helper class for calling WSL Functions:
+// https://msdn.microsoft.com/en-us/library/windows/desktop/mt826874(v=vs.85).aspx
+WslApiLoader g_wslApi(DistributionInfo::Name);
+
 GTEST_API_ int main(int argc, char **argv)
 {
     printf("Running main() from %s\n", __FILE__);


### PR DESCRIPTION
### Description
The idea is to link in the source files from the project, so their functionality can still be tested.

### Status
Ready

### Changelog
- Added DistroLauncher sources to Test solution
- Added onecore.lib to linker
- Added definition of `g_wslApi` in `main.cpp` (Needed by the compiler even if not used)
- Removed includes of sourcefiles
- Added a filter in VS project to keep test- and launcher-sources separate