### PR TITLE
Abstraction on top of Win32 Named Events that can be set only once

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -78,6 +78,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="..\..\DistroLauncher\named_mutex.cpp" />
     <ClCompile Include="..\..\DistroLauncher\OOBE.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ProcessRunner.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\SetOnceNamedEvent.cpp" />
     <ClCompile Include="..\..\DistroLauncher\stdafx.cpp" />
     <ClCompile Include="..\..\DistroLauncher\Win32Utils.cpp" />
     <ClCompile Include="..\..\DistroLauncher\WindowsUserInfo.cpp" />
@@ -94,6 +95,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="IniFindValueTests.cpp" />
     <ClCompile Include="mock_api.cpp" />
     <ClCompile Include="named_mutex_tests.cpp" />
+    <ClCompile Include="SetOnceNamedEventTests.cpp" />
     <ClCompile Include="SplashControllerTests.cpp" />
     <ClCompile Include="StateMachineTests.cpp" />
     <ClCompile Include="sudo_tests.cpp" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -91,6 +91,8 @@
     <ClCompile Include="ChildProcessTests.cpp" />
     <ClCompile Include="FakeChildProcessImpl.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ChildProcess.cpp" />
+    <ClCompile Include="SetOnceNamedEventTests.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\SetOnceNamedEvent.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="InstallerControllerTestPolicies.h" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SetOnceNamedEventTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SetOnceNamedEventTests.cpp
@@ -7,7 +7,7 @@ namespace Win32Utils
     TEST(SetOnceNamedEvent, ValidUntilSet)
     {
         auto now = std::chrono::system_clock::now().time_since_epoch();
-        std::wstring name = L"a-global-unique-name-for-today"  + std::to_wstring(now.count());
+        std::wstring name = L"a-global-unique-name-for-today" + std::to_wstring(now.count());
         SetOnceNamedEvent event{name.c_str()};
         EXPECT_TRUE(event.isValid());
         EXPECT_TRUE(event.set());

--- a/DistroLauncher-Tests/DistroLauncher-Tests/SetOnceNamedEventTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/SetOnceNamedEventTests.cpp
@@ -1,0 +1,16 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+#include "SetOnceNamedEvent.h"
+
+namespace Win32Utils
+{
+    TEST(SetOnceNamedEvent, ValidUntilSet)
+    {
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        std::wstring name = L"a-global-unique-name-for-today"  + std::to_wstring(now.count());
+        SetOnceNamedEvent event{name.c_str()};
+        EXPECT_TRUE(event.isValid());
+        EXPECT_TRUE(event.set());
+        ASSERT_FALSE(event.isValid());
+    }
+}

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -154,6 +154,7 @@
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="ProcessRunner.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="SetOnceNamedEvent.h" />
     <ClInclude Include="splash_controller.h" />
     <ClInclude Include="state_machine.h" />
     <ClInclude Include="stdafx.h" />
@@ -180,6 +181,7 @@
     <ClCompile Include="ProcessRunner.cpp" />
     <ClCompile Include="find_main_thread_window.cpp" />
     <ClCompile Include="ini_find_value.cpp" />
+    <ClCompile Include="SetOnceNamedEvent.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/DistroLauncher/DistroLauncher.vcxproj.filters
+++ b/DistroLauncher/DistroLauncher.vcxproj.filters
@@ -39,6 +39,63 @@
     <ClInclude Include="named_mutex.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Application.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationStrategy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ChildProcess.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="console_service.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ExitStatus.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="extended_cli_parser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="extended_messages.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="installer_controller.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="installer_policy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="not_null.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ProcessRunner.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="splash_controller.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="state_machine.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="sudo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Win32Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="expected.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="WSLInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="local_named_pipe.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SetOnceNamedEvent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DistroLauncher.cpp">
@@ -63,6 +120,42 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="named_mutex.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationStrategy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ChildProcess.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ExitStatus.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="exit_status_parser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="extended_cli_parser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="local_named_pipe.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProcessRunner.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="find_main_thread_window.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ini_find_value.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win32Utils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WSLInfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SetOnceNamedEvent.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DistroLauncher/SetOnceNamedEvent.cpp
+++ b/DistroLauncher/SetOnceNamedEvent.cpp
@@ -37,7 +37,7 @@ namespace Win32Utils
         }
     }
 
