### PR TITLE
Solved some clang-tidy complaints

### DIFF
--- a/DistroLauncher/.clang-tidy
+++ b/DistroLauncher/.clang-tidy
@@ -1,5 +1,7 @@
 Checks: 'bugprone-*,performance-*,readability-*,google-readability-casting,modernize-use-nullptr,cppcoreguidelines-avoid-non-const-global-variables,misc-misplaced-const'
 HeaderFilterRegex: DistroLauncher/.+\.h$
 CheckOptions:
+  - key: readability-identifier-length.IgnoredParameterNames
+    value: "hr|ok|st"
   - key: readability-identifier-length.IgnoredVariableNames
     value: "hr|ok|st"

--- a/DistroLauncher/.clang-tidy
+++ b/DistroLauncher/.clang-tidy
@@ -1,2 +1,5 @@
 Checks: 'bugprone-*,performance-*,readability-*,google-readability-casting,modernize-use-nullptr,cppcoreguidelines-avoid-non-const-global-variables,misc-misplaced-const'
 HeaderFilterRegex: DistroLauncher/.+\.h$
+CheckOptions:
+  - key: readability-identifier-length.IgnoredVariableNames
+    value: "hr|ok|st"

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -90,8 +90,7 @@ namespace Oobe
     } // namespace.
 
     SplashEnabledStrategy::SplashEnabledStrategy() : splashExePath{splashPath()}
-    {
-    }
+    { }
 
     void SplashEnabledStrategy::do_run_splash(bool hideConsole)
     {

--- a/DistroLauncher/ApplicationStrategy.cpp
+++ b/DistroLauncher/ApplicationStrategy.cpp
@@ -90,7 +90,8 @@ namespace Oobe
     } // namespace.
 
     SplashEnabledStrategy::SplashEnabledStrategy() : splashExePath{splashPath()}
