### PR TITLE
Skip C++ source linting for unrelevant PRs

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -3,7 +3,9 @@ on:
   push:
     branches:
     - main
+    paths: [DistroLauncher/**, .github/workflows/**]
   pull_request:
+    paths: [DistroLauncher/**, .github/workflows/**]
 
 concurrency:
   group: QA-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Linting is quite resource consuming.
Only the sources inside `DistroLauncher/` are linted.
PR's which won't touch those files (or the workflow ones) will have QA skipped.
This will not skip run-tests workflow.