### PR TITLE
Checks whether the rootfs has UDI or Subiquity snaps

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -111,6 +111,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\DistroLauncher\algorithms.h" />
     <ClInclude Include="FakeChildProcessImpl.h" />
     <ClInclude Include="mock_api.h" />
     <ClInclude Include="InstallerControllerTestPolicies.h" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -104,6 +104,7 @@
     <ClInclude Include="InstallerControllerTestPolicies.h" />
     <ClInclude Include="mock_api.h" />
     <ClInclude Include="FakeChildProcessImpl.h" />
+    <ClInclude Include="..\..\DistroLauncher\algorithms.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/upgrade_policy_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/upgrade_policy_tests.cpp
@@ -20,37 +20,37 @@
 
 TEST(UpgradePolicyTests, StringParsing)
 {
-    ASSERT_FALSE(internal::starts_with(L"", L"hello"));
-    ASSERT_FALSE(internal::starts_with(L"he", L"hello"));
-    ASSERT_TRUE(internal::starts_with(L"hello", L"hello"));
-    ASSERT_TRUE(internal::starts_with(L"hello, world!", L"hello"));
-    ASSERT_FALSE(internal::starts_with(L"cheers, world!", L"hello"));
-    ASSERT_FALSE(internal::starts_with(L"HELLO", L"hello"));
+    ASSERT_FALSE(starts_with(L"", L"hello"));
+    ASSERT_FALSE(starts_with(L"he", L"hello"));
+    ASSERT_TRUE(starts_with(L"hello", L"hello"));
+    ASSERT_TRUE(starts_with(L"hello, world!", L"hello"));
+    ASSERT_FALSE(starts_with(L"cheers, world!", L"hello"));
+    ASSERT_FALSE(starts_with(L"HELLO", L"hello"));
 
-    ASSERT_FALSE(internal::ends_with(L"", L"world!"));
-    ASSERT_FALSE(internal::ends_with(L"d!", L"world!"));
-    ASSERT_TRUE(internal::ends_with(L"world!", L"world!"));
-    ASSERT_TRUE(internal::ends_with(L"hello, world!", L"world!"));
-    ASSERT_FALSE(internal::ends_with(L"hello, world?", L"world!"));
-    ASSERT_FALSE(internal::ends_with(L"this string is completely diferent", L"world!"));
-    ASSERT_FALSE(internal::ends_with(L"HELLO", L"hello"));
+    ASSERT_FALSE(ends_with(L"", L"world!"));
+    ASSERT_FALSE(ends_with(L"d!", L"world!"));
+    ASSERT_TRUE(ends_with(L"world!", L"world!"));
+    ASSERT_TRUE(ends_with(L"hello, world!", L"world!"));
+    ASSERT_FALSE(ends_with(L"hello, world?", L"world!"));
+    ASSERT_FALSE(ends_with(L"this string is completely diferent", L"world!"));
+    ASSERT_FALSE(ends_with(L"HELLO", L"hello"));
 
-    ASSERT_FALSE(internal::starts_with(L"", L"Ubuntu"));
-    ASSERT_TRUE(internal::starts_with(L"Ubuntu 22.04.1 LTS", L"Ubuntu"));
-    ASSERT_TRUE(internal::ends_with(L"Ubuntu 22.04.1 LTS", L"LTS"));
+    ASSERT_FALSE(starts_with(L"", L"Ubuntu"));
+    ASSERT_TRUE(starts_with(L"Ubuntu 22.04.1 LTS", L"Ubuntu"));
+    ASSERT_TRUE(ends_with(L"Ubuntu 22.04.1 LTS", L"LTS"));
 }
 
 TEST(UpgradePolicyTests, Concat)
 {
     // Checking default functionality
     std::wstring dog = L"dog";
-    auto example = internal::concat(L"The", L" quick brown fox", L" jumps over the lazy ", std::quoted(dog), '.');
+    auto example = concat(L"The", L" quick brown fox", L" jumps over the lazy ", std::quoted(dog), '.');
 
     ASSERT_EQ(example, LR"(The quick brown fox jumps over the lazy "dog".)");
 
     // Checking quote nesting
-    auto nested = internal::concat(L"\n{\n  ", std::quoted(L"name"), L": ", std::quoted(L"example"), L",\n  ",
-                                   std::quoted(L"value"), L": ", std::quoted(example), L"\n}\n");
+    auto nested = concat(L"\n{\n  ", std::quoted(L"name"), L": ", std::quoted(L"example"), L",\n  ",
+                         std::quoted(L"value"), L": ", std::quoted(example), L"\n}\n");
     auto expected = LR"(
 {
   "name": "example",
@@ -61,7 +61,6 @@ TEST(UpgradePolicyTests, Concat)
 
     // Checking path auto-quoting
     std::filesystem::path example_file{L"/home/fox/documents/example.json"};
-    auto with_path =
-      internal::concat(L"diff ", example_file, L" ", example_file.wstring()); // Only first one to be quoted
+    auto with_path = concat(L"diff ", example_file, L" ", example_file.wstring()); // Only first one to be quoted
     ASSERT_EQ(with_path, LR"(diff "/home/fox/documents/example.json" /home/fox/documents/example.json)");
 }

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -138,6 +138,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="algorithms.h" />
     <ClInclude Include="Application.h" />
     <ClInclude Include="ApplicationStrategy.h" />
     <ClInclude Include="ChildProcess.h" />

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -49,6 +49,15 @@ namespace Oobe::internal
     /// <https://docs.microsoft.com/en-us/windows/wsl/wsl-config#:~:text=WSL%202%20VM.-,localhostForwarding,-boolean>
     bool isLocalhostForwardingEnabled(const std::filesystem::path& wslConfig);
 
+    /// Returns true if the ubuntu-desktop-installer snap is found inside the rootfs.
+    /// It's possible that we have only Subiquity or none instead.
+    /// That's meant to be called during setup, where filesystem errors are less likely to happen.
+    bool hasUdiSnap();
+
+    /// Returns true if the subiquity snap is found inside the rootfs.
+    /// It's possible that we have the ubuntu-desktop-installer or none instead.
+    /// That's meant to be called during setup, where filesystem errors are less likely to happen.
+    bool hasSubiquitySnap();
 }
 
 namespace Oobe

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -1,0 +1,58 @@
+#pragma once
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Common algorithms to be used everywhere in the launcher project with style resembling the std ones.
+
+template <typename CharT>
+bool starts_with(const std::basic_string_view<CharT> tested, const std::basic_string_view<CharT> start)
+{
+    if (tested.size() < start.size()) {
+        return false;
+    }
+    auto mismatch = std::mismatch(start.cbegin(), start.cend(), tested.cbegin());
+    return mismatch.first == start.cend();
+}
+
+template <typename CharT, std::size_t TestedSize, std::size_t StartSize>
+bool starts_with(CharT const (&tested)[TestedSize], CharT const (&start)[StartSize])
+{
+    return starts_with<CharT>(std::basic_string_view<CharT>{tested}, std::basic_string_view<CharT>{start});
+}
+
+template <typename CharT>
+bool ends_with(const std::basic_string_view<CharT> tested, const std::basic_string_view<CharT> end)
+{
+    if (tested.size() < end.size()) {
+        return false;
+    }
+    auto mismatch = std::mismatch(end.crbegin(), end.crend(), tested.crbegin());
+    return mismatch.first == end.crend();
+}
+
+template <typename CharT, std::size_t TestedSize, std::size_t EndSize>
+bool ends_with(const CharT (&tested)[TestedSize], const CharT (&end)[EndSize])
+{
+    return ends_with<CharT>(std::basic_string_view<CharT>{tested}, std::basic_string_view<CharT>{end});
+}
+
+template <typename... Args> std::wstring concat(Args&&... args)
+{
+    std::wstringstream buffer;
+    (buffer << ... << std::forward<Args>(args));
+    return buffer.str();
+}

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -56,3 +56,15 @@ template <typename... Args> std::wstring concat(Args&&... args)
     (buffer << ... << std::forward<Args>(args));
     return buffer.str();
 }
