### PR TITLE
Refactored starts_with and ends_with

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -102,7 +102,6 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="SplashControllerTests.cpp" />
     <ClCompile Include="StateMachineTests.cpp" />
     <ClCompile Include="sudo_tests.cpp" />
-    <ClCompile Include="upgrade_policy_tests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -86,6 +86,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="..\..\DistroLauncher\WindowsUserInfo.cpp" />
     <ClCompile Include="..\..\DistroLauncher\WslApiLoader.cpp" />
     <ClCompile Include="..\..\DistroLauncher\WSLInfo.cpp" />
+    <ClCompile Include="algorithms_tests.cpp" />
     <ClCompile Include="ChildProcessTests.cpp" />
     <ClCompile Include="ConsoleServiceTests.cpp" />
     <ClCompile Include="ExtendedCliParserTests.cpp" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="..\..\DistroLauncher\LauncherForceMode.cpp" />
     <ClCompile Include="LauncherForceModeTests.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ApplicationStrategyCommon.cpp" />
+    <ClCompile Include="algorithms_tests.cpp">
+      <Filter>TestSources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="InstallerControllerTestPolicies.h" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -58,6 +58,27 @@ TEST(AlgorithmTests, StartsEndsWithExtra)
 
     ASSERT_FALSE(starts_with(vec_1, arr_2));
     ASSERT_TRUE(ends_with(vec_1, arr_2));
+
+    int carray[] = {1, 1, 2, 3, 5, 8, 13};
+    ASSERT_TRUE(starts_with(carray, arr_1));
+    ASSERT_FALSE(ends_with(carray, arr_1));
+
+    ASSERT_FALSE(starts_with(carray, arr_2));
+    ASSERT_TRUE(ends_with(carray, arr_2));
+
+    int* cvector = carray;
+    ASSERT_TRUE(starts_with(cvector, arr_1));
+    ASSERT_FALSE(ends_with(cvector, arr_1));
+
+    ASSERT_FALSE(starts_with(cvector, arr_2));
+    ASSERT_TRUE(ends_with(cvector, arr_2));
+
+    const int* c_const_vector = carray;
+    ASSERT_TRUE(starts_with(c_const_vector, arr_1));
+    ASSERT_FALSE(ends_with(c_const_vector, arr_1));
+
+    ASSERT_FALSE(starts_with(c_const_vector, arr_2));
+    ASSERT_TRUE(ends_with(c_const_vector, arr_2));
 }
 
 TEST(AlgorithmTests, Concat)

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -65,8 +65,6 @@ TEST(AlgorithmTests, StartsEndsWithExtra)
 
     ASSERT_FALSE(starts_with(carray, arr_2));
     ASSERT_TRUE(ends_with(carray, arr_2));
-
-    starts_with(L"Hi! How are you?", "Hi!");
 }
 
 TEST(AlgorithmTests, Concat)

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -65,6 +65,12 @@ TEST(AlgorithmTests, StartsEndsWithExtra)
 
     ASSERT_FALSE(starts_with(carray, arr_2));
     ASSERT_TRUE(ends_with(carray, arr_2));
+
+    char str_1[] = "Is";
+    ASSERT_TRUE(starts_with("Is this the real life?", str_1));
+    
+    char str_2[] = "Is this just fantasy?";
+    ASSERT_TRUE(ends_with(str_2, "fantasy?"));
 }
 
 TEST(AlgorithmTests, Concat)

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -17,8 +17,9 @@
 
 #include "stdafx.h"
 #include "gtest/gtest.h"
+#include "mock_api.h"
 