-    bool SetOnceNamedEvent::set()
+    bool SetOnceNamedEvent::set() noexcept
     {
         if (event == nullptr) {
             return false;
@@ -52,10 +52,9 @@ namespace Win32Utils
 
     SetOnceNamedEvent::SetOnceNamedEvent(SetOnceNamedEvent&& other) noexcept :
         event{std::exchange(other.event, nullptr)}
-    {
-    }
+    { }
 
-    bool SetOnceNamedEvent::isValid() const
+    bool SetOnceNamedEvent::isValid() const noexcept
     {
         return event != nullptr;
     }

--- a/DistroLauncher/SetOnceNamedEvent.cpp
+++ b/DistroLauncher/SetOnceNamedEvent.cpp
@@ -52,7 +52,8 @@ namespace Win32Utils
 
     SetOnceNamedEvent::SetOnceNamedEvent(SetOnceNamedEvent&& other) noexcept :
         event{std::exchange(other.event, nullptr)}
-    { }
+    {
+    }
 
     bool SetOnceNamedEvent::isValid() const noexcept
     {

--- a/DistroLauncher/SetOnceNamedEvent.cpp
+++ b/DistroLauncher/SetOnceNamedEvent.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "SetOnceNamedEvent.h"
+
+namespace Win32Utils
+{
+
+    SetOnceNamedEvent::SetOnceNamedEvent(const wchar_t* name) noexcept
+    {
+        HANDLE handle = CreateEvent(nullptr, TRUE, FALSE, name);
+        if (handle != nullptr) {
+            event = handle;
+        }
+    }
+
+    SetOnceNamedEvent::~SetOnceNamedEvent() noexcept
+    {
+        if (event != nullptr) {
+            CloseHandle(event);
+            event = nullptr;
+        }
+    }
+
+    bool SetOnceNamedEvent::set()
+    {
+        if (event == nullptr) {
+            return false;
+        }
+        if (SetEvent(event) == FALSE) {
+            return false;
+        }
+        CloseHandle(event);
+        event = nullptr;
+        return true;
+    }
+
+    SetOnceNamedEvent::SetOnceNamedEvent(SetOnceNamedEvent&& other) noexcept :
+        event{std::exchange(other.event, nullptr)}
+    { }
+
+    bool SetOnceNamedEvent::isValid() const
+    {
+        return event != nullptr;
+    }
+}

--- a/DistroLauncher/SetOnceNamedEvent.cpp
+++ b/DistroLauncher/SetOnceNamedEvent.cpp
@@ -52,7 +52,8 @@ namespace Win32Utils
 
     SetOnceNamedEvent::SetOnceNamedEvent(SetOnceNamedEvent&& other) noexcept :
         event{std::exchange(other.event, nullptr)}
-    { }
+    {
+    }
 
     bool SetOnceNamedEvent::isValid() const
     {

--- a/DistroLauncher/SetOnceNamedEvent.h
+++ b/DistroLauncher/SetOnceNamedEvent.h
@@ -58,8 +58,8 @@ namespace Win32Utils
         SetOnceNamedEvent& operator=(const SetOnceNamedEvent& other) = delete;
         // Sets the event and subsequently closes its handle. From this moment on the object becomes useless.
         // Returns false on failure. NOTE: Subsequent calls are no-op.
-        [[nodiscard]] bool set();
-        [[nodiscard]] bool isValid() const;
+        [[nodiscard]] bool set() noexcept;
+        [[nodiscard]] bool isValid() const noexcept;
 
       private:
         HANDLE event = nullptr;

--- a/DistroLauncher/SetOnceNamedEvent.h
+++ b/DistroLauncher/SetOnceNamedEvent.h
@@ -1,0 +1,67 @@
+#pragma once
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace Win32Utils
+{
+    /*
+     *  Abstract
+     *  --------
+     *  An abstraction on top of Win32 Named Events that can be set only once.
+     *
+     *  Usage
+     *  --------
+     *  Ensure a unique name is used for its initialization. This is an IPC mechanism, so other processes will find it.
+     *
+     *  ```
+     *  SetOnceNamedEvent event(L"unique_identifyier");
+     *  ```
+     *  When something interesting happens and you want to let the world know about it, set the event:
+     *
+     *  ```
+     *  bool ok = event.set();
+     *  ```
+     *
+     *  That's it. From now on the variable is useless. The event remains valid from a succesfull construction until
+     * it's set.
+     *
+     * ```
+     * ASSERT_FALSE(event.isValid())
+     * ````
+     *
+     * NOTE: Win32 Events (named or unnamed) are resetable, meaning that one can toggle on-off as much as desired. They
+     * can even be automatically reset by the OS, if configured to do so by the CreateEvent function. This class
+     * restricts that behavior by closing the OS handle and nulling out the private field that would represent it, thus
+     * rendering the object useless after being once set.
+     */
+    class SetOnceNamedEvent
+    {
+      public:
+        // Creates an event called [name].
+        explicit SetOnceNamedEvent(const wchar_t* name) noexcept;
+        ~SetOnceNamedEvent() noexcept;
+        SetOnceNamedEvent(SetOnceNamedEvent&& other) noexcept;
+        SetOnceNamedEvent(const SetOnceNamedEvent& other) = delete;
+        SetOnceNamedEvent& operator=(const SetOnceNamedEvent& other) = delete;
+        // Sets the event and subsequently closes its handle. From this moment on the object becomes useless.
+        // Returns false on failure. NOTE: Subsequent calls are no-op.
+        [[nodiscard]] bool set();
+        [[nodiscard]] bool isValid() const;
+
+      private:
+        HANDLE event = nullptr;
+    };
+}


### PR DESCRIPTION
## Abstract

An abstraction on top of Win32 Named Events that can be set only once.

>NOTE: Win32 Events (named or unnamed) are resetable, meaning that one can toggle on-off as much as desired. They
can even be automatically reset by the OS, if configured to do so by the CreateEvent function. This class
restricts that behavior by closing the OS handle and nulling out the private field that would represent it, thus
rendering the object useless after being once set.

Usage
----
Ensure a unique name is used for its initialization. This is an IPC mechanism, so other processes will find it.

  ```
 SetOnceNamedEvent event(L"unique_identifyier");
 ```
 When something interesting happens and you want to let the world know about it, set the event:

 ```
bool ok = event.set();
```

That's it. From now on the variable is useless. The event remains valid from a succesfull construction until
it's set.

```
ASSERT_FALSE(event.isValid())
````

That will be used to notify the OOBE of the distro registration completion as well as to kindly ask it to quit, events that by nature happens at most once.
 