### PR TITLE
Adapts the image base name to the new pipeline

### DIFF
--- a/wsl-builder/prepare-build/buildGHMatrix.go
+++ b/wsl-builder/prepare-build/buildGHMatrix.go
@@ -38,11 +38,14 @@ func buildGHMatrix(csvPath, metaPath string) error {
 			}
 			// Currently only Kinetic (22.10) and later are published to "https://cloud-images.ubuntu.com/wsl/"
 			codeNameSubUri := r.CodeName
+			imageBaseName := fmt.Sprintf("%s-server-cloudimg", r.CodeName)
 			if strings.Compare(r.BuildVersion, "2210") >= 0 {
 				codeNameSubUri = filepath.Join("wsl", r.CodeName)
+				// The image base name scheme also changed.
+				imageBaseName = fmt.Sprintf("ubuntu-%s-wsl", r.CodeName)
 			}
 
-			t += fmt.Sprintf("https://cloud-images.ubuntu.com/%s/current/%s-server-cloudimg-%s-wsl.rootfs.tar.gz::%s", codeNameSubUri, r.CodeName, arch, arch)
+			t += fmt.Sprintf("https://cloud-images.ubuntu.com/%s/current/%s-%s-wsl.rootfs.tar.gz::%s", codeNameSubUri, imageBaseName, arch, arch)
 			rootfses += t
 		}
 


### PR DESCRIPTION
I was so happy with the new pipeline that I didn't notice the image naming scheme also changed. 😳

Older images scheme: `<codename>-server-cloudimg-<arch>-wsl.rootfs.tar.gz`.

With the new pipeline: `ubuntu-<codename>-wsl-<arch>-wsl.rootfs.tar.gz`.

Before:

![image](https://user-images.githubusercontent.com/11138291/180429473-4fabab95-0c90-47f6-9dc7-ba6067405a27.png)


After:

![image](https://user-images.githubusercontent.com/11138291/180429613-5443a348-be63-451d-ad3a-e2d9994b20ff.png)


This PR complements #235 to adapt the image base name convention.