-    { }
+    {
+    }
 
     void SplashEnabledStrategy::do_run_splash(bool hideConsole)
     {

--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -132,21 +132,21 @@ namespace Oobe
 
         VoidResult act(const KeyValuePairs& launcherCmds)
         {
-            auto actionIt = launcherCmds.find("action");
+            const auto actionIt = launcherCmds.find("action");
             if (actionIt == launcherCmds.end()) {
                 // nothing to do.
                 return VoidResult();
             }
 
             // I'm hardcoding that "action" expects strings.
-            auto action = std::any_cast<std::string>(actionIt->second);
+            const auto action = std::any_cast<std::string>(actionIt->second);
 
-            auto f = capabilities.find(action);
-            if (f == capabilities.end()) {
+            const auto found = capabilities.find(action);
+            if (found == capabilities.end()) {
                 return nonstd::make_unexpected(std::runtime_error(action));
             }
 
-            auto res = f->second();
+            auto res = found->second();
             if (!res.has_value()) {
                 return nonstd::make_unexpected(res.error());
             }

--- a/DistroLauncher/OOBE.cpp
+++ b/DistroLauncher/OOBE.cpp
@@ -27,10 +27,10 @@ namespace DistributionInfo
 
     bool shouldSkipInstaller(std::vector<std::wstring_view>& arguments, std::wstring_view value)
     {
-        auto it = std::remove(arguments.begin(), arguments.end(), value);
-        auto r = std::distance(it, arguments.end());
-        arguments.erase(it, arguments.end());
-        return r == 0;
+        const auto new_end = std::remove(arguments.begin(), arguments.end(), value);
+        const auto n_removed = std::distance(new_end, arguments.end());
+        arguments.erase(new_end, arguments.end());
+        return n_removed == 0;
     }
 
     bool isOOBEAvailable()

--- a/DistroLauncher/ProcessRunner.cpp
+++ b/DistroLauncher/ProcessRunner.cpp
@@ -122,7 +122,7 @@ namespace Helpers
         BOOL bSuccess = FALSE;
         for (;;) {
             bSuccess = ReadFile(g_hChildStd_OUT_Rd, chBuf, BUFSIZE, &dwRead, nullptr);
-            if (!bSuccess || dwRead == 0) {
+            if (bSuccess==FALSE || dwRead == 0) {
                 break;
             }
 

--- a/DistroLauncher/ProcessRunner.cpp
+++ b/DistroLauncher/ProcessRunner.cpp
@@ -122,7 +122,7 @@ namespace Helpers
         BOOL bSuccess = FALSE;
         for (;;) {
             bSuccess = ReadFile(g_hChildStd_OUT_Rd, chBuf, BUFSIZE, &dwRead, nullptr);
-            if (bSuccess==FALSE || dwRead == 0) {
+            if (bSuccess == FALSE || dwRead == 0) {
                 break;
             }
 

--- a/DistroLauncher/ProcessRunner.cpp
+++ b/DistroLauncher/ProcessRunner.cpp
@@ -17,14 +17,16 @@
 
 #include "stdafx.h"
 
-namespace Helpers {
+namespace Helpers
+{
 
-    ProcessRunner::ProcessRunner(std::wstring_view commandLine) {
+    ProcessRunner::ProcessRunner(std::wstring_view commandLine)
+    {
         ZeroMemory(&_piProcInfo, sizeof(PROCESS_INFORMATION));
         ZeroMemory(&_siStartInfo, sizeof(STARTUPINFO));
         _sa.nLength = sizeof(SECURITY_ATTRIBUTES);
         _sa.bInheritHandle = TRUE;
-        _sa.lpSecurityDescriptor = NULL;
+        _sa.lpSecurityDescriptor = nullptr;
         cmd = commandLine;
         defunct = false;
         alreadyRun = false;
@@ -42,10 +44,10 @@ namespace Helpers {
             _siStartInfo.hStdOutput = g_hChildStd_OUT_Wr;
             _siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
         }
-
     }
 
-    bool ProcessRunner::isDefunct() const {
+    bool ProcessRunner::isDefunct() const
+    {
         return defunct;
     }
 
@@ -55,35 +57,39 @@ namespace Helpers {
         exit_code = ERROR_PROCESS_ABORTED;
     }
 
-    std::wstring_view ProcessRunner::getStdErr() const {
+    std::wstring_view ProcessRunner::getStdErr() const
+    {
         return stdErr;
     }
 
-    std::wstring_view ProcessRunner::getStdOut() const {
+    std::wstring_view ProcessRunner::getStdOut() const
+    {
         return stdOut;
     }
 
-    DWORD ProcessRunner::getExitCode() const {
+    DWORD ProcessRunner::getExitCode() const
+    {
         return exit_code;
     }
 
-    DWORD ProcessRunner::run() {
+    DWORD ProcessRunner::run()
+    {
         if (alreadyRun || defunct) {
             return exit_code;
         }
 
         TCHAR szCmdline[80];
         wcsncpy_s(szCmdline, cmd.data(), cmd.length());
-        exit_code = CreateProcess(NULL,     // command line 
-            szCmdline,                      // non-const CLI
-            NULL,                           // process security attributes 
-            NULL,                           // primary thread security attributes 
-            TRUE,                           // handles are inherited 
-            0,                              // creation flags 
-            NULL,                           // use parent's environment 
-            NULL,                           // use parent's current directory 
-            &_siStartInfo,                  // STARTUPINFO pointer 
-            &_piProcInfo);                  // output: PROCESS_INFORMATION 
+        exit_code = CreateProcess(nullptr,       // command line
+                                  szCmdline,     // non-const CLI
+                                  nullptr,       // process security attributes
+                                  nullptr,       // primary thread security attributes
+                                  TRUE,          // handles are inherited
+                                  0,             // creation flags
+                                  nullptr,       // use parent's environment
+                                  nullptr,       // use parent's current directory
+                                  &_siStartInfo, // STARTUPINFO pointer
+                                  &_piProcInfo); // output: PROCESS_INFORMATION
         CloseHandle(g_hChildStd_ERR_Wr);
         CloseHandle(g_hChildStd_OUT_Wr);
         if (exit_code == 0) {
@@ -98,7 +104,8 @@ namespace Helpers {
         return exit_code;
     }
 
-    ProcessRunner::~ProcessRunner() {
+    ProcessRunner::~ProcessRunner()
+    {
         if (!defunct) {
             CloseHandle(g_hChildStd_OUT_Rd);
             CloseHandle(g_hChildStd_ERR_Rd);
@@ -107,13 +114,14 @@ namespace Helpers {
         }
     }
 
-    void ProcessRunner::read_pipes() {
+    void ProcessRunner::read_pipes()
+    {
         DWORD dwRead;
         const size_t BUFSIZE = 80;
         TCHAR chBuf[BUFSIZE];
         BOOL bSuccess = FALSE;
         for (;;) {
-            bSuccess = ReadFile(g_hChildStd_OUT_Rd, chBuf, BUFSIZE, &dwRead, NULL);
+            bSuccess = ReadFile(g_hChildStd_OUT_Rd, chBuf, BUFSIZE, &dwRead, nullptr);
             if (!bSuccess || dwRead == 0) {
                 break;
             }
@@ -123,7 +131,7 @@ namespace Helpers {
 
         dwRead = 0;
         for (;;) {
-            bSuccess = ReadFile(g_hChildStd_ERR_Rd, chBuf, BUFSIZE, &dwRead, NULL);
+            bSuccess = ReadFile(g_hChildStd_ERR_Rd, chBuf, BUFSIZE, &dwRead, nullptr);
             if (!bSuccess || dwRead == 0) {
                 break;
             }

--- a/DistroLauncher/ProcessRunner.h
+++ b/DistroLauncher/ProcessRunner.h
@@ -35,10 +35,10 @@ namespace Helpers {
 
         // internals. Could be hidden by PIMPL, for instance,
         // but that's not necessary for now.
-        HANDLE g_hChildStd_OUT_Rd = NULL;
-        HANDLE g_hChildStd_OUT_Wr = NULL;
-        HANDLE g_hChildStd_ERR_Rd = NULL;
-        HANDLE g_hChildStd_ERR_Wr = NULL;
+        HANDLE g_hChildStd_OUT_Rd = nullptr;
+        HANDLE g_hChildStd_OUT_Wr = nullptr;
+        HANDLE g_hChildStd_ERR_Rd = nullptr;
+        HANDLE g_hChildStd_ERR_Wr = nullptr;
         SECURITY_ATTRIBUTES _sa;
         PROCESS_INFORMATION _piProcInfo;
         STARTUPINFO _siStartInfo;

--- a/DistroLauncher/ProcessRunner.h
+++ b/DistroLauncher/ProcessRunner.h
@@ -22,11 +22,9 @@
 // Once created it cannot be reassigned, nor reused,
 // except for holding exit code and std out and err streams content
 // of the launched process.
-namespace Helpers
-{
-    class ProcessRunner
-    {
-      private:
+namespace Helpers {
+    class ProcessRunner {
+    private:
         // Exposed thru getters.
         std::wstring cmd;
         DWORD exit_code;
@@ -48,7 +46,7 @@ namespace Helpers
         void read_pipes();
         void setDefunctState();
 
-      public:
+    public:
         // Constructs a runner for a given CLI.
         // Once constructed, it cannot have its CLI argument changed.
         ProcessRunner(std::wstring_view commandLine);

--- a/DistroLauncher/ProcessRunner.h
+++ b/DistroLauncher/ProcessRunner.h
@@ -22,9 +22,11 @@
 // Once created it cannot be reassigned, nor reused,
 // except for holding exit code and std out and err streams content
 // of the launched process.
-namespace Helpers {
-    class ProcessRunner {
-    private:
+namespace Helpers
+{
+    class ProcessRunner
+    {
+      private:
         // Exposed thru getters.
         std::wstring cmd;
         DWORD exit_code;
@@ -46,7 +48,7 @@ namespace Helpers {
         void read_pipes();
         void setDefunctState();
 
-    public:
+      public:
         // Constructs a runner for a given CLI.
         // Once constructed, it cannot have its CLI argument changed.
         ProcessRunner(std::wstring_view commandLine);

--- a/DistroLauncher/Win32Utils.cpp
+++ b/DistroLauncher/Win32Utils.cpp
@@ -101,9 +101,9 @@ namespace Win32Utils
                 if (!GetMonitorInfo(monitor, &mInfo)) {
                     return nonstd::make_unexpected(GetLastError());
                 }
-                int x = (mInfo.rcWork.right - width) / 2;
-                int y = (mInfo.rcWork.bottom - height) / 2;
-                return placement{x, y, width, height};
+                int px_x = (mInfo.rcWork.right - width) / 2;
+                int px_y = (mInfo.rcWork.bottom - height) / 2;
+                return placement{px_x, px_y, width, height};
             }
 
             /// Applies this placement to [window] according to [flags]. Returns 0 on success.

--- a/DistroLauncher/console_service.h
+++ b/DistroLauncher/console_service.h
@@ -116,12 +116,12 @@ namespace Win32Utils
                 }
                 // The pipe class must guarantee that if the Handle is valid, the File descriptor is also valid. See
                 // LocalNamedPipe.h.
-                int fd = redirectTo.writeFileDescriptor();
+                int file_descriptor = redirectTo.writeFileDescriptor();
                 fflush(stderrStream);
                 fflush(stdoutStream);
                 // Saving the standard streams context before redirecting.
                 previousConsoleState = consoleState();
-                ConsoleState newConsoleState{fd, fd, handle, handle};
+                ConsoleState newConsoleState{file_descriptor, file_descriptor, handle, handle};
 
                 applyConsoleState(newConsoleState, stderrStream, nStderrHandle, stdoutStream, nStdoutHandle);
                 // No buffering seems mandatory for this situation. Tests with launching child apps reading from this

--- a/DistroLauncher/extended_cli_parser.cpp
+++ b/DistroLauncher/extended_cli_parser.cpp
@@ -117,10 +117,10 @@ namespace Oobe::internal
         Opts options{parse(arguments)};
 
         // Erasing the extended command line options to avoid confusion in the upstream code.
-        auto it = std::remove_if(arguments.begin(), arguments.end(), [](auto arg) {
+        auto new_end = std::remove_if(arguments.begin(), arguments.end(), [](auto arg) {
             return std::find(allExtendedArgs.begin(), allExtendedArgs.end(), arg) != allExtendedArgs.end();
         });
-        arguments.erase(it, arguments.end());
+        arguments.erase(new_end, arguments.end());
 
 #ifdef UNSUPPORTED_EXTENDED_CLI
         if (shouldWarnUnsupported(options)) {

--- a/DistroLauncher/extended_cli_parser.h
+++ b/DistroLauncher/extended_cli_parser.h
@@ -28,14 +28,14 @@ namespace Oobe::internal
                                                 ARG_EXT_INSTALLER_TUI, ARG_EXT_UAP10_PARAMETERS};
     // compile-time array concatenation.
     template <typename T, std::size_t SizeA, std::size_t SizeB>
-    constexpr std::array<T, SizeA + SizeB> join(const std::array<T, SizeA>& a, const std::array<T, SizeB>& b)
+    constexpr std::array<T, SizeA + SizeB> join(const std::array<T, SizeA>& left, const std::array<T, SizeB>& right)
     {
         std::array<T, SizeA + SizeB> result;
         for (int i = 0; i < SizeA; ++i) {
-            result[i] = a[i];
+            result[i] = left[i];
         }
         for (int i = 0; i < SizeB; ++i) {
-            result[i + SizeA] = b[i];
+            result[i + SizeA] = right[i];
         }
         return result;
     }

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -29,13 +29,13 @@ namespace Oobe
             ExitStatusHandling();
         }
 
-        static bool copy_file_into_distro(const std::filesystem::path& from, const std::wstring& to)
+        static bool copy_file_into_distro(const std::filesystem::path& source, const std::wstring& destination)
         {
             std::wstring wslPrefixedDest = WslPathPrefix() + DistributionInfo::Name;
-            wslPrefixedDest.append(to);
+            wslPrefixedDest.append(destination);
             std::filesystem::path realDest{wslPrefixedDest};
-            std::error_code ec;
-            return std::filesystem::copy_file(from, realDest, ec);
+            std::error_code errorCode;
+            return std::filesystem::copy_file(source, realDest, errorCode);
         }
 
         /// Attempts to find and hide the installer GUI window.
@@ -95,8 +95,8 @@ namespace Oobe
             DWORD sslxExitCode;
             HRESULT sslxHr;
 
-            auto delaysGenerator = [cur = initialDelay, q = delayRatio]() mutable {
-                cur *= q;
+            auto delaysGenerator = [cur = initialDelay, ratio = delayRatio]() mutable {
+                cur *= ratio;
                 return cur;
             };
 

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -74,7 +74,7 @@ namespace Win32Utils
         template <typename... Args>
         explicit LocalNamedPipe(bool inheritRead, bool inheritWrite, Args&&... args) :
             szPipeName{pipeNameFrom(std::forward<Args>(args)...)}, writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
-            szPipeName{pipeNameFrom(std::forward<Args>(args)...)}, inheritWrite{inheritWrite}
+            writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true}, inheritWrite{inheritWrite}
         {
             HANDLE handle = CreateNamedPipe(szPipeName.c_str(),
                                             PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -101,7 +101,8 @@ namespace Win32Utils
             writeSA{std::exchange(other.writeSA, {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE})}, // zeroing everything.
             hRead{std::exchange(other.hRead, nullptr)}, hWrite{std::exchange(other.hWrite, nullptr)},
             writeFd{std::exchange(other.writeFd, -1)}, inheritWrite{std::exchange(other.inheritWrite, false)}
-        { }
+        {
+        }
 
         HANDLE readHandle() const
         {

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -73,7 +73,7 @@ namespace Win32Utils
         // a child process, since the main usage of named pipes envolves inter process communication.
         template <typename... Args>
         explicit LocalNamedPipe(bool inheritRead, bool inheritWrite, Args&&... args) :
-            szPipeName{pipeNameFrom(std::forward<Args>(args)...)}, writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
+            szPipeName{pipeNameFrom(std::forward<Args>(args)...)}, readSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
             writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true}, inheritWrite{inheritWrite}
         {
             HANDLE handle = CreateNamedPipe(szPipeName.c_str(),

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -74,16 +74,16 @@ namespace Win32Utils
         template <typename... Args>
         explicit LocalNamedPipe(bool inheritRead, bool inheritWrite, Args&&... args) :
             readSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true}, writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
-            inheritWrite{inheritWrite}, szPipeName{pipeNameFrom(std::forward<Args>(args)...)}
+            szPipeName{pipeNameFrom(std::forward<Args>(args)...)}, inheritWrite{inheritWrite}
         {
-            auto handle = CreateNamedPipe(szPipeName.c_str(),
-                                          PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
-                                          PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT,
-                                          PIPE_UNLIMITED_INSTANCES,
-                                          0,
-                                          0,
-                                          0,
-                                          &readSA);
+            HANDLE handle = CreateNamedPipe(szPipeName.c_str(),
+                                            PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+                                            PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                                            PIPE_UNLIMITED_INSTANCES,
+                                            0,
+                                            0,
+                                            0,
+                                            &readSA);
             // That's the exact value returned by the function call above if it fails.
             // NOLINTNEXTLINE(performance-no-int-to-ptr)
             if (handle != INVALID_HANDLE_VALUE) {

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -73,7 +73,7 @@ namespace Win32Utils
         // a child process, since the main usage of named pipes envolves inter process communication.
         template <typename... Args>
         explicit LocalNamedPipe(bool inheritRead, bool inheritWrite, Args&&... args) :
-            readSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true}, writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
+            szPipeName{pipeNameFrom(std::forward<Args>(args)...)}, writeSA{sizeof(SECURITY_ATTRIBUTES), nullptr, true},
             szPipeName{pipeNameFrom(std::forward<Args>(args)...)}, inheritWrite{inheritWrite}
         {
             HANDLE handle = CreateNamedPipe(szPipeName.c_str(),

--- a/DistroLauncher/local_named_pipe.h
+++ b/DistroLauncher/local_named_pipe.h
@@ -101,8 +101,7 @@ namespace Win32Utils
             writeSA{std::exchange(other.writeSA, {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE})}, // zeroing everything.
             hRead{std::exchange(other.hRead, nullptr)}, hWrite{std::exchange(other.hWrite, nullptr)},
             writeFd{std::exchange(other.writeFd, -1)}, inheritWrite{std::exchange(other.inheritWrite, false)}
-        {
-        }
+        { }
 
         HANDLE readHandle() const
         {

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -161,7 +161,7 @@ namespace Oobe::internal
             ExpectedState maybe = std::visit(
               overloaded{
                 [&](auto& st) -> std::enable_if_t<std::is_convertible_v<decltype(st.on_event(event)), ExpectedState>,
-                                                 ExpectedState> { return st.on_event(event); },
+                                                  ExpectedState> { return st.on_event(event); },
                 [&](auto&&...) -> ExpectedState {
                     return nonstd::make_unexpected(InvalidTransition{state_, event});
                 },

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -26,10 +26,12 @@ namespace Oobe::internal
      * is_variant_v metafunction holds true if the type argument is a concrete instantiation of std::variant.
      */
     template <typename T> struct is_variant : std::false_type
-    { };
+    {
+    };
 
     template <typename... Args> struct is_variant<std::variant<Args...>> : std::true_type
-    { };
+    {
+    };
 
     template <typename T> inline constexpr bool is_variant_v = is_variant<T>::value;
 
@@ -37,11 +39,13 @@ namespace Oobe::internal
      * is_variant_of_v holds true if the type argument T is one of the alternative types of the variant V.
      */
     template <typename T, typename U> struct is_variant_of : std::false_type
-    { };
+    {
+    };
 
     template <typename T, typename... Ts>
     struct is_variant_of<T, std::variant<Ts...>> : public std::disjunction<std::is_same<T, Ts>...>
-    { };
+    {
+    };
 
     template <typename T, typename V> inline constexpr bool is_variant_of_v = is_variant_of<T, V>::value;
 

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -162,7 +162,7 @@ namespace Oobe::internal
               overloaded{
                 [&](auto& s) -> std::enable_if_t<std::is_convertible_v<decltype(s.on_event(event)), ExpectedState>,
                                                  ExpectedState> { return s.on_event(event); },
-                [&](auto&&... arg) -> ExpectedState {
+                [&](auto&&...) -> ExpectedState {
                     return nonstd::make_unexpected(InvalidTransition{state_, event});
                 },
               },

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -160,8 +160,8 @@ namespace Oobe::internal
         {
             ExpectedState maybe = std::visit(
               overloaded{
-                [&](auto& s) -> std::enable_if_t<std::is_convertible_v<decltype(s.on_event(event)), ExpectedState>,
-                                                 ExpectedState> { return s.on_event(event); },
+                [&](auto& st) -> std::enable_if_t<std::is_convertible_v<decltype(st.on_event(event)), ExpectedState>,
+                                                 ExpectedState> { return st.on_event(event); },
                 [&](auto&&...) -> ExpectedState {
                     return nonstd::make_unexpected(InvalidTransition{state_, event});
                 },
@@ -180,9 +180,9 @@ namespace Oobe::internal
         {
             ExpectedState maybe = std::visit(
               overloaded{
-                [](auto& s,
-                   auto& event) -> std::enable_if_t<std::is_convertible_v<decltype(s.on_event(event)), ExpectedState>,
-                                                    ExpectedState> { return s.on_event(event); },
+                [](auto& st,
+                   auto& event) -> std::enable_if_t<std::is_convertible_v<decltype(st.on_event(event)), ExpectedState>,
+                                                    ExpectedState> { return st.on_event(event); },
                 [&](auto&&... arg) -> ExpectedState {
                     return nonstd::make_unexpected(InvalidTransition{state_, event});
                 },

--- a/DistroLauncher/state_machine.h
+++ b/DistroLauncher/state_machine.h
@@ -26,12 +26,10 @@ namespace Oobe::internal
      * is_variant_v metafunction holds true if the type argument is a concrete instantiation of std::variant.
      */
     template <typename T> struct is_variant : std::false_type
-    {
-    };
+    { };
 
     template <typename... Args> struct is_variant<std::variant<Args...>> : std::true_type
-    {
-    };
+    { };
 
     template <typename T> inline constexpr bool is_variant_v = is_variant<T>::value;
 
@@ -39,13 +37,11 @@ namespace Oobe::internal
      * is_variant_of_v holds true if the type argument T is one of the alternative types of the variant V.
      */
     template <typename T, typename U> struct is_variant_of : std::false_type
-    {
-    };
+    { };
 
     template <typename T, typename... Ts>
     struct is_variant_of<T, std::variant<Ts...>> : public std::disjunction<std::is_same<T, Ts>...>
-    {
-    };
+    { };
 
     template <typename T, typename V> inline constexpr bool is_variant_of_v = is_variant_of<T, V>::value;
 


### PR DESCRIPTION
Only made changes in non-microsoft files. Applied most clang-tidy feedback from the last run in main (https://github.com/ubuntu/WSL/runs/7303623016?check_suite_focus=true).

**Solved**
- Most short-variable-name complaints
- Adding some consts
- `NULL` -> `nullptr`
- Removed some unused variable names in lambda arguments. Example: `[&](auto&&... s) { return E_UNEXPECTED; },` becomes `[&](auto&&...) { return E_UNEXPECTED; },`.
- Order of constructor list

**Not solved**
- Reasonable or standard short variable names (e.g: `ok` or `hr`)
- Some variables that I wasn't sure what to rename them to.
- Implicit casts from `BOOL` (Microsoft's typedef'd int) to `bool`.