-TEST(UpgradePolicyTests, StringParsing)
+TEST(AlgorithmTests, StartsWith)
 {
     ASSERT_FALSE(starts_with(L"", L"hello"));
     ASSERT_FALSE(starts_with(L"he", L"hello"));
@@ -26,7 +27,14 @@ TEST(UpgradePolicyTests, StringParsing)
     ASSERT_TRUE(starts_with(L"hello, world!", L"hello"));
     ASSERT_FALSE(starts_with(L"cheers, world!", L"hello"));
     ASSERT_FALSE(starts_with(L"HELLO", L"hello"));
+    ASSERT_FALSE(starts_with(L"", L"Ubuntu"));
 
+    const std::wstring test_str{L"Ubuntu 22.04.1 LTS"};
+    ASSERT_TRUE(starts_with(test_str, L"Ubuntu"));
+}
+
+TEST(AlgorithmTests, EndsWith)
+{
     ASSERT_FALSE(ends_with(L"", L"world!"));
     ASSERT_FALSE(ends_with(L"d!", L"world!"));
     ASSERT_TRUE(ends_with(L"world!", L"world!"));
@@ -35,12 +43,24 @@ TEST(UpgradePolicyTests, StringParsing)
     ASSERT_FALSE(ends_with(L"this string is completely diferent", L"world!"));
     ASSERT_FALSE(ends_with(L"HELLO", L"hello"));
 
-    ASSERT_FALSE(starts_with(L"", L"Ubuntu"));
-    ASSERT_TRUE(starts_with(L"Ubuntu 22.04.1 LTS", L"Ubuntu"));
-    ASSERT_TRUE(ends_with(L"Ubuntu 22.04.1 LTS", L"LTS"));
+    const std::wstring test_str{L"Ubuntu 22.04.1 LTS"};
+    ASSERT_TRUE(ends_with(test_str, L"LTS"));
 }
 
-TEST(UpgradePolicyTests, Concat)
+TEST(AlgorithmTests, StartsEndsWithExtra)
+{
+    const std::vector<int> vec_1{1, 1, 2, 3, 5, 8, 13};
+    const std::array<int, 3> arr_1{1, 1, 2};
+    const std::array<int, 3> arr_2{5, 8, 13};
+
+    ASSERT_TRUE(starts_with(vec_1, arr_1));
+    ASSERT_FALSE(ends_with(vec_1, arr_1));
+
+    ASSERT_FALSE(starts_with(vec_1, arr_2));
+    ASSERT_TRUE(ends_with(vec_1, arr_2));
+}
+
+TEST(AlgorithmTests, Concat)
 {
     // Checking default functionality
     std::wstring dog = L"dog";

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -68,7 +68,7 @@ TEST(AlgorithmTests, StartsEndsWithExtra)
 
     char str_1[] = "Is";
     ASSERT_TRUE(starts_with("Is this the real life?", str_1));
-    
+
     char str_2[] = "Is this just fantasy?";
     ASSERT_TRUE(ends_with(str_2, "fantasy?"));
 }

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -66,19 +66,7 @@ TEST(AlgorithmTests, StartsEndsWithExtra)
     ASSERT_FALSE(starts_with(carray, arr_2));
     ASSERT_TRUE(ends_with(carray, arr_2));
 
-    int* cvector = carray;
-    ASSERT_TRUE(starts_with(cvector, arr_1));
-    ASSERT_FALSE(ends_with(cvector, arr_1));
-
-    ASSERT_FALSE(starts_with(cvector, arr_2));
-    ASSERT_TRUE(ends_with(cvector, arr_2));
-
-    const int* c_const_vector = carray;
-    ASSERT_TRUE(starts_with(c_const_vector, arr_1));
-    ASSERT_FALSE(ends_with(c_const_vector, arr_1));
-
-    ASSERT_FALSE(starts_with(c_const_vector, arr_2));
-    ASSERT_TRUE(ends_with(c_const_vector, arr_2));
+    starts_with(L"Hi! How are you?", "Hi!");
 }
 
 TEST(AlgorithmTests, Concat)

--- a/DistroLauncher/DistroLauncher.vcxproj.filters
+++ b/DistroLauncher/DistroLauncher.vcxproj.filters
@@ -105,6 +105,12 @@
     <ClInclude Include="NoSplashStrategy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="algorithms.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LauncherForceMode.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DistroLauncher.cpp">
