### PR TITLE
Extracts the process handling out of the splash controller

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/ChildProcessTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ChildProcessTests.cpp
@@ -1,0 +1,26 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+#include "ChildProcess.h"
+
+namespace Oobe
+{
+    const auto* fake = L"./do_not_exists";
+    TEST(ChildProcess, StartNTerminate)
+    {
+        ChildProcess process{fake, L""};
+        EXPECT_EQ(process.pid(), 0);
+        process.start();
+        EXPECT_NE(process.pid(), 0);
+        process.terminate();
+        ASSERT_EQ(process.pid(), 0);
+    }
+    TEST(ChildProcess, ListenerIsCalled)
+    {
+        bool called = false;
+        ChildProcess process{fake, L""};
+        process.setListener([&called] { called = true; });
+        EXPECT_FALSE(called);
+        process.start();
+        ASSERT_TRUE(called);
+    }
+}

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ChildProcessTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ChildProcessTests.cpp
@@ -1,9 +1,10 @@
 #include "stdafx.h"
 #include "gtest/gtest.h"
-#include "ChildProcess.h"
+#include "FakeChildProcessImpl.h"
 
-namespace Oobe
+namespace Testing
 {
+    using ChildProcess = Oobe::ChildProcessInterface<FakeChildProcess>;
     const auto* fake = L"./do_not_exists";
     TEST(ChildProcess, StartNTerminate)
     {

--- a/DistroLauncher-Tests/DistroLauncher-Tests/ChildProcessTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/ChildProcessTests.cpp
@@ -5,7 +5,7 @@
 namespace Testing
 {
     using ChildProcess = Oobe::ChildProcessInterface<FakeChildProcess>;
-    const auto* fake = L"./do_not_exists";
+    const auto* fake = L"./does_not_exist";
     TEST(ChildProcess, StartNTerminate)
     {
         ChildProcess process{fake, L""};

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -66,6 +66,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\DistroLauncher\ApplicationStrategy.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\ChildProcess.cpp" />
     <ClCompile Include="..\..\DistroLauncher\DistributionInfo.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ExitStatus.cpp" />
     <ClCompile Include="..\..\DistroLauncher\exit_status_parser.cpp" />
@@ -106,6 +107,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="FakeChildProcessImpl.h" />
     <ClInclude Include="mock_api.h" />
     <ClInclude Include="InstallerControllerTestPolicies.h" />
   </ItemGroup>

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -82,8 +82,10 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="..\..\DistroLauncher\WindowsUserInfo.cpp" />
     <ClCompile Include="..\..\DistroLauncher\WslApiLoader.cpp" />
     <ClCompile Include="..\..\DistroLauncher\WSLInfo.cpp" />
+    <ClCompile Include="ChildProcessTests.cpp" />
     <ClCompile Include="ConsoleServiceTests.cpp" />
     <ClCompile Include="ExtendedCliParserTests.cpp" />
+    <ClCompile Include="FakeChildProcessImpl.cpp" />
     <ClCompile Include="InstallerControllerTests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ExitStatusParserTests.cpp" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -90,10 +90,12 @@
     </ClCompile>
     <ClCompile Include="ChildProcessTests.cpp" />
     <ClCompile Include="FakeChildProcessImpl.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\ChildProcess.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="InstallerControllerTestPolicies.h" />
     <ClInclude Include="mock_api.h" />
+    <ClInclude Include="FakeChildProcessImpl.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -88,6 +88,8 @@
     <ClCompile Include="mock_api.cpp">
       <Filter>TestSources</Filter>
     </ClCompile>
+    <ClCompile Include="ChildProcessTests.cpp" />
+    <ClCompile Include="FakeChildProcessImpl.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="InstallerControllerTestPolicies.h" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/FakeChildProcessImpl.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/FakeChildProcessImpl.cpp
@@ -1,10 +1,10 @@
 #include "stdafx.h"
-#include "ChildProcess.h"
+#include "FakeChildProcessImpl.h"
 
 // Fake the Win32 Child Process implementation
-namespace Oobe
+namespace Testing
 {
-    bool Win32ChildProcess::do_start()
+    bool FakeChildProcess::do_start()
     {
         // harmless because the value is never used other than for comparing to nullptr.
         procInfo.hProcess = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -14,18 +14,18 @@ namespace Oobe
         return true;
     }
 
-    void Win32ChildProcess::do_terminate()
+    void FakeChildProcess::do_terminate()
     {
         procInfo = PROCESS_INFORMATION{0};
         procInfo.hProcess = nullptr;
     }
 
-    void Win32ChildProcess::do_unsubscribe()
+    void FakeChildProcess::do_unsubscribe()
     {
         waiterHandle = nullptr;
     }
 
-    DWORD Win32ChildProcess::do_waitExitSync(DWORD timeoutMs)
+    DWORD FakeChildProcess::do_waitExitSync(DWORD timeoutMs)
     {
         return 0;
     }

--- a/DistroLauncher-Tests/DistroLauncher-Tests/FakeChildProcessImpl.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/FakeChildProcessImpl.cpp
@@ -1,0 +1,32 @@
+#include "stdafx.h"
+#include "ChildProcess.h"
+
+// Fake the Win32 Child Process implementation
+namespace Oobe
+{
+    bool Win32ChildProcess::do_start()
+    {
+        // harmless because the value is never used other than for comparing to nullptr.
+        procInfo.hProcess = GetStdHandle(STD_OUTPUT_HANDLE);
+        procInfo.dwProcessId = 1;
+        procInfo.dwThreadId = 2;
+        notifyListener();
+        return true;
+    }
+
+    void Win32ChildProcess::do_terminate()
+    {
+        procInfo = PROCESS_INFORMATION{0};
+        procInfo.hProcess = nullptr;
+    }
+
+    void Win32ChildProcess::do_unsubscribe()
+    {
+        waiterHandle = nullptr;
+    }
+
+    DWORD Win32ChildProcess::do_waitExitSync(DWORD timeoutMs)
+    {
+        return 0;
+    }
+}

--- a/DistroLauncher-Tests/DistroLauncher-Tests/FakeChildProcessImpl.h
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/FakeChildProcessImpl.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "ChildProcess.h"
+
+namespace Testing
+{
+    // Abstracts the OS interaction required to start and manage the child process from the API class. Invariants are
+    // held by the parent. Thus everything here is private. Inheritance is used to access the parent class data members.
+    class FakeChildProcess : public Oobe::ChildProcessInterface<FakeChildProcess>
+    {
+        // Effectively starts the process.
+        bool do_start();
+
+        // Terminates a running process.
+        void do_terminate();
+
+        // Unregisters the wait callback.
+        void do_unsubscribe();
+
+        // Blocks the calling thread for [timeoutMs] ms waiting the process to exit. Returns its exit code on success or
+        // the waiting error code.
+        DWORD do_waitExitSync(DWORD timeoutMs);
+
+        friend class Oobe::ChildProcessInterface<FakeChildProcess>;
+    };
+
+}

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
@@ -24,15 +24,10 @@ namespace Oobe
     const auto* fakeFileName = L"./do_not_exists";
     // I just need to compare to nullptr, I'll not do anything else with that pointer.
     HWND globalFakeWindow = reinterpret_cast<HWND>(const_cast<wchar_t*>(fakeFileName));
+
     // Fake strategies to exercise the Splash controller state machine.
     struct NothingWorksStrategy
     {
-        static bool do_create_process(const std::filesystem::path& exePath,
-                                      STARTUPINFO& startup,
-                                      PROCESS_INFORMATION& process)
-        {
-            return false;
-        }
 
         static HWND do_read_window_from_ipc()
         {
@@ -49,27 +44,12 @@ namespace Oobe
             return false;
         }
 
-        static HANDLE do_on_close(HANDLE process, WAITORTIMERCALLBACK callback, void* data)
-        {
-            return nullptr;
-        }
-        static void do_cleanup_process(PROCESS_INFORMATION& h)
-        { }
-        static void do_unsubscribe(HANDLE h)
-        { }
         // The other methods will never be called, so there is no need to define them. Otherwise it would not even
         // compile.
     }; // struct NothingWorksStrategy
 
     struct EverythingWorksStrategy
     {
-        static bool do_create_process(const std::filesystem::path& exePath,
-                                      STARTUPINFO& startup,
-                                      PROCESS_INFORMATION& process)
-        {
-            return true;
-        }
-
         static HWND do_read_window_from_ipc()
         {
             // no risk because this handle will not be used for anything besides passing around.
@@ -97,16 +77,6 @@ namespace Oobe
         static void do_gracefully_close(HWND window)
         { }
 
-        static void do_cleanup_process(PROCESS_INFORMATION& h)
-        { }
-
-        static HANDLE do_on_close(HANDLE process, WAITORTIMERCALLBACK callback, void* data)
-        {
-            return static_cast<HANDLE>(globalFakeWindow);
-        }
-
-        static void do_unsubscribe(HANDLE h)
-        { }
         // The other methods will never be called, so there is no need to define them. Otherwise it would not even
         // compile.
     }; // struct EverythingWorksStrategy
@@ -126,12 +96,6 @@ namespace Oobe
     {
         struct CantFindWindowStrategy
         {
-            static bool do_create_process(const std::filesystem::path& exePath,
-                                          STARTUPINFO& startup,
-                                          PROCESS_INFORMATION& process)
-            {
-                return true;
-            }
 
             static HWND do_read_window_from_ipc()
             {
@@ -146,11 +110,6 @@ namespace Oobe
             static bool do_show_window(HWND window)
             {
                 return false;
-            }
-
-            static HANDLE do_on_close(HANDLE process, WAITORTIMERCALLBACK callback, void* data)
-            {
-                return static_cast<HANDLE>(globalFakeWindow);
             }
 
             static void do_gracefully_close(HWND window)
@@ -173,12 +132,6 @@ namespace Oobe
     {
         struct AlmostEverythingWorksStrategy
         {
-            static bool do_create_process(const std::filesystem::path& exePath,
-                                          STARTUPINFO& startup,
-                                          PROCESS_INFORMATION& process)
-            {
-                return true;
-            }
 
             static HWND do_read_window_from_ipc()
             {
@@ -202,10 +155,6 @@ namespace Oobe
             static bool do_place_behind(HWND toBeFront, HWND toBeBehind)
             {
                 return true;
-            }
-            static HANDLE do_on_close(HANDLE process, WAITORTIMERCALLBACK callback, void* data)
-            {
-                return static_cast<HANDLE>(globalFakeWindow);
             }
 
             static void do_gracefully_close(HWND window)

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
@@ -22,7 +22,7 @@
 
 namespace Oobe
 {
-    const auto* fakeFileName = L"./do_not_exists";
+    const auto* fakeFileName = L"./does_not_exist";
     // I just need to compare to nullptr, I'll not do anything else with that pointer.
     HWND globalFakeWindow = reinterpret_cast<HWND>(const_cast<wchar_t*>(fakeFileName));
 

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SplashControllerTests.cpp
@@ -17,6 +17,7 @@
 
 #include "stdafx.h"
 #include "gtest/gtest.h"
+#include "FakeChildProcessImpl.h"
 #include "splash_controller.h"
 
 namespace Oobe
@@ -86,7 +87,7 @@ namespace Oobe
     // The whole purpose of adding this state machine technique was to improve overall testability.
     TEST(SplashControllerTests, LaunchFailedShouldStayIdle)
     {
-        using Controller = SplashController<NothingWorksStrategy>;
+        using Controller = SplashController<NothingWorksStrategy, Testing::FakeChildProcess>;
         Controller controller{fakeFileName, GetStdHandle(STD_OUTPUT_HANDLE), callback};
         controller.sm.addEvent(Controller::Events::Run{&controller}); // This fails but it is a valid transition.
         ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Closed>());
@@ -120,7 +121,7 @@ namespace Oobe
             { }
         }; // struct CantFindWindowStrategy
 
-        using Controller = SplashController<CantFindWindowStrategy>;
+        using Controller = SplashController<CantFindWindowStrategy, Testing::FakeChildProcess>;
         Controller controller{fakeFileName, GetStdHandle(STD_OUTPUT_HANDLE), callback};
         controller.sm.addEvent(Controller::Events::Run{&controller});
         ASSERT_TRUE(controller.sm.isCurrentStateA<Controller::States::Closed>());
@@ -165,7 +166,7 @@ namespace Oobe
             { }
         }; // struct AlmostEverythingWorksStrategy
 
-        using Controller = SplashController<AlmostEverythingWorksStrategy>;
+        using Controller = SplashController<AlmostEverythingWorksStrategy, Testing::FakeChildProcess>;
         Controller controller{fakeFileName, GetStdHandle(STD_OUTPUT_HANDLE), callback};
         auto transition = controller.sm.addEvent(Controller::Events::Run{&controller});
         // Since almost everything works in this realm, all transitions below should be valid...
@@ -175,7 +176,7 @@ namespace Oobe
 
     TEST(SplashControllerTests, AHappySequenceOfEvents)
     {
-        using Controller = SplashController<EverythingWorksStrategy>;
+        using Controller = SplashController<EverythingWorksStrategy, Testing::FakeChildProcess>;
         Controller controller{fakeFileName, GetStdHandle(STD_OUTPUT_HANDLE), callback};
         auto transition = controller.sm.addEvent(Controller::Events::Run{&controller});
         // Since everything works in this realm, all transitions below should be valid...
@@ -200,7 +201,7 @@ namespace Oobe
     // This proves to be impossible to run the splash application more than once after the first success.
     TEST(SplashControllerTests, OnlyIdleStateAcceptsRunEvent)
     {
-        using Controller = SplashController<EverythingWorksStrategy>;
+        using Controller = SplashController<EverythingWorksStrategy, Testing::FakeChildProcess>;
         Controller controller{fakeFileName, GetStdHandle(STD_OUTPUT_HANDLE), callback};
         auto transition = controller.sm.addEvent(Controller::Events::Run{&controller});
         // Since everything works in this realm, all transitions below should be valid...
@@ -238,7 +239,7 @@ namespace Oobe
     TEST(SplashControllerTests, MustCloseOnlyOnce)
     {
         // Remember that in this realm everything just works...
-        using Controller = SplashController<EverythingWorksStrategy>;
+        using Controller = SplashController<EverythingWorksStrategy, Testing::FakeChildProcess>;
         Controller controller{fakeFileName, GetStdHandle(STD_OUTPUT_HANDLE), callback};
         auto transition = controller.sm.addEvent(Controller::Events::Run{&controller});
         ASSERT_TRUE(transition.has_value());

--- a/DistroLauncher/ChildProcess.cpp
+++ b/DistroLauncher/ChildProcess.cpp
@@ -28,6 +28,7 @@ namespace Oobe
 
     void Win32ChildProcess::do_terminate()
     {
+        // NOLINTNEXTLINE(performance-no-int-to-ptr) - that's the Win32 way.
         if (procInfo.hProcess != nullptr && procInfo.hProcess != INVALID_HANDLE_VALUE) {
             TerminateProcess(procInfo.hProcess, 0);
             destroy();

--- a/DistroLauncher/ChildProcess.cpp
+++ b/DistroLauncher/ChildProcess.cpp
@@ -1,0 +1,78 @@
+#include "stdafx.h"
+
+namespace Oobe
+{
+
+    void Win32ChildProcess::onClose(void* data, BOOLEAN /*unused*/)
+    {
+        auto* instance = static_cast<Win32ChildProcess*>(data);
+        instance->unsubscribe();
+        // Process ended anyway.
+        instance->destroy();
+        instance->notifyListener();
+    }
+
+    void Win32ChildProcess::do_unsubscribe()
+    {
+        if (waiterHandle != nullptr) {
+            UnregisterWait(waiterHandle);
+        }
+    }
+
+    void Win32ChildProcess::destroy()
+    {
+        CloseHandle(procInfo.hThread);
+        CloseHandle(procInfo.hProcess);
+        procInfo.hProcess = nullptr;
+    }
+
+    void Win32ChildProcess::do_terminate()
+    {
+        if (procInfo.hProcess != nullptr && procInfo.hProcess != INVALID_HANDLE_VALUE) {
+            TerminateProcess(procInfo.hProcess, 0);
+            destroy();
+        }
+    }
+
+    bool Win32ChildProcess::do_start()
+    {
+        if (!std::filesystem::exists(executable)) {
+            std::wcerr << L"Executable <" << executable << L"> doesn't exist.\n";
+            return false;
+        }
+
+        auto cli = executable.wstring();
+        if (!arguments.empty()) {
+            cli.append(1, L' ');
+            cli.append(arguments);
+        }
+
+        BOOL res = CreateProcess(nullptr,                   // command line
+                                 cli.data(),                // non-const CLI
+                                 &sa,                       // process security attributes
+                                 nullptr,                   // primary thread security attributes
+                                 TRUE,                      // handles are inherited
+                                 0,                         // creation flags
+                                 nullptr,                   // use parent's environment
+                                 nullptr,                   // use parent's current directory
+                                 &startInfo,                // STARTUPINFO pointer
+                                 &procInfo);                // output: PROCESS_INFORMATION
+        auto ok = res != 0 && procInfo.hProcess != nullptr; // success
+        if (ok) {
+            RegisterWaitForSingleObject(&waiterHandle, procInfo.hProcess, onClose, this, INFINITE,
+                                        WT_EXECUTEDEFAULT | WT_EXECUTEONLYONCE);
+        }
+
+        return ok;
+    }
+
+    DWORD Win32ChildProcess::do_waitExitSync(DWORD timeout)
+    {
+        if (auto waitRes = WaitForSingleObject(procInfo.hProcess, timeout); waitRes != WAIT_OBJECT_0) {
+            return waitRes;
+        }
+        DWORD exitCode = 0;
+        GetExitCodeProcess(procInfo.hProcess, &exitCode);
+        return exitCode;
+    }
+}

--- a/DistroLauncher/ChildProcess.h
+++ b/DistroLauncher/ChildProcess.h
@@ -1,0 +1,164 @@
+#pragma once
+/*
+ *  Abstract
+ *  --------
+ *  A proxy for a child process that enables reacting to its termination from the outside.
+ *  Useful when dealing with processes that may be closed at any moment by the user, like GUI ones.
+ *
+ *
+ *  Usage
+ *  --------
+ *  Define the process executable, CLI arguments and handles to the standard console devices:
+ *
+ *  ```
+ *  ChildProcess child{L"notepad.exe",L"",nullptr,nullptr,nullptr}; //nullptr handles disable console interaction.
+ *  ```
+ *
+ *  Set a listener if and when you want to be notified about an extraneous process termination:
+ *
+ *  ```
+ *  child.setListener([]{std::cout << "Who killed my child?\n";});
+ *  ```
+ *
+ *  > The function object above will be owned by this class. The listener will be called on another thread, be careful
+ * with synchronization. Throwing exceptions there is also not a very good idea.
+ *  > Setting a listener for a process that never runs effectively does nothing.
+ *
+ *  Kill it if you're upset with its behavior for some reason:
+ *
+ * ```
+ *  child.terminate();
+ * ```
+ *
+ * Or just let the destructor do it. Move the child to an outer scope if you don't want the process to be killed.
+ *
+ * Or else wait on the process to exit:
+ *
+ * ```
+ * DWORD exitCode = child.waitExitSync(); // without any arguments it will wait forever.
+ * ```
+ *
+ */
+
+namespace Oobe
+{
+
+    template <typename ProcessAPI> class ChildProcessInterface
+    {
+      public:
+        // Alias to just enforce the communication that the supplied callback will run on another thread.
+        using CallInOtherThread = std::function<void()>;
+
+        // Starts the process.
+        bool start()
+        {
+            return static_cast<ProcessAPI*>(this)->do_start();
+        }
+
+        /// Sets the listener that will be called back once (and if) the process ends from the outside.
+        /// IMPORTANT NOTE ON MULTITHREADING: [onClose] will be invoked by another thread, thus any precaution
+        /// required to ensure safe concurrent call must be taken by the [onClose] callable implementation itself and
+        /// any functions it calls inside its body. That's the reason for the horrible type name.
+        template <typename CallableInOtherThread> void setListener(CallableInOtherThread&& onCloseCallback)
+        {
+            onCloseListener.emplace(std::forward<CallableInOtherThread>(onCloseCallback));
+        }
+
+        // Terminates the running process forcebly.
+        void terminate()
+        {
+            unsubscribe();
+            static_cast<ProcessAPI*>(this)->do_terminate();
+        }
+        DWORD waitExitSync(DWORD timeoutMs = INFINITE)
+        {
+            return static_cast<ProcessAPI*>(this)->do_waitExitSync(timeoutMs);
+        }
+
+        // Unregisters the wait callback, if set.
+        void unsubscribe()
+        {
+            if (waiterHandle != nullptr) {
+                static_cast<ProcessAPI*>(this)->do_unsubscribe();
+                waiterHandle = nullptr;
+            }
+        }
+
+        DWORD pid() const
+        {
+            return procInfo.dwProcessId;
+        }
+
+        DWORD threadId() const
+        {
+            return procInfo.dwProcessId;
+        }
+
+        constexpr ChildProcessInterface(const std::filesystem::path& exePath, const std::wstring& args,
+                                        HANDLE stdErr = nullptr, HANDLE stdIn = nullptr, HANDLE stdOut = nullptr) :
+            executable{exePath},
+            arguments{args}
+        {
+            startInfo.cb = sizeof(STARTUPINFO);
+            startInfo.hStdError = stdErr;
+            startInfo.hStdInput = stdIn;
+            startInfo.hStdOutput = stdOut;
+            startInfo.dwFlags |= STARTF_USESTDHANDLES;
+        }
+
+      protected:
+        HANDLE waiterHandle;
+        // The ID of the process's main thread.
+        PROCESS_INFORMATION procInfo = {0};
+        STARTUPINFO startInfo = {0};
+        SECURITY_ATTRIBUTES sa = {0};
+
+        // The program's path.
+        std::filesystem::path executable;
+
+        // It's command line arguments.
+        std::wstring arguments;
+
+        // A callback that will be executed in another thread in case the user closes the window.
+        std::optional<CallInOtherThread> onCloseListener;
+
+        // Executes the listener callback, if set. Not meant to be called from the wild.
+        void notifyListener()
+        {
+            if (onCloseListener.has_value()) {
+                onCloseListener.value()();
+            }
+        }
+    };
+
+    // Abstracts the OS interaction required to start and manage the child process from the API class. Invariants are
+    // held by the parent. Thus everything here is private. Inheritance is used to access the parent class data members.
+    class Win32ChildProcess : public ChildProcessInterface<Win32ChildProcess>
+    {
+        // Effectively starts the process.
+        bool do_start();
+
+        // Terminates a running process.
+        void do_terminate();
+
+        // Unregisters the wait callback.
+        void do_unsubscribe();
+
+        // Blocks the calling thread for [timeoutMs] ms waiting the process to exit. Returns its exit code on success or
+        // the waiting error code.
+        DWORD do_waitExitSync(DWORD timeoutMs);
+
+        // Destroys the required handles.
+        void destroy();
+
+        // Call-once function which must be called only by the OS in reaction to process termination from the outside.
+        // Since the onCloseListener member is initialized before the process runs and (must) never be touched since
+        // then, it's safe to assume no need for synchronization whatsoever in accessing it. Any need for
+        // synchronization must be taken care of by the callable itself.
+        static void onClose(void* data, BOOLEAN /*unused*/);
+
+        friend class ChildProcessInterface<Win32ChildProcess>;
+    };
+
+    using ChildProcess = ChildProcessInterface<Win32ChildProcess>;
+}

--- a/DistroLauncher/ChildProcess.h
+++ b/DistroLauncher/ChildProcess.h
@@ -95,6 +95,7 @@ namespace Oobe
         }
 
         constexpr ChildProcessInterface(const std::filesystem::path& exePath, const std::wstring& args,
+                                        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) - that's the Win32 way.
                                         HANDLE stdErr = nullptr, HANDLE stdIn = nullptr, HANDLE stdOut = nullptr) :
             executable{exePath},
             arguments{args}
@@ -107,11 +108,11 @@ namespace Oobe
         }
 
       protected:
-        HANDLE waiterHandle;
+        HANDLE waiterHandle{nullptr};
         // The ID of the process's main thread.
-        PROCESS_INFORMATION procInfo = {0};
-        STARTUPINFO startInfo = {0};
-        SECURITY_ATTRIBUTES sa = {0};
+        PROCESS_INFORMATION procInfo{};
+        STARTUPINFO startInfo{};
+        SECURITY_ATTRIBUTES sa{};
 
         // The program's path.
         std::filesystem::path executable;

--- a/DistroLauncher/ChildProcess.h
+++ b/DistroLauncher/ChildProcess.h
@@ -11,6 +11,7 @@
  *  Define the process executable, CLI arguments and handles to the standard console devices:
  *
  *  ```
+ *  using ChildProcess = ChildProcessInterface<Win32ChildProcess>;
  *  ChildProcess child{L"notepad.exe",L"",nullptr,nullptr,nullptr}; //nullptr handles disable console interaction.
  *  ```
  *
@@ -160,6 +161,4 @@ namespace Oobe
 
         friend class ChildProcessInterface<Win32ChildProcess>;
     };
-
-    using ChildProcess = ChildProcessInterface<Win32ChildProcess>;
 }

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -140,6 +140,7 @@
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="ApplicationStrategy.h" />
+    <ClInclude Include="ChildProcess.h" />
     <ClInclude Include="console_service.h" />
     <ClInclude Include="ExitStatus.h" />
     <ClInclude Include="extended_cli_parser.h" />
@@ -166,6 +167,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ApplicationStrategy.cpp" />
+    <ClCompile Include="ChildProcess.cpp" />
     <ClCompile Include="DistributionInfo.cpp" />
     <ClCompile Include="ExitStatus.cpp" />
     <ClCompile Include="exit_status_parser.cpp" />

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -184,9 +184,10 @@ namespace Oobe
     ///
     /// Since ShouldBeClosed state cannot handle any event, it's expected that the Close event will happen only once.
     /// Also, since the Run event can only be handled by the initial state, that event is expected to succeed only once.
-    template <typename Strategy = SplashStrategy> class SplashController
+    template <typename Strategy = SplashStrategy, typename ProcessAPI = Win32ChildProcess> class SplashController
     {
       private:
+        using ChildProcess = ChildProcessInterface<ProcessAPI>;
         std::unique_ptr<ChildProcess> process;
 
       public:
@@ -212,7 +213,7 @@ namespace Oobe
             // controller's private members.
             struct Run
             {
-                not_null<SplashController<Strategy>*> controller;
+                not_null<SplashController<Strategy, ProcessAPI>*> controller;
             };
             struct ToggleVisibility
             { };
@@ -224,7 +225,7 @@ namespace Oobe
 
             struct Close
             {
-                not_null<SplashController<Strategy>*> controller;
+                not_null<SplashController<Strategy, ProcessAPI>*> controller;
             };
             using EventVariant = std::variant<ToggleVisibility, Run, PlaceBehind, Close>;
         };
@@ -326,7 +327,7 @@ namespace Oobe
         // and state types are now dependent and cannot be explicitly referred to without the templated type argument.
         using State = typename States::StateVariant;
         using Event = typename Events::EventVariant;
-        internal::state_machine<SplashController<Strategy>> sm;
+        internal::state_machine<SplashController<Strategy, ProcessAPI>> sm;
 
         ~SplashController() = default;
     };

--- a/DistroLauncher/splash_controller.h
+++ b/DistroLauncher/splash_controller.h
@@ -191,14 +191,14 @@ namespace Oobe
 
       public:
         SplashController(const SplashController& other) = delete;
-        SplashController(SplashController&& other) = default;
+        SplashController(SplashController&& other) noexcept = default;
         template <typename CallableInOtherThread>
         SplashController(const std::filesystem::path& exePath,
                          not_null<HANDLE> const stdIn,
                          CallableInOtherThread&& onClose) :
             process{std::make_unique<ChildProcess>(exePath, L"", nullptr, stdIn, nullptr)}
         {
-            process->setListener(std::move(onClose));
+            process->setListener(std::forward<CallableInOtherThread>(onClose));
         }
         // controller events;
         struct Events

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -51,6 +51,7 @@
 #include "ProcessRunner.h"
 #include "WSLInfo.h"
 #include "Win32Utils.h"
+#include "ChildProcess.h"
 #include "ApplicationStrategy.h"
 #include "Application.h"
 #include "named_mutex.h"


### PR DESCRIPTION
The splash controller is made of a state machine and a strategy class full of static functions to encapsulate the Win32 API's with the duty of starting and controlling the slide show application. There are a few premises related to its job:
1. Launcher output stream must be succefully redirected so the child process can read it and display the messages.
2. The Flutter executable must exist.
3. Starting the application must succeed.
4. Detecting its HWND also succeeds.

It's quite easy to predict that the behavior of that class could be a nightmare of if-elses. That's why the state machine design.

Yet, the strategy class that feeds the controller with the Win32 capabilities is doing too much: controlling the application process and the application window. When porting the OOBE to Windows, most of the process handling behavior would be duplicated, but the window control would not, thus splitting those duties in two different components allows for an easier migration to the new OOBE while not breaking the current behavior (required for the upcoming point release).

So, this PR extracts the process creation, termination and spurious termination notification out of the splash controller component. Also, the splash controller is updated to reflect the changes in such a way that user won't notice any difference in the application behavior.