### PR TITLE
Enables MSBuild to update and build the Flutter app if required

### DIFF
--- a/DistroLauncher-Appx/Directory.build.props
+++ b/DistroLauncher-Appx/Directory.build.props
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-        <FlutterSplashDir>..\ubuntu-wsl-splash\build\windows\runner\Release\</FlutterSplashDir>
-    </PropertyGroup>
+	<PropertyGroup>
+		<FlutterSplashRoot>..\ubuntu-wsl-splash</FlutterSplashRoot>
+		<FlutterSplashDir>$(FlutterSplashRoot)\build\windows\runner\Release\</FlutterSplashDir>
+	</PropertyGroup>
+	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterSplashDir))">
+		<Message Text="Building Flutter artifacts" Importance="high"/>
+		<Exec Command="flutter build windows --release" WorkingDirectory="$(FlutterSplashRoot)" />
+	</Target>
 	<ItemGroup>
 		<FlutterSplashFiles Include="$(FlutterSplashDir)" /> 
 	</ItemGroup>


### PR DESCRIPTION
Attempting to build the solution without having the Flutter splash subproject checked out and compiled in release mode produces a message almost impossible to correlate with the real problem in the build system.

This PR enables automatically updating and building the Flutter submodule as part of the appx build system. The task is skipped if the `$(FlutterSplashRoot)\build\windows\runner\Release\` directory exists.