@@ -174,6 +180,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="NoSplashStrategy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="LauncherForceMode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/DistroLauncher/WSLInfo.cpp
+++ b/DistroLauncher/WSLInfo.cpp
@@ -142,7 +142,7 @@ namespace Oobe::internal
         namespace fs = std::filesystem;
         const auto path = Oobe::WindowsPath(fs::path{L"/var/lib/snapd/snaps/"});
         return find_file_if(path, [name](const auto& entry) {
-            return fs::is_regular_file(entry) && starts_with({entry.path().filename().wstring()}, name);
+            return fs::is_regular_file(entry) && starts_with(entry.path().filename().wstring(), name);
         });
     }
 

--- a/DistroLauncher/WSLInfo.h
+++ b/DistroLauncher/WSLInfo.h
@@ -59,7 +59,6 @@ namespace Oobe::internal
     /// Returns true if the there is any snap matching of one the [names] inside the rootfs.
     template <typename... StringLike> bool hasAnyOfSnaps(StringLike&&... names)
     {
-        using namespace std::literals::string_view_literals;
         std::vector<std::wstring_view> elements;
         push_back_many(elements, std::forward<StringLike>(names)...);
 
@@ -72,7 +71,7 @@ namespace Oobe::internal
             }
             const std::wstring filename{entry.path().filename().wstring()};
             return std::any_of(std::begin(elements), std::end(elements), [&filename](const auto& element) {
-                return starts_with(filename, element) && ends_with(filename, L".snap"sv);
+                return starts_with(filename, element) && ends_with(filename, L".snap");
             });
         });
     }

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -52,6 +52,7 @@ namespace algo_internal
     }
 
     template <typename IteratorTested, typename IteratorCompare>
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) - Parameters must have the same type.
     bool starts_with_impl(IteratorTested tested_begin, IteratorTested tested_end, IteratorCompare compare_begin,
                           IteratorCompare compare_end)
     {

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -39,10 +39,11 @@ namespace algo_internal
         return value;
     }
 
