### PR TITLE
Models the environment variable LAUNCHER_FORCE_MODE

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -74,6 +74,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="..\..\DistroLauncher\find_main_thread_window.cpp" />
     <ClCompile Include="..\..\DistroLauncher\Helpers.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ini_find_value.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\LauncherForceMode.cpp" />
     <ClCompile Include="..\..\DistroLauncher\local_named_pipe.cpp" />
     <ClCompile Include="..\..\DistroLauncher\named_mutex.cpp" />
     <ClCompile Include="..\..\DistroLauncher\OOBE.cpp" />
@@ -90,6 +91,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="ExtendedCliParserTests.cpp" />
     <ClCompile Include="FakeChildProcessImpl.cpp" />
     <ClCompile Include="InstallerControllerTests.cpp" />
+    <ClCompile Include="LauncherForceModeTests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ExitStatusParserTests.cpp" />
     <ClCompile Include="LocalNamedPipeTests.cpp" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -99,6 +99,8 @@
     <ClCompile Include="upgrade_policy_tests.cpp">
       <Filter>TestSources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\DistroLauncher\LauncherForceMode.cpp" />
+    <ClCompile Include="LauncherForceModeTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="InstallerControllerTestPolicies.h" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/LauncherForceModeTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/LauncherForceModeTests.cpp
@@ -1,0 +1,33 @@
+#include "stdafx.h"
+#include "gtest/gtest.h"
+#include "LauncherForceMode.h"
+
+namespace Oobe
+{
+    constexpr wchar_t varName[] = L"LAUNCHER_FORCE_MODE";
+    TEST(LauncherForceMode, Undefined)
+    {
+        SetEnvironmentVariable(varName, NULL);
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::Unset);
+    }
+    TEST(LauncherForceMode, Invalids)
+    {
+        SetEnvironmentVariable(varName, L"7");
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::Invalid);
+        SetEnvironmentVariable(varName, L"002");
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::Invalid);
+        SetEnvironmentVariable(varName, L"a");
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::Invalid);
+        SetEnvironmentVariable(varName, L"A");
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::Invalid);
+    }
+    TEST(LauncherForceMode, Valids)
+    {
+        SetEnvironmentVariable(varName, L"1");
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::TextForced);
+        SetEnvironmentVariable(varName, L"2");
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::GuiForced);
+        SetEnvironmentVariable(varName, L"0");
+        ASSERT_EQ(environmentForceMode(), LauncherForceMode::Unset);
+    }
+}

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -148,6 +148,7 @@
     <ClInclude Include="extended_messages.h" />
     <ClInclude Include="installer_controller.h" />
     <ClInclude Include="installer_policy.h" />
+    <ClInclude Include="LauncherForceMode.h" />
     <ClInclude Include="named_mutex.h" />
     <ClInclude Include="not_null.h" />
     <ClInclude Include="OOBE.h" />
@@ -176,6 +177,7 @@
     <ClCompile Include="extended_cli_parser.cpp" />
     <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="DistroLauncher.cpp" />
+    <ClCompile Include="LauncherForceMode.cpp" />
     <ClCompile Include="local_named_pipe.cpp" />
     <ClCompile Include="named_mutex.cpp" />
     <ClCompile Include="OOBE.cpp" />

--- a/DistroLauncher/LauncherForceMode.cpp
+++ b/DistroLauncher/LauncherForceMode.cpp
@@ -1,0 +1,37 @@
+#include "stdafx.h"
+#include "LauncherForceMode.h"
+
+namespace Oobe
+{
+    constexpr bool inRange(wchar_t value)
+    {
+        return value >= static_cast<wchar_t>(LauncherForceMode::min) &&
+               value <= static_cast<wchar_t>(LauncherForceMode::max);
+    }
+
+    LauncherForceMode environmentForceMode()
+    {
+
+        // has to consider the NULL-terminating.
+        const DWORD expectedSize = 2;
+        wchar_t value[expectedSize];
+        auto readResult = GetEnvironmentVariable(L"LAUNCHER_FORCE_MODE", value, expectedSize);
+        // var unset is not an error.
+        const bool unset = (readResult == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND);
+        if (unset) {
+            return LauncherForceMode::Unset;
+        }
+
+        // more than one char + NULL, that's invalid. Like a string or a more than one digit number.
+        const bool notASingleChar = (readResult >= expectedSize || value[1] != NULL);
+        if (notASingleChar) {
+            return LauncherForceMode::Invalid;
+        }
+
+        if (!inRange(value[0])) {
+            return LauncherForceMode::Invalid;
+        }
+
+        return LauncherForceMode{value[0]};
+    }
+}

