### PR TITLE
[CI] Sets a 20 min timeout for clang-tidy

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -19,6 +19,7 @@ jobs:
   quality:
     name: Lint C++ sources with LLVM
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
GitHub history shows that succesful runs finish under 15 minutes long. Longer runs required manual cancellation.
Not sure the cause, but let's limit the runs to 20 minutes for now to avoid depending on manual cancellations, at least.
GitHub default limit seems too much: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes 