### PR TITLE
Implements the WinOobeStrategy

### DIFF
--- a/DistroLauncher/ApplicationStrategy.h
+++ b/DistroLauncher/ApplicationStrategy.h
@@ -20,13 +20,26 @@
 #if defined _M_ARM64
 // The splash application is written in Dart/Flutter, which currently does not supported Windows ARM64 targets.
 // See: https://github.com/flutter/flutter/issues/62597
+#if defined WIN_OOBE_ENABLED
+#include "WinTuiStrategy.h"
+using DefaultAppStrategy = Oobe::WinTuiStrategy;
 
+#else // WIN_OOBE_ENABLED
 #include "NoSplashStrategy.h"
 using DefaultAppStrategy = Oobe::NoSplashStrategy;
 
+#endif // WIN_OOBE_ENABLED
+
 #else // _M_ARM64
 
+#if defined WIN_OOBE_ENABLED
+#include "WinOobeStrategy.h"
+using DefaultAppStrategy = Oobe::WinOobeStrategy;
+
+#else // WIN_OOBE_ENABLED
 #include "SplashEnabledStrategy.h"
 using DefaultAppStrategy = Oobe::SplashEnabledStrategy;
+
+#endif // WIN_OOBE_ENABLED
 
 #endif // _M_ARM64

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -167,6 +167,7 @@
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Win32Utils.h" />
     <ClInclude Include="WinTuiStrategy.h" />
+    <ClInclude Include="WinOobeStrategy.h" />
     <ClInclude Include="WslApiLoader.h" />
     <ClInclude Include="expected.hpp" />
     <ClInclude Include="WSLInfo.h" />
@@ -198,6 +199,7 @@
     <ClCompile Include="Win32Utils.cpp" />
     <ClCompile Include="WindowsUserInfo.cpp" />
     <ClCompile Include="WinTuiStrategy.cpp" />
+    <ClCompile Include="WinOobeStrategy.cpp" />
     <ClCompile Include="WslApiLoader.cpp" />
     <ClCompile Include="WSLInfo.cpp" />
   </ItemGroup>

--- a/DistroLauncher/DistroLauncher.vcxproj.filters
+++ b/DistroLauncher/DistroLauncher.vcxproj.filters
@@ -112,6 +112,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="WinTuiStrategy.h">
+    <ClInclude Include="WinOobeStrategy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -189,6 +190,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="WinTuiStrategy.cpp">
+    <ClCompile Include="WinOobeStrategy.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -15,7 +15,7 @@ namespace Oobe
         return Win32Utils::homedir() / L".wslconfig";
     }
 
-    std::wstring createEventName(const wchar_t const* suffix)
+    std::wstring createEventName(const wchar_t* const suffix)
     {
         return L"Local\\" + DistributionInfo::Name + L'-' + suffix;
     }
@@ -312,6 +312,7 @@ namespace Oobe
     WinOobeStrategy::WinOobeStrategy() :
         oobeExePath{getOobeExePath()}, hRegistrationEvent{createEventName(L"registered").c_str()},
         hCloseOobeEvent{createEventName(L"close-oobe").c_str()}, prefill{}
-    { }
+    {
+    }
 
 }

