### PR TITLE
Traverse the filesystem only once when looking for UDI and Subiquity snaps.

### DIFF
--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -141,7 +141,7 @@ namespace Oobe::internal
     {
         namespace fs = std::filesystem;
         const auto path = Oobe::WindowsPath(fs::path{L"/var/lib/snapd/snaps/"});
-        return find_file_if(path, [name](const auto& entry) {
+        return any_file_of(path, [name](const auto& entry) {
             return fs::is_regular_file(entry) && starts_with({entry.path().filename().wstring()}, name);
         });
     }

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -142,7 +142,8 @@ namespace Oobe::internal
         namespace fs = std::filesystem;
         const auto path = Oobe::WindowsPath(fs::path{L"/var/lib/snapd/snaps/"});
         return any_file_of(path, [name](const auto& entry) {
-            return fs::is_regular_file(entry) && starts_with({entry.path().filename().wstring()}, name);
+            const std::wstring_view filename{entry.path().filename().wstring()};
+            return fs::is_regular_file(entry) && starts_with(filename, name) && ends_with(filename, {L"snap"});
         });
     }
 

--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -47,6 +47,7 @@ namespace Oobe
     template <typename OnGui, typename OnTui, typename OnNone>
     HRESULT run_on_autodetect_ui(OnGui onGui, OnTui onTui, OnNone onNone)
     {
+        using namespace std::literals::string_view_literals;
         static_assert(std::is_convertible_v<OnGui, std::function<HRESULT()>>,
                       "onGui callback must be a callable returning HRESULT with no arguments");
         static_assert(std::is_convertible_v<OnTui, std::function<HRESULT()>>,
@@ -72,7 +73,7 @@ namespace Oobe
             return onNone();
         }
         // if none of the required snaps exist in the rootfs no UI will be available.
-        if (!internal::hasUdiSnap() && !internal::hasSubiquitySnap()) {
+        if (!internal::hasAnyOfSnaps(L"ubuntu-desktop-installer"sv, L"subiquity"sv)) {
             return onNone();
         }
 

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -75,3 +75,11 @@ template <typename Pred> bool any_file_of(const std::filesystem::path& directory
     }
     return std::find_if(begin(listing), end(listing), std::forward<Pred>(pred)) != end(listing);
 }
+
+// Pushes back to the vector [v] as many elements to a vector as [args] count by folding subsequent calls to
+// v.push_back().
+template <typename T, typename... Args> void push_back_many(std::vector<T>& vec, Args&&... args)
+{
+    static_assert((std::is_constructible_v<T, Args&&> && ...));
+    (vec.push_back(std::forward<Args>(args)), ...);
+}

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -81,5 +81,6 @@ template <typename Pred> bool any_file_of(const std::filesystem::path& directory
 template <typename T, typename... Args> void push_back_many(std::vector<T>& vec, Args&&... args)
 {
     static_assert((std::is_constructible_v<T, Args&&> && ...));
+    vec.reserve(vec.size() + sizeof...(args));
     (vec.push_back(std::forward<Args>(args)), ...);
 }

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -20,6 +20,7 @@
 
 /// Returns true if [tested] starts with [end]. Null-termination is not required.
 template <typename CharT>
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) - Parameters must have the same type.
 bool starts_with(const std::basic_string_view<CharT> tested, const std::basic_string_view<CharT> start)
 {
     if (tested.size() < start.size()) {
@@ -37,6 +38,7 @@ bool starts_with(CharT const (&tested)[TestedSize], CharT const (&start)[StartSi
 
 /// Returns true if [tested] ends with [end]. Null-termination is not required.
 template <typename CharT>
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) - Parameters must have the same type.
 bool ends_with(const std::basic_string_view<CharT> tested, const std::basic_string_view<CharT> end)
 {
     if (tested.size() < end.size()) {

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -62,7 +62,7 @@ template <typename... Args> std::wstring concat(Args&&... args)
 /// Returns true for the first entry of [directory] for which [pred] returns true.
 /// Returns false if none of the entries match the predicate.
 /// Iteration order is not specified.
-template <typename Pred> bool find_file_if(const std::filesystem::path& directory, Pred&& pred)
+template <typename Pred> bool any_file_of(const std::filesystem::path& directory, Pred&& pred)
 {
     namespace fs = std::filesystem;
     std::error_code error;

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -16,8 +16,9 @@
  *
  */
 
-// Common algorithms to be used everywhere in the launcher project with style resembling the std ones.
+/// Common algorithms to be used everywhere in the launcher project with style resembling the std ones.
 
+/// Returns true if [tested] starts with [end]. Null-termination is not required.
 template <typename CharT>
 bool starts_with(const std::basic_string_view<CharT> tested, const std::basic_string_view<CharT> start)
 {
@@ -34,6 +35,7 @@ bool starts_with(CharT const (&tested)[TestedSize], CharT const (&start)[StartSi
     return starts_with<CharT>(std::basic_string_view<CharT>{tested}, std::basic_string_view<CharT>{start});
 }
 
+/// Returns true if [tested] ends with [end]. Null-termination is not required.
 template <typename CharT>
 bool ends_with(const std::basic_string_view<CharT> tested, const std::basic_string_view<CharT> end)
 {
@@ -57,6 +59,9 @@ template <typename... Args> std::wstring concat(Args&&... args)
     return buffer.str();
 }
 
+/// Returns true for the first entry of [directory] for which [pred] returns true.
+/// Returns false if none of the entries match the predicate.
+/// Iteration order is not specified.
 template <typename Pred> bool find_file_if(const std::filesystem::path& directory, Pred&& pred)
 {
     namespace fs = std::filesystem;


### PR DESCRIPTION
Here is the key of this PR:

```diff
        // if none of the required snaps exist in the rootfs no UI will be available.
-        if (!internal::hasUdiSnap() && !internal::hasSubiquitySnap()) {
+        if (!internal::hasAnyOfSnaps(L"ubuntu-desktop-installer"sv, L"subiquity"sv)) {
```

For that to be possible, `hasAnyOfSnaps()` has to be implemented as a template function that can accept a variadic number of `string_view` arguments and applies the existing algorithms to find entries inside the snap directory matching one of the supplied arguments. Since that receives a variadic argument in order to nicely compose `find_file_if` and `std::any_of` we put together a `push_back_many` algorithm that populates a vector of string_views from a variadic argument list.

BTW, `find_file_if` returns a bool instead of iterator, so more like `std::any_of` than `std::find_if`, thus the function was renamed to `any_file_of`.

And since there were some documentation comments lacking on the `algorithms.h` header and some unevitable linter complains about parameters of the same type in `starts/ends_with` algorithms, I put some comments to stop linter at those lines.

I think it is easier to review this PR commit by commit.