### PR TITLE
Let SetOnceNamedEvent wait for confirmation

### DIFF
--- a/DistroLauncher/SetOnceNamedEvent.cpp
+++ b/DistroLauncher/SetOnceNamedEvent.cpp
@@ -42,9 +42,11 @@ namespace Win32Utils
         if (event == nullptr) {
             return false;
         }
-        if (SetEvent(event) == FALSE) {
+
+        if (SignalObjectAndWait(event, event, INFINITE, FALSE) != WAIT_OBJECT_0) {
             return false;
         }
+
         CloseHandle(event);
         event = nullptr;
         return true;


### PR DESCRIPTION
Calling SetEvent may return quickly enough so that the event HANDLE is closed without the other end receiving the notification.
SignalObjectAndWait let's us wait for the same event we are setting, so that we only proceed when the OS really delivered the notification.