--- a/DistroLauncher/LauncherForceMode.h
+++ b/DistroLauncher/LauncherForceMode.h
@@ -1,0 +1,40 @@
+#pragma once
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Oobe
+{
+    /// Decouples parsing the environment variable from the rest of the GUI support detection
+    /// routine for the OOBE.
+    enum class LauncherForceMode : wchar_t
+    {
+        Invalid,
+        Unset = L'0',
+        TextForced = L'1',
+        GuiForced = L'2',
+        min = Unset,
+        max = GuiForced,
+    };
+
+    /// Returns a [LauncherForceMode] value by reading the LAUNCHER_FORCE_MODE environment variable,
+    /// which can only be:
+    ///	0 or unset or invalid = autodetection
+    ///	1 = text mode
+    ///	2 = GUI mode.
+    LauncherForceMode environmentForceMode();
+
+}

--- a/DistroLauncher/OOBE.h
+++ b/DistroLauncher/OOBE.h
@@ -19,9 +19,6 @@
 
 namespace DistributionInfo
 {
-    // OOBE Experience.
-    HRESULT OOBESetup();
-
     // isOOBEAvailable returns true if OOBE executable is found inside rootfs.
     bool isOOBEAvailable();
 
@@ -33,15 +30,6 @@ namespace DistributionInfo
     // Returns empty string if we fail to generate the prefill file
     // or the postfix to be added to the OOBE command line.
     std::wstring PreparePrefillInfo();
-
-    // Returns true if OOBE has to be launched in text mode.
-    // That might be the case due lack of graphics support in WSL
-    // or user requirement, by setting the environment variable
-    // LAUNCHER_FORCE_MODE, which can only be:
-    //	0 or unset or invalid = autodetection
-    //	1 = text mode
-    //	2 = GUI mode.
-    bool mustRunOOBEinTextMode();
 
     // Returns true if the argument ARG_SKIP_INSTALLER is present.
     // Removes it from the argument vector if present to avoid interference with upstream code.

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -159,12 +159,6 @@ namespace Oobe::internal
         return hasSubiquity;
     }
 
-} // namespace Oobe::internal
-
-// This was kept under Helpers namespace to avoid touching OOBE.cpp/h files.
-// TODO: move to Oobe namespace when its time to maintain OOBE.cpp/h
-namespace Helpers
-{
     bool WslGraphicsSupported()
     {
         // It's possible that we have only Subiquity instead of the Ubuntu-Desktop-Installer snap.

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -17,16 +17,13 @@
 
 #pragma once
 
-namespace Helpers
-{
-    // Returns true if WSLg is enabled and distro subsystem version is > 1.
-    bool WslGraphicsSupported();
-}
-
 namespace Oobe::internal
 {
     // Returns true if user system has WSLg enabled.
     inline bool isWslgEnabled();
+
+    // Returns true if WSLg is enabled and distro subsystem version is > 1.
+    bool WslGraphicsSupported();
 
     // Returns the subsystem version for this specific distro or 0 if failed.
     DWORD WslGetDistroSubsystemVersion();

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -31,6 +31,7 @@ namespace Oobe
             case LauncherForceMode::GuiForced:
                 return false;
             }
+            return false;
         }
 
         // Detect and act upon the launcher command file left by the OOBE.

--- a/DistroLauncher/installer_policy.h
+++ b/DistroLauncher/installer_policy.h
@@ -20,7 +20,17 @@ namespace Oobe
         // Returns true if the OOBE must be launched in text mode.
         static bool must_run_in_text_mode()
         {
-            return DistributionInfo::mustRunOOBEinTextMode();
+            LauncherForceMode forced = environmentForceMode();
+            switch (forced) {
+            case LauncherForceMode::Invalid:
+                [[fallthrough]];
+            case LauncherForceMode::Unset:
+                return !internal::WslGraphicsSupported();
+            case LauncherForceMode::TextForced:
+                return true;
+            case LauncherForceMode::GuiForced:
+                return false;
+            }
         }
 
         // Detect and act upon the launcher command file left by the OOBE.

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -44,6 +44,7 @@
 #include "algorithms.h"
 #include "expected.hpp"
 #include "not_null.h"
+#include "LauncherForceMode.h"
 #include "WslApiLoader.h"
 #include "Helpers.h"
 #include "DistributionInfo.h"


### PR DESCRIPTION
That variable is used to force a UI mode from the outside, before running the launcher. It's meant mainly for testability.

```cpp
    ///	0 or unset or invalid = autodetection
    ///	1 = text mode
    ///	2 = GUI mode.
```

It's use was located in the implementation of the function `mustRunOOBEinTextMode()` tightly coupled with detecting WSLg support. That function was in turn called by the `installer_policy.h` and the already dead `OOBESetup()` function.

The OOBE on Windows will have other requirements, but not WSLg, thus decoupling is necessary in order to preserve the env var semantics.

Thus, let's promote it to a "component" (its own thing) and decouple it from WSLg detection. The InstallerPolicy knows what to do if the variable is set or not, the same will be for the Windows OOBE application strategy.

This also clears out the consequently dead code plus a TODO around naming: moving the function `WslGraphicsSupported` to the `Oobe::internal` namespace, instead of  the `Helpers` one, which belongs to the upstream source code and functionality. That function usage is now limited to one single caller.