--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -1,0 +1,317 @@
+#include "stdafx.h"
+#include "ApplicationStrategyCommon.h"
+#include "WinOobeStrategy.h"
+
+namespace Oobe
+{
+
+    std::filesystem::path getOobeExePath()
+    {
+        return Win32Utils::thisAppRootdir() / L"ubuntu_wsl_setup.exe";
+    }
+
+    std::filesystem::path getWslConfigPath()
+    {
+        return Win32Utils::homedir() / L".wslconfig";
+    }
+
+    std::wstring createEventName(const wchar_t const* suffix)
+    {
+        return L"Local\\" + DistributionInfo::Name + L'-' + suffix;
+    }
+
+    // Checks the server status file for a successful exit and perform the required post-exit actions.
+    HRESULT serverExitStatusCheck()
+    {
+        if (internal::WslLaunchSuccess(L"grep -E 'DONE|EXITED' /run/subiquity/server-state")) {
+            ExitStatusHandling();
+            return S_OK;
+        }
+        return E_FAIL;
+    }
+
+    // Concatenates [args...] with the common base CLI to be able to run the OOBE in live run mode.
+    // [args...] must contain spaces and quotes and any other metacharacters required to build the command line.
+    // Sample result:
+    // ubuntu_wsl_setup.exe LR"( --no-dry-run --distro-name="Ubuntu-Preview" ) <args...>"
+    //                         |--------------- common cli ------------------|
+    template <typename... Streamable> std::wstring makeCli(Streamable&&... args)
+    {
+        const wchar_t baseCli[] = L" --no-dry-run --distro-name=";
+        return concat(baseCli, std::quoted(DistributionInfo::Name), L' ', std::forward<Streamable>(args)...);
+    }
+
+    // Detects what UI is supported and runs the appropriate callable supplied.
+    // That enables using the same mechanism to run the setup and reconfiguration workflows,
+    // since the requirements for running the OOBE won't change between them.
+    template <typename OnGui, typename OnTui, typename OnNone>
+    HRESULT run_on_autodetect_ui(OnGui onGui, OnTui onTui, OnNone onNone)
+    {
+        static_assert(std::is_convertible_v<OnGui, std::function<HRESULT()>>,
+                      "onGui callback must be a callable returning HRESULT with no arguments");
+        static_assert(std::is_convertible_v<OnTui, std::function<HRESULT()>>,
+                      "onTui callback must be a callable returning HRESULT with no arguments");
+        static_assert(std::is_convertible_v<OnNone, std::function<HRESULT()>>,
+                      "onNone callback must be a callable returning HRESULT with no arguments");
+
+        // No further checks if LAUNCHER_FORCE_MODE is set.
+        LauncherForceMode forced = environmentForceMode();
+        switch (forced) {
+        case LauncherForceMode::Invalid:
+            [[fallthrough]];
+        case LauncherForceMode::Unset:
+            break;
+        case LauncherForceMode::TextForced:
+            return onTui();
+        case LauncherForceMode::GuiForced:
+            return onGui();
+        }
+
+        // WSL 1 cannot mount the Subiquity snap, thus neither GUI nor TUI will be available.
+        if (Oobe::internal::WslGetDistroSubsystemVersion() < 2) {
+            return onNone();
+        }
+        // if none of the required snaps exist in the rootfs no UI will be available.
+        if (!internal::hasUdiSnap() && !internal::hasSubiquitySnap()) {
+            return onNone();
+        }
+
+        // if there is no way to boostrap the OOBE snap, no UI available.
+        if (!DistributionInfo::isOOBEAvailable()) {
+            return onNone();
+        }
+
+        // Without localhost forwarding, the OOBE will not be able to connect to the server.
+        // TUI mode is still supported.
+        if (!Oobe::internal::isLocalhostForwardingEnabled(getWslConfigPath())) {
+            return onTui();
+        }
+
+        // Otherwise, running the OOBE on Windows is supported. Platform is implied, since this strategy is selected at
+        // compile time based on whether the platform supports running the GUI app.
+        return onGui();
+    }
+
+    bool WslFileBuf::isEmpty() const
+    {
+        return contents.empty();
+    }
+
+    bool WslFileBuf::write() const
+    {
+        const auto path = WindowsPath(linuxPath);
+        std::ofstream file;
+        file.open(path.string(), std::ios::ate);
+        if (file.fail()) {
+            return false;
+        }
+        file << contents;
+        file.close();
+        return !file.fail();
+    }
+
+    HRESULT Oobe::WinOobeStrategy::do_tui_reconfigure()
+    {
+        return Oobe::internal::reconfigure_linux_ui(installer);
+    }
+
+    HRESULT WinOobeStrategy::do_gui_reconfigure()
+    {
+        // The OOBE process must not be previously created.
+        assert(!oobeProcess.has_value());
+        const auto cli = makeCli(L"--reconfigure");
+        oobeProcess.emplace(oobeExePath, cli.c_str(), nullptr, nullptr, nullptr);
+        if (!oobeProcess.has_value()) {
+            return E_UNEXPECTED;
+        }
+        auto& oobe = oobeProcess.value();
+        if (!oobe.start()) {
+            return E_APPLICATION_ACTIVATION_EXEC_FAILURE;
+        }
+
+        if (!hRegistrationEvent.set()) {
+            do_close_oobe();
+            return EVENT_E_USER_EXCEPTION;
+        }
+        if (oobe.waitExitSync() != 0) {
+            return E_FAIL;
+        }
+        return S_OK;
+    }
+
+    HRESULT Oobe::WinOobeStrategy::do_reconfigure()
+    {
+        // Preserving the same semantics as the previous OOBE, there is no UI mode CLI parameter for reconfiguration,
+        // thus always relying on GUI support auto detection. The environment variable can still influence the decision.
+        return run_on_autodetect_ui([this] { return do_gui_reconfigure(); }, [this] { return do_tui_reconfigure(); },
+                                    [] { return E_NOTIMPL; });
+    }
+
+    HRESULT WinOobeStrategy::do_autoinstall(const std::filesystem::path& autoinstall_file)
+    {
+        return Oobe::internal::do_autoinstall(installer, autoinstall_file);
+    }
+
+    void WinOobeStrategy::do_show_console()
+    {
+        if (!consoleService.has_value()) {
+            return;
+        }
+        std::unique_lock<std::timed_mutex> guard{consoleGuard, std::defer_lock};
+        using namespace std::chrono_literals;
+        constexpr auto tryLockTimeout = 5s;
+        if (!guard.try_lock_for(tryLockTimeout)) {
+            wprintf(L"Failed to lock console state for modification. Somebody else is holding the lock.\n");
+            return;
+        }
+
+        consoleService.value().restoreConsole();
+        if (!consoleIsVisible) {
+            consoleIsVisible = consoleService.value().showConsoleWindow();
+        }
+    }
+
+    void WinOobeStrategy::do_close_oobe()
+    {
+        do_show_console();
+        if (splashIsRunning) {
+            oobeProcess.value().unsubscribe();
+            if (!hCloseOobeEvent.set()) {
+                oobeProcess.value().terminate();
+                oobeProcess.reset();
+            }
+            splashIsRunning = false;
+        }
+    }
+
+    HRESULT WinOobeStrategy::do_install(Mode uiMode)
+    {
+        // Preserving the same semantics as the previous OOBE, command line takes precendence over the environment
+        // variable, only checked if the UI mode CLI parameter is not passed.
+        switch (uiMode) {
+        case Mode::AutoDetect:
+            return run_on_autodetect_ui([this] { return do_gui_install(); }, [this] { return do_tui_install(); },
+                                        [] { return E_NOTIMPL; });
+        case Mode::Text:
+            return do_tui_install();
+
+        case Mode::Gui:
+            return do_gui_install();
+        }
+        return E_INVALIDARG;
+    }
+
+    HRESULT WinOobeStrategy::do_gui_install()
+    {
+        if (!prefill.isEmpty()) {
+            prefill.write();
+        }
+
+        if (!hRegistrationEvent.set()) {
+            do_close_oobe();
+            return EVENT_E_USER_EXCEPTION;
+        }
+
+        if (oobeProcess.value().waitExitSync() != 0) {
+            return E_FAIL;
+        }
+
+        return S_OK;
+    }
+
+    HRESULT WinOobeStrategy::do_tui_install()
+    {
+        std::array<InstallerController<>::Event, 3> eventSequence{
+          InstallerController<>::Events::InteractiveInstall{Mode::Text},
+          InstallerController<>::Events::StartInstaller{}, InstallerController<>::Events::BlockOnInstaller{}};
+        HRESULT hr = E_NOTIMPL;
+        for (auto& event : eventSequence) {
+            auto ok = installer.sm.addEvent(event);
+
+            // unexpected transition occurred here?
+            if (!ok.has_value()) {
+                do_close_oobe();
+                return hr;
+            }
+
+            std::visit(internal::overloaded{
+                         [&](InstallerController<>::States::PreparedTui&) { do_show_console(); },
+                         [&](InstallerController<>::States::Ready&) { do_close_oobe(); },
+                         [&](InstallerController<>::States::Success&) { hr = S_OK; },
+                         [&](InstallerController<>::States::UpstreamDefaultInstall& state) {
+                             do_show_console();
+                             hr = state.hr;
+                         },
+                         [&](auto&&...) { hr = E_UNEXPECTED; },
+                       },
+                       ok.value());
+        }
+
+        return hr;
+    }
+
+    void WinOobeStrategy::do_run_splash(bool hideConsole)
+    {
+        if (!std::filesystem::exists(oobeExePath)) {
+            wprintf(L"OOBE executable [%s] not found.\n", oobeExePath.c_str());
+            return;
+        }
+
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        auto pipe = Win32Utils::makeNamedPipe(true, false, std::to_wstring(now.count()));
+        if (!pipe.has_value()) {
+            wprintf(L"Unable to prepare for the execution of the OOBE. Error: %s.\n", pipe.error().c_str());
+            return;
+        }
+
+        // Even though pipe will be moved soon, the handle is just a pointer value, it won't change or invalidate
+        // after moving to another owner.
+        consoleReadHandle = pipe.value().readHandle();
+        consoleService.emplace(std::move(pipe.value()));
+        if (!consoleService.has_value()) {
+            wprintf(L"Failed to prepare the console configuration.\n");
+            return;
+        }
+        auto& console = consoleService.value();
+
+        std::unique_lock<std::timed_mutex> guard{consoleGuard, std::defer_lock};
+        using namespace std::chrono_literals;
+        constexpr auto tryLockTimeout = 5s;
+        if (!guard.try_lock_for(tryLockTimeout)) {
+            wprintf(L"Failed to lock console state for modification. Somebody else is holding the lock.\n");
+            return;
+        }
+
+        console.redirectConsole();
+
+        prefill = WslFileBuf{DistributionInfo::GetPrefillInfoInYaml(), L"/var/log/prefill-system-setup.yaml"};
+        const auto cli{prefill.isEmpty() ? makeCli() : makeCli(L" --prefill=", prefill.linuxPath)};
+
+        oobeProcess.emplace(oobeExePath, cli.c_str(), nullptr, consoleReadHandle, nullptr);
+        if (!oobeProcess.has_value()) {
+            // rollback.
+            console.restoreConsole();
+            return;
+        }
+        auto& process = oobeProcess.value();
+        // The GUI consumes the messages printed to this process stdout.
+        // If it dies without this process restoring its console, the next wprintf call would deadlock.
+        process.setListener([this]() { do_show_console(); });
+        if (!process.start()) {
+            // rollback.
+            console.restoreConsole();
+            return;
+        }
+
+        if (hideConsole) {
+            consoleIsVisible = !console.hideConsoleWindow();
+        }
+        splashIsRunning = true;
+    }
+
+    WinOobeStrategy::WinOobeStrategy() :
+        oobeExePath{getOobeExePath()}, hRegistrationEvent{createEventName(L"registered").c_str()},
+        hCloseOobeEvent{createEventName(L"close-oobe").c_str()}, prefill{}
+    { }
+
+}