+
+template <typename Pred> bool find_file_if(std::filesystem::path directory, Pred&& pred)
+{
+    namespace fs = std::filesystem;
+    std::error_code error;
+    assert(fs::is_directory(directory));
+    auto listing = fs::directory_iterator{directory, error};
+    if (error) {
+        return false;
+    }
+    return std::find_if(begin(listing), end(listing), std::forward<Pred>(pred)) != end(listing);
+}

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -57,7 +57,7 @@ template <typename... Args> std::wstring concat(Args&&... args)
     return buffer.str();
 }
 
-template <typename Pred> bool find_file_if(std::filesystem::path directory, Pred&& pred)
+template <typename Pred> bool find_file_if(const std::filesystem::path& directory, Pred&& pred)
 {
     namespace fs = std::filesystem;
     std::error_code error;

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -41,6 +41,7 @@
 #include <variant>
 #include <type_traits>
 #include <utility>
+#include "algorithms.h"
 #include "expected.hpp"
 #include "not_null.h"
 #include "WslApiLoader.h"

--- a/DistroLauncher/upgrade_policy.cpp
+++ b/DistroLauncher/upgrade_policy.cpp
@@ -20,31 +20,13 @@
 namespace internal
 {
 
-    bool starts_with(const std::wstring_view tested, const std::wstring_view start)
-    {
-        if (tested.size() < start.size()) {
-            return false;
-        }
-        auto mismatch = std::mismatch(start.cbegin(), start.cend(), tested.cbegin());
-        return mismatch.first == start.cend();
-    }
-
-    bool ends_with(const std::wstring_view tested, const std::wstring_view end)
-    {
-        if (tested.size() < end.size()) {
-            return false;
-        }
-        auto mismatch = std::mismatch(end.crbegin(), end.crend(), tested.crbegin());
-        return mismatch.first == end.crend();
-    }
-
     std::wstring GetUpgradePolicy()
     {
         std::wstring_view name = DistributionInfo::Name;
         if (name == L"Ubuntu") {
             return L"lts";
         }
-        if (starts_with(name, L"Ubuntu") && ends_with(name, L"LTS")) {
+        if (starts_with(name, {L"Ubuntu"}) && ends_with(name, {L"LTS"})) {
             return L"never";
         }
         return L"normal";

--- a/DistroLauncher/upgrade_policy.h
+++ b/DistroLauncher/upgrade_policy.h
@@ -19,17 +19,7 @@
 
 namespace internal
 {
-    bool starts_with(std::wstring_view tested, std::wstring_view start);
-    bool ends_with(std::wstring_view tested, std::wstring_view end);
-
     std::wstring GetUpgradePolicy();
-
-    template <typename... Args> std::wstring concat(Args&&... args)
-    {
-        std::wstringstream buffer;
-        (buffer << ... << std::forward<Args>(args));
-        return buffer.str();
-    }
 
     void SetDefaultUpgradePolicyImpl();
 


### PR DESCRIPTION
Currently only checking for UDI is relevant. Soon Subiquity-only will be as well, which will break the possibility of rendering a GUI from inside Linux, since there will be no GUI there anymore.

Thus, this pull request modifies the function that checks whether the distro is GUI-enabled to check for the existence of the UDI snap.

Since I wanted to reuse your implementation of `starts|ends_with` algorithms, I created a new header to host them (plus some other bits with similar scope).