### PR TITLE
No need for the registration event in reconfiguration workflow

### DIFF
--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -129,10 +129,6 @@ namespace Oobe
             return E_APPLICATION_ACTIVATION_EXEC_FAILURE;
         }
 
-        if (!hRegistrationEvent.set()) {
-            do_close_oobe();
-            return EVENT_E_USER_EXCEPTION;
-        }
         if (oobeProcess->waitExitSync() != 0) {
             return E_FAIL;
         }


### PR DESCRIPTION
In the reconfiguration worflow the OOBE must be able to start the Subiquity server as soon as possible. There is no need to wait for the registration event to be set. Setting it is harmless, but should not necessary. There was an issue in the OOBE, though, preventing it to start the server without the event being set. It's being adressed by: https://github.com/canonical/ubuntu-desktop-installer/pull/1035