--- a/DistroLauncher/WinOobeStrategy.h
+++ b/DistroLauncher/WinOobeStrategy.h
@@ -1,0 +1,104 @@
+#pragma once
+#include <mutex>
+#include "state_machine.h"
+#include "installer_policy.h"
+#include "installer_controller.h"
+#include "local_named_pipe.h"
+#include "console_service.h"
+#include "ChildProcess.h"
+#include "SetOnceNamedEvent.h"
+
+namespace Oobe
+{
+    using Mode = InstallerController<>::Mode;
+    using ChildProcess = ChildProcessInterface<Win32ChildProcess>;
+
+    /// Small buffer for files inside the distro used to delay writing the file to disk from generating its contents.
+    struct WslFileBuf
+    {
+        /// Buffer for the file contents.
+        std::string contents;
+
+        /// The full path of the file inside the distro, without the WSL prefix.
+        std::filesystem::path linuxPath;
+
+        /// Writes the file to disk.
+        bool write() const;
+
+        /// Returns true if this buffer is empty.
+        bool isEmpty() const;
+    };
+
+    /// Concrete strategy implementation to fulfill the [Application] class that supports running the Flutter OOBE on
+    /// Windows. No dependency on WSLg.
+    class WinOobeStrategy
+    {
+      public:
+        /// Places the sequence of events to make Subiquity perform an automatic installation.
+        /// Does not run the Flutter GUI (not even for the slide show).
+        HRESULT do_autoinstall(const std::filesystem::path& autoinstall_file);
+
+        /// Performs an interactive installation.
+        /// By default GUI support is checked before launching the OOBE.
+        HRESULT do_install(Mode uiMode);
+
+        /// Runs the reconfiguration variant of the Flutter GUI.
+        HRESULT do_reconfigure();
+
+        /// Triggers the console redirection and launch the OOBE slide show.
+        void do_run_splash(bool hideConsole = false);
+
+        WinOobeStrategy();
+        ~WinOobeStrategy() = default;
+
+      private:
+        // The Flutter OOBE executable file path.
+        std::filesystem::path oobeExePath;
+        // It's process manager instance.
+        std::optional<ChildProcess> oobeProcess;
+        // Named event set upon distro registration detected complete.
+        Win32Utils::SetOnceNamedEvent hRegistrationEvent;
+        // Named event set to request the OOBE to quit.
+        Win32Utils::SetOnceNamedEvent hCloseOobeEvent;
+        // This mutex must be acquired before calling ConsoleService::redirectConsole() and
+        // ConsoleService::restoreConsole() because those calls may run concurrently with another thread as documented
+        // in [ChildProcess].
+        std::timed_mutex consoleGuard;
+        bool consoleIsVisible = true;
+        bool splashIsRunning = false;
+
+        // The controller for running the installer inside Linux. For this strategy that's only used for Subiquity TUI.
+        InstallerController<> installer;
+
+        // The handle to the read end of the named pipe that will act as the OOBE stdin.
+        HANDLE consoleReadHandle = nullptr;
+
+        // Instance of the console service able to redirect this process stdout to the named pipe that will be read
+        // through [consoleReadHandle]
+        std::optional<Win32Utils::ConsoleService<Win32Utils::LocalNamedPipe>> consoleService;
+
+        // User information acquired from Windows to populate the GUI during setup. Those contents must be made
+        // available to Subiquity as a file and passed to its command line. Since the GUI is responsible for generating
+        // the server command line, it needs to know upfront whether there will be contents to pass to the server.
+        WslFileBuf prefill;
+
+        /// Restores the console context, which means undo the console redirection and making the window visible.
+        void do_show_console();
+
+        /// Notifies the splash controller to quit the application. Console restoration is immediately requested to
+        /// prevent leaving the launcher process without a stdout consumer.
+        void do_close_oobe();
+
+        /// Runs the Subiquity TUI if the user requested it from command line.
+        HRESULT do_tui_install();
+
+        /// Runs the setup variant of Flutter OOBE on Windows.
+        HRESULT do_gui_install();
+
+        /// Runs the reconfiguration variant of the Flutter GUI.
+        HRESULT do_gui_reconfigure();
+
+        /// Runs the reconfiguration variant of the Subiquity TUI.
+        HRESULT do_tui_reconfigure();
+    };
+}


