### PR TITLE
Enables downloading images from the c-i.u.c/wsl

### DIFF
--- a/wsl-builder/prepare-build/buildGHMatrix.go
+++ b/wsl-builder/prepare-build/buildGHMatrix.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ubuntu/wsl/wsl-builder/common"
 )
@@ -34,7 +35,14 @@ func buildGHMatrix(csvPath, metaPath string) error {
 			if i == 0 {
 				t = ""
 			}
-			t += fmt.Sprintf("https://cloud-images.ubuntu.com/%s/current/%s-server-cloudimg-%s-wsl.rootfs.tar.gz::%s", r.CodeName, r.CodeName, arch, arch)
+			// Currently only Kinetic (22.10) and later are published to "https://cloud-images.ubuntu.com/wsl/"
+			codeNameSubUri := func() string {
+				if strings.Compare(r.BuildVersion, "2210") >= 0 {
+					return "wsl/" + r.CodeName
+				}
+				return r.CodeName
+			}()
+			t += fmt.Sprintf("https://cloud-images.ubuntu.com/%s/current/%s-server-cloudimg-%s-wsl.rootfs.tar.gz::%s", codeNameSubUri, r.CodeName, arch, arch)
 			rootfses += t
 		}
 

--- a/wsl-builder/prepare-build/buildGHMatrix.go
+++ b/wsl-builder/prepare-build/buildGHMatrix.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/ubuntu/wsl/wsl-builder/common"
@@ -36,12 +37,11 @@ func buildGHMatrix(csvPath, metaPath string) error {
 				t = ""
 			}
 			// Currently only Kinetic (22.10) and later are published to "https://cloud-images.ubuntu.com/wsl/"
-			codeNameSubUri := func() string {
-				if strings.Compare(r.BuildVersion, "2210") >= 0 {
-					return "wsl/" + r.CodeName
-				}
-				return r.CodeName
-			}()
+			codeNameSubUri := r.CodeName
+			if strings.Compare(r.BuildVersion, "2210") >= 0 {
+				codeNameSubUri = filepath.Join("wsl", r.CodeName)
+			}
+
 			t += fmt.Sprintf("https://cloud-images.ubuntu.com/%s/current/%s-server-cloudimg-%s-wsl.rootfs.tar.gz::%s", codeNameSubUri, r.CodeName, arch, arch)
 			rootfses += t
 		}


### PR DESCRIPTION
My Go skills are a bit rusty, so I'd prefer asking review from an expert. 😄 

Per the CPC team information. Kinetic (22.10) and later versions are to be published to that location (see https://cloud-images.ubuntu.com/wsl/kinetic/ for instance). Previous versions stay in cloud-images.ubuntu.com.

This PR aims to let the build matrix routine to differentiate the base URI from where to download the images.