### PR TITLE
Prevents filesystem exceptions

### DIFF
--- a/DistroLauncher/ExitStatus.cpp
+++ b/DistroLauncher/ExitStatus.cpp
@@ -57,8 +57,13 @@ namespace Oobe
         prefixedFilePath.append(DistributionInfo::Name);
         prefixedFilePath.append(launcherCommandFilePath);
         std::ifstream launcherCmdFile;
-        if (!std::filesystem::exists(prefixedFilePath)) {
+        std::error_code error;
+        if (!std::filesystem::exists(prefixedFilePath, error)) {
             // OOBE left nothing to do.
+            return;
+        }
+        if (error) {
+            Helpers::PrintFromUtf8(error.message().c_str());
             return;
         }
         launcherCmdFile.open(prefixedFilePath);
@@ -85,7 +90,8 @@ namespace Oobe
 
         launcherCmdFile.close();
         // We don't want that file existing after actions were taken.
-        std::filesystem::remove(prefixedFilePath);
+        // Errors at this point are irrelevant.
+        std::filesystem::remove(prefixedFilePath, error);
     }
 
     namespace


### PR DESCRIPTION
Filesystem calls in the context this PR touches could fail due user making some configuration to the distro preventing Windows from accessing the referred file as well as user permissions, since the affected function is no longer called only during distro setup.

Thus, this PR avoids exceptions been thrown due filesystem API errors. `std::bad_alloc` can still be thrown :D 

I preferred to go with the `error_code` API then the Pokémon approach (`catch (...)`).