### PR TITLE
Use strings.Fields to split the checksum file.

### DIFF
--- a/wsl-builder/prepare-build/build.go
+++ b/wsl-builder/prepare-build/build.go
@@ -330,7 +330,7 @@ func checksumMatches(path, origName, checksumPath string) (err error) {
 
 	var found bool
 	for _, l := range text {
-		e := strings.Split(l, " ")
+		e := strings.Fields(l)
 		if len(e) != 2 {
 			continue
 		}


### PR DESCRIPTION
The WSL pipeline checksum file has more whistespaces between the fields.
`strings.Split` fails to produce the desired output: `Split: ["2f1e68d12994cb9c61085ea09720c7cef1728ca634ba9a447baa8a295499daf8" "" "ubuntu-kinetic-wsl-amd64-wsl.rootfs.manifest"]`
`strings.Fields` can treat multiple whitespaces as one, thus generating the expected length-2 slices.