-    template <std::size_t Size, typename T> constexpr auto view_adaptor(const T value[Size])
+    template <std::size_t Size, typename T>
+    constexpr std::enable_if_t<!is_character<T>(), std::basic_string_view<T>> view_adaptor(const T value[Size])
     {
         // In c++20, switch to std::span
-        return std::basic_string_view<const T>(value, Size);
+        return std::basic_string_view<T>(value, Size);
     }
 
     template <typename CharT>

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -56,7 +56,7 @@ namespace algo_internal
     bool starts_with_impl(IteratorTested tested_begin, IteratorTested tested_end, IteratorCompare compare_begin,
                           IteratorCompare compare_end)
     {
-        using tested_type = std::iterator_traits<IteratorTested>::value_type;
+        using tested_type = typename std::iterator_traits<IteratorTested>::value_type;
         using compare_type = std::iterator_traits<IteratorCompare>::value_type;
 
         if constexpr (is_character<tested_type>() || is_character<compare_type>()) {

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -52,7 +52,7 @@ namespace algo_internal
         return value;
     }
 
-    template <typename T> constexpr std::enable_if_t<!is_character<T>(), T const*> string_adaptor(T* value)
+    template <typename T> constexpr std::enable_if_t<!is_character<T>(), T const*> string_adaptor(T const* value)
     {
         return value;
     }

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -57,7 +57,7 @@ namespace algo_internal
                           IteratorCompare compare_end)
     {
         using tested_type = typename std::iterator_traits<IteratorTested>::value_type;
-        using compare_type = std::iterator_traits<IteratorCompare>::value_type;
+        using compare_type = typename std::iterator_traits<IteratorCompare>::value_type;
 
         if constexpr (is_character<tested_type>() || is_character<compare_type>()) {
             static_assert(std::is_same_v<tested_type, compare_type>,

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -25,7 +25,7 @@ namespace algo_internal
     {
         return (std::is_same_v<T, Args> || ...);
     }
-    
+
     // Tells chars appart from other types
     template <typename T> constexpr bool is_character() noexcept
     {

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -39,7 +39,7 @@ namespace algo_internal
      * - CharT* into basic_string_view<CharT>
      * - Anything else stays the same
      */
-    template <typename T> constexpr T const& view_adaptor(T const& value)
+    template <typename T> constexpr T const& view_adaptor(const T& value)
     {
         return value;
     }
@@ -82,7 +82,7 @@ namespace algo_internal
 
 /// Returns true if [tested] starts with [start].
 template <typename RangeTested, typename RangeCompare>
-bool starts_with(RangeTested const& tested, RangeCompare const& start)
+bool starts_with(const RangeTested& tested, const RangeCompare& start)
 {
     auto const& tested_ = algo_internal::view_adaptor(tested);
     auto const& compared_ = algo_internal::view_adaptor(start);
@@ -92,7 +92,7 @@ bool starts_with(RangeTested const& tested, RangeCompare const& start)
 
 /// Returns true if [tested] ends with [end].
 template <typename RangeTested, typename RangeCompare>
-bool ends_with(RangeTested const& tested, RangeCompare const& end)
+bool ends_with(const RangeTested& tested, const RangeCompare& end)
 {
     auto const& tested_ = algo_internal::view_adaptor(tested);
     auto const& compared_ = algo_internal::view_adaptor(end);

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -20,11 +20,16 @@
 
 namespace algo_internal
 {
+    // Checks if a type is in a specified list of types
+    template <typename T, typename... Args> constexpr bool is_same_as_any()
+    {
+        return (std::is_same_v<T, Args> || ...);
+    }
+    
     // Tells chars appart from other types
     template <typename T> constexpr bool is_character() noexcept
     {
-        return std::is_same_v<T, char> || std::is_same_v<T, wchar_t> || std::is_same_v<T, signed char> ||
-               std::is_same_v<T, unsigned char> || std::is_same_v<T, char16_t> || std::is_same_v<T, char32_t>;
+        return is_same_as_any<T, char, wchar_t, signed char, unsigned char, char16_t, char32_t>();
         // C++20 introduces char8_t
     }
 

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -45,7 +45,8 @@ namespace algo_internal
         return std::basic_string_view<const T>(value, Size);
     }
 
-    template <typename CharT> constexpr std::enable_if_t < is_character<CharT>(), std::basic_string_view<CharT>> view_adaptor(const CharT* value)
+    template <typename CharT>
+    constexpr std::enable_if_t<is_character<CharT>(), std::basic_string_view<CharT>> view_adaptor(const CharT* value)
     {
         return {value};
     }

--- a/DistroLauncher/upgrade_policy.cpp
+++ b/DistroLauncher/upgrade_policy.cpp
@@ -26,7 +26,7 @@ namespace internal
         if (name == L"Ubuntu") {
             return L"lts";
         }
-        if (starts_with(name, {L"Ubuntu"}) && ends_with(name, {L"LTS"})) {
+        if (starts_with(name, L"Ubuntu") && ends_with(name, L"LTS")) {
             return L"never";
         }
         return L"normal";


### PR DESCRIPTION
## Abstract
Removed the need to add braces around string literals in `starts_with` and `ends_with`:
```diff
- starts_with(string, { L"string_literal" });
+ starts_with(string,   L"string_literal"  );
```

## Explanation
The main issue is that `std::end(const char*)` points to the entry after the null termination, making naive implementations fail. This can be solved using string_views. Then template parameter deduction starts behaving funny. This is solved here with a helper adaptor template that does the following type conversions, in this order:
- `const CharT* -> basic_string_view<CharT>`: SFINAE'd to work only with chars. Null-termination expected.
- `const T[N] -> basic_string_view<T>`: SFINAE'd to work for non-characters only. No null-termination.
- `const T& -> const T&`: Any other containers stay as they were.

Comparing `char` and `wchar_t` (or any other combination of diferent chars) stays forbidden, now with a static assert instead of template resolution falure.

### Side benefits
These were not the goal but it's nice to have them
- Expanded functionality: These two functions now work with any container (See unit tests with arrays, vectors and c-style arrays of int).
- Deduplication: `starts_with` and `ends_with` now use the same implementation `starts_with_impl`, simply switching between forward and reverse iterators.