### PR TITLE
Removed Sudo::WslLaunch

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/mock_api.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/mock_api.cpp
@@ -126,21 +126,8 @@ namespace Testing
         }
     }
 
-    HRESULT WslMockAPI::Launch(PCWSTR command, BOOL useCurrentWorkingDirectory, HANDLE stdIn, HANDLE stdOut,
-                               HANDLE stdErr, HANDLE* process) noexcept
-    {
-        try {
-            *process = mock_process;
-            command_log.emplace_back<Command>({command, useCurrentWorkingDirectory, stdIn, stdOut, stdErr});
-            return S_OK;
-        } catch (...) {
-            return -1; // Failed: hr<0
-        }
-    }
-
     void WslMockAPI::reset_mock_distro()
     {
-        command_log = {};
         interactive_command_log = {};
         defaultUID_ = 0xabcdef;
         wslDistributionFlags_ = WSL_DISTRIBUTION_FLAGS{};
@@ -150,10 +137,6 @@ namespace Testing
     // Initializing statics
     inline std::list<MockMutexAPI::MockMutex> MockMutexAPI::dummy_back_end{};
 
-    inline int WslMockAPI::mock_process_impl = 0;
-    inline HANDLE WslMockAPI::mock_process = static_cast<HANDLE>(&Testing::WslMockAPI::mock_process_impl);
-
-    inline std::vector<WslMockAPI::Command> Testing::WslMockAPI::command_log{};
     inline std::vector<WslMockAPI::InteractiveCommand> Testing::WslMockAPI::interactive_command_log{};
     inline ULONG WslMockAPI::defaultUID_ = 0xabcdef;
     inline WSL_DISTRIBUTION_FLAGS WslMockAPI::wslDistributionFlags_ = WSL_DISTRIBUTION_FLAGS{};

--- a/DistroLauncher-Tests/DistroLauncher-Tests/mock_api.h
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/mock_api.h
@@ -69,15 +69,6 @@ namespace Testing
         static WSL_DISTRIBUTION_FLAGS wslDistributionFlags_;
 
         // Instead of executing commands, they are logged
-        struct Command
-        {
-            PCWSTR command;
-            BOOL useCurrentWorkingDirectory;
-            HANDLE stdIn;
-            HANDLE stdOut;
-            HANDLE stdErr;
-        };
-
         struct InteractiveCommand
         {
             PCWSTR command;
@@ -86,18 +77,10 @@ namespace Testing
 
         static HRESULT LaunchInteractive(PCWSTR command, BOOL useCurrentWorkingDirectory, DWORD* exitCode) noexcept;
 
-        static HRESULT Launch(PCWSTR command, BOOL useCurrentWorkingDirectory, HANDLE stdIn, HANDLE stdOut,
-                              HANDLE stdErr, HANDLE* process) noexcept;
-
         static void reset_mock_distro();
 
         // Log of commands
-        static std::vector<Command> command_log;
         static std::vector<InteractiveCommand> interactive_command_log;
-
-        // Mock process, and a mock variable for the HANDLE to point to
-        static HANDLE mock_process;
-        static int mock_process_impl;
     };
 
     // Aliases within the Testing namespace

--- a/DistroLauncher-Tests/DistroLauncher-Tests/sudo_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/sudo_tests.cpp
@@ -66,29 +66,8 @@ TEST(SudoTests, WslInterface)
         ASSERT_EQ(exitCode, 0);
         ASSERT_EQ(Testing::WslMockAPI::defaultUID_, 0xabcdef);             // Default user restored
         ASSERT_EQ(Testing::WslMockAPI::interactive_command_log.size(), 1); // Interactive command launched
-        ASSERT_EQ(Testing::WslMockAPI::command_log.size(), 0);             // Regular command not launched
         ASSERT_EQ(Testing::WslMockAPI::interactive_command_log.back().command, command1);
         ASSERT_EQ(Testing::WslMockAPI::interactive_command_log.back().useCurrentWorkingDirectory, TRUE);
-
-        const auto command2 = L"mkdir ${HOME}/desktop/important_stuff";
-        int x = 0, y = 0, z = 0;
-        HANDLE stdIn = &x;  // Mock StdIn
-        HANDLE stdOut = &y; // Mock StdOut
-        HANDLE stdErr = &z; // Mock stdErr
-        HANDLE process = nullptr;
-        hr = Testing::Sudo::WslLaunch(command2, FALSE, stdIn, stdOut, stdErr, &process);
-
-        ASSERT_TRUE(SUCCEEDED(hr));
-        ASSERT_EQ(Testing::WslMockAPI::defaultUID_, 0xabcdef);             // Default user restored
-        ASSERT_EQ(Testing::WslMockAPI::command_log.size(), 1);             // Command launched
-        ASSERT_EQ(Testing::WslMockAPI::interactive_command_log.size(), 1); // Interactive command not launched
-
-        ASSERT_EQ(Testing::WslMockAPI::command_log.back().command, command2);
-        ASSERT_EQ(Testing::WslMockAPI::command_log.back().useCurrentWorkingDirectory, FALSE);
-        ASSERT_EQ(Testing::WslMockAPI::command_log.back().stdIn, stdIn);
-        ASSERT_EQ(Testing::WslMockAPI::command_log.back().stdOut, stdOut);
-        ASSERT_EQ(Testing::WslMockAPI::command_log.back().stdErr, stdErr);
-        ASSERT_EQ(process, Testing::WslMockAPI::mock_process); // Process out variable not ignored
     }
 
     // Testing failure (fails because it's locked already)