### PR DESCRIPTION
## Abstract

Complementary to #254 , this PR implements the component will feed the Application class with the behavior necessary to run the OOBE on Windows. No dependency on WSLg. Requires x64 platform.

Choosing the app strategy now depends on:

- the platform set by the compiler
- the definition of WIN_OOBE_ENABLED constant (not yet defined anywhere, thus this won't affect 22.04.1 release).

Since the top-level `Application<>` class remains the same both the supported command line and its semantics must be preserved.

## Explanation

### TUI

Terminal user interface support is still required because there are still situations only detectable during runtime that may prevent running the new OOBE, such as user disabling WSL2 localhost forwarding in `~\.wslconfig`. Achieving TUI support is very similar to what is done in `SplashEnabledStrategy`, with the need to present the splash and close it when the TUI is ready for interaction. Thus, the `InstallerController` component is reused as is, even though it can only be used in TUI mode. In the near future we will be able to further reduce its functionality when we completely drop support for running the OOBE thrrough WSLg, but that's topic for another cycle, when we would be sure it won't be anymore necessary.

### GUI

#### Command line
As with SplashEnabledStrategy, this component must offer the slide show (aka splash) and control the installer. As the OOBE on Windows is merged with the slide show as a single app, the installer is started at the `do_run_splash()` method. That means that the required command line must be known at that moment. `makeCli()` thus enables creating the command line for the OOBE by ensuring a minimal stem concatenated with further options passed as parameters. The command line for the setup may have an optional `--prefil` option, if the launcher succesfully acquire some user information necessary to prefill the UI fields during setup (user name and language). In such scenario we fill a file buffer with that information before starting the OOBE and write its contents into the rootfs after registration.

#### Setup versus Reconfiguration
`do_run_splash()` only runs for the WSL setup variant. The same application is also used for the reconfiguration variant. So, `do_reconfigure()` must be able to start the OOBE process as well, with different command line options. `do_run_splash()` and `do_reconfigure()` are never called in the same run of the launcher. In that situation, there is no need for the slide show, as the distro is already registered, but that's handled in the Flutter code.

The runtime requirements for both variants are the same but their behaviors are very different, so the function `run_on_autodetect_ui()` provides selecting which UI to run and accept callables with the different behaviors that must be achieved.

Setup UI can be selected via launcher command line (via the option `--ui`) as well as by setting the `LAUNCHER_FORCE_MODE` environment variable (reading it is part of the autodetection routine). For simplicity it was decided in the past that we wouldn't support the `--ui` option in reconfiguration, but instead rely on autodetection. That remains.

#### Server control and monitoring

In GUI mode everything server-related is done by Flutter. This is a great point of simplification, since we don't need to start it, spawn small processes to watch its startup and timeout after some attempts. Timeout heuristics are always questionable.

#### GUI Startup and IPC

The slide show reads text from standard input that comes from the launcher's stdout to monitor for errors, as before. Launcher is responsible for piping stdout to the child process stdin to make that possible. The same `ConsoleService` used in`SplashEnabledStrategy` fed by a named pipe is used for that.

Additionally, the launcher must notify the child process of the suitable moment to start the server (after registration is complete) and request it to gracefully quit, if TUI is required instead of GUI, for instance. Both behaviors are achieved by using distinct `SetOnceNamedEvent`s created before running the OOBE and set when (and if) necessary. Closing the OOBE window is achieved by setting one named event (support for that is landing in https://github.com/canonical/ubuntu-desktop-installer/pull/1032).

## Trying out

Playing with this requires cloning https://github.com/canonical/ubuntu-desktop-installer somewhere, compiling the Windows entry point of the ubuntu_wsl_setup package, copying the generated artifacts into this repository build folder (`x64\Debug` for instance) and passing the `WIN_OOEB_ENABLED` definition during compilation. Quite complicated for now, but my next PRs will address that complexity by bringing UDI as a submodule and tweaking the build system to select and build the correct submodule automatically as well as defining the constant.

```
cd <this-repository-root-dir>
git clone https://github.com/canonical/ubuntu-desktop-installer UDI
cd UDI/packages/ubuntu_wsl_setup
flutter pub get
flutter build windows -t lib/main_win.dart --release
copy build/windows/runner/Release/* <this-repository-root-dir>/x64/Debug
cd <this-repository-root-dir>
.\DistroLauncher.sln
```
Set WIN_OOBE_ENABLED in the IDE GUI and debug it as you would.