### PR TITLE
showConsoleWindow accepts topWindow nullptr

### DIFF
--- a/DistroLauncher/console_service.h
+++ b/DistroLauncher/console_service.h
@@ -159,9 +159,9 @@ namespace Win32Utils
             return ShowWindow(window_, SW_HIDE) != FALSE;
         }
 
-        bool showConsoleWindow(HWND topWindow) const
+        bool showConsoleWindow(HWND topWindow = nullptr) const
         {
-            if (IsWindowVisible(topWindow) == TRUE) {
+            if (topWindow != nullptr && IsWindowVisible(topWindow) == TRUE) {
                 if (auto res = Win32Utils::resize_to(window_, topWindow); res != 0) {
                     Helpers::PrintErrorMessage(HRESULT_FROM_WIN32(res));
                 }


### PR DESCRIPTION
The previous experience prized for hiding the console behind the slideshow precisely, which included resizing the console window to the same dimensions as the slideshow application. With the new OOBE that requirement can be relaxed. Accepting a null window parameter materializes that requriment for the showConsoleWindow method. The window will be shown as normal, without resizing.