### PR TITLE
New app strategy for ARM64 in the context of the new OOBE

### DIFF
--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -166,6 +166,7 @@
     <ClInclude Include="sudo.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Win32Utils.h" />
+    <ClInclude Include="WinTuiStrategy.h" />
     <ClInclude Include="WslApiLoader.h" />
     <ClInclude Include="expected.hpp" />
     <ClInclude Include="WSLInfo.h" />
@@ -196,6 +197,7 @@
     <ClCompile Include="upgrade_policy.cpp" />
     <ClCompile Include="Win32Utils.cpp" />
     <ClCompile Include="WindowsUserInfo.cpp" />
+    <ClCompile Include="WinTuiStrategy.cpp" />
     <ClCompile Include="WslApiLoader.cpp" />
     <ClCompile Include="WSLInfo.cpp" />
   </ItemGroup>

--- a/DistroLauncher/DistroLauncher.vcxproj.filters
+++ b/DistroLauncher/DistroLauncher.vcxproj.filters
@@ -105,6 +105,15 @@
     <ClInclude Include="NoSplashStrategy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="algorithms.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LauncherForceMode.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="WinTuiStrategy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DistroLauncher.cpp">
@@ -174,6 +183,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="NoSplashStrategy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="LauncherForceMode.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WinTuiStrategy.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DistroLauncher/WinTuiStrategy.cpp
+++ b/DistroLauncher/WinTuiStrategy.cpp
@@ -9,9 +9,9 @@ namespace Oobe
         return internal::do_autoinstall(installer, autoinstall_file);
     }
 
-    HRESULT WinTuiStrategy::do_install(Mode ui)
+    HRESULT WinTuiStrategy::do_install(Mode uiMode)
     {
-        if (ui == Mode::Gui) {
+        if (uiMode == Mode::Gui) {
             wprintf(L"GUI mode is not supported on this platform.\n");
         }
         return internal::install_linux_ui(installer, Mode::Text);

--- a/DistroLauncher/WinTuiStrategy.cpp
+++ b/DistroLauncher/WinTuiStrategy.cpp
@@ -1,0 +1,29 @@
+#include "stdafx.h"
+#include "ApplicationStrategyCommon.h"
+#include "WinTuiStrategy.h"
+
+namespace Oobe
+{
+    HRESULT WinTuiStrategy::do_autoinstall(const std::filesystem::path& autoinstall_file)
+    {
+        return internal::do_autoinstall(installer, autoinstall_file);
+    }
+
+    HRESULT WinTuiStrategy::do_install(Mode ui)
+    {
+        if (ui == Mode::Gui) {
+            wprintf(L"GUI mode is not supported on this platform.\n");
+        }
+        return internal::install_linux_ui(installer, Mode::Text);
+    }
+
+    HRESULT WinTuiStrategy::do_reconfigure()
+    {
+        return internal::reconfigure_linux_ui(installer);
+    }
+
+    void WinTuiStrategy::do_run_splash(bool hideConsole)
+    {
+        wprintf(L"This device architecture doesn't support running the splash screen.\n");
+    }
+}

--- a/DistroLauncher/WinTuiStrategy.cpp
+++ b/DistroLauncher/WinTuiStrategy.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "stdafx.h"
 #include "ApplicationStrategyCommon.h"
 #include "WinTuiStrategy.h"

--- a/DistroLauncher/WinTuiStrategy.h
+++ b/DistroLauncher/WinTuiStrategy.h
@@ -1,0 +1,48 @@
+#pragma once
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Oobe
+{
+    /// Concrete strategy implementation to fulfill the [Application] class for Windows platforms that don't support
+    /// running the Flutter OOBE. In such platforms only TUI and the upstream default experiences are offered because
+    /// the UDI snap has been replaced by Subiquity-only snap.
+    class WinTuiStrategy
+    {
+      public:
+        /// Places the sequence of events to make Subiquity perform an automatic installation.
+        /// Does not run the Flutter GUI (not even for the slide show).
+        HRESULT do_autoinstall(const std::filesystem::path& autoinstall_file);
+
+        /// Performs an interactive installation.
+        /// By default GUI support is checked before launching the OOBE.
+        HRESULT do_install(Mode ui);
+
+        /// Runs the reconfiguration variant of the Flutter GUI.
+        HRESULT do_reconfigure();
+
+        /// Triggers the console redirection and launch the OOBE slide show. Not supported by this strategy.
+        static void do_run_splash(bool hideConsole = false);
+
+        WinTuiStrategy() = default;
+        ~WinTuiStrategy() = default;
+
+      private:
+        InstallerController<> installer;
+    };
+
+}

--- a/DistroLauncher/WinTuiStrategy.h
+++ b/DistroLauncher/WinTuiStrategy.h
@@ -1,4 +1,3 @@
-#pragma once
 /*
  * Copyright (C) 2022 Canonical Ltd
  *
@@ -15,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 namespace Oobe
 {

--- a/DistroLauncher/WinTuiStrategy.h
+++ b/DistroLauncher/WinTuiStrategy.h
@@ -30,7 +30,7 @@ namespace Oobe
 
         /// Performs an interactive installation.
         /// By default GUI support is checked before launching the OOBE.
-        HRESULT do_install(Mode ui);
+        HRESULT do_install(Mode uiMode);
 
         /// Runs the reconfiguration variant of the Flutter GUI.
         HRESULT do_reconfigure();


### PR DESCRIPTION
It is expected that UDI snap will be replaced by Subiquity only.
Thus GUI will only be supported if Flutter is supported on Windows.
Thus, for ARM64, only TUI will be possible.
Although we could add some checks to the existing NoSplashStrategy,
I'd rather keep them orthogonal as other differences may be detected later on.

The next step is the x64 strategy, which is more complicated, thus I preferred to push on a separate PR.