@@ -105,22 +84,6 @@ TEST(SudoTests, WslInterface)
         ASSERT_EQ(exitCode, 0xBAD); // Exit code not modified
 
         ASSERT_EQ(Testing::WslMockAPI::defaultUID_, 0);                    // Still sudo
-        ASSERT_EQ(Testing::WslMockAPI::interactive_command_log.size(), 0); // Command not lauched
-        ASSERT_EQ(Testing::WslMockAPI::command_log.size(), 0);             // Command not lauched
-
-        const auto command2 = L"mkdir ${HOME}/desktop/important_stuff";
-        int x = 0, y = 0, z = 0;
-        HANDLE stdIn = &x;  // Mock StdIn
-        HANDLE stdOut = &y; // Mock StdOut
-        HANDLE stdErr = &z; // Mock stdErr
-        HANDLE process = nullptr;
-        hr = Testing::Sudo::WslLaunch(command2, FALSE, stdIn, stdOut, stdErr, &process);
-
-        ASSERT_TRUE(FAILED(hr));     // Failed to acquire Sudo lock
-        ASSERT_EQ(process, nullptr); // Process not assigned
-
-        ASSERT_EQ(Testing::WslMockAPI::defaultUID_, 0);                    // Still sudo
-        ASSERT_EQ(Testing::WslMockAPI::command_log.size(), 0);             // Command not lauched
         ASSERT_EQ(Testing::WslMockAPI::interactive_command_log.size(), 0); // Command not lauched
     }
     ASSERT_EQ(Testing::WslMockAPI::defaultUID_, 0xabcdef); // Scope lock released

--- a/DistroLauncher/sudo.h
+++ b/DistroLauncher/sudo.h
@@ -195,19 +195,6 @@ namespace SudoInternals
             return hr;
         }
 
-        static HRESULT WslLaunch(PCWSTR command, BOOL useCurrentWorkingDirectory, HANDLE stdIn, HANDLE stdOut,
-                                 HANDLE stdErr, HANDLE* process) noexcept
-        {
-            HRESULT hr = S_FALSE;
-            SudoInterface()
-              .and_then([&]() noexcept {
-                  hr = WslAPI::Launch(command, useCurrentWorkingDirectory, stdIn, stdOut, stdErr, process);
-              })
-              .or_else([&] { hr = WAIT_FAILED; });
-
-            return hr;
-        }
-
         static MutexType& GetMutex()
         {
             static MutexType sudo_mutex(L"root-user", true);
@@ -247,12 +234,6 @@ namespace SudoInternals
         static HRESULT LaunchInteractive(PCWSTR command, BOOL useCurrentWorkingDirectory, DWORD* exitCode) noexcept
         {
             return g_wslApi.WslLaunchInteractive(command, useCurrentWorkingDirectory, exitCode);
-        }
-
-        static HRESULT Launch(PCWSTR command, BOOL useCurrentWorkingDirectory, HANDLE stdIn, HANDLE stdOut,
-                              HANDLE stdErr, HANDLE* process) noexcept
-        {
-            return g_wslApi.WslLaunch(command, useCurrentWorkingDirectory, stdIn, stdOut, stdErr, process);
         }
     };
 


### PR DESCRIPTION
This static function is problematic because the process it launches may outlive the user change.

The goal of the Sudo class is to abstract away these complexites, and this function failed to achieve this.