### PR TITLE
Upload program debug databases

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -167,6 +167,28 @@ jobs:
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="${{ env.AppxBundlePlatforms }}" /p:UapAppxPackageBuildMode=${{ env.UapAppxPackageBuildMode }} -verbosity:normal
+      - name: Collect the PDB files
+        working-directory: ${{ env.workDir }}
+        shell: bash
+        run: |
+          set -eu
+          
+          # Launcher PDBs
+
+          for arch in "x64" "ARM64"; do
+            collectTo="debug-database-${{ matrix.AppID }}/launcher/$arch"
+            mkdir -p "$collectTo"
+            find "$arch/Release/" -name "*.pdb" -exec cp '{}' "$collectTo" \;
+          done
+
+          # Flutter PDBs
+
+          # Move this to the loop once Flutter supports ARM64.
+          collectTo="debug-database-${{ matrix.AppID }}/oobe/x64/"
+          mkdir -p "$collectTo"
+          find . -name "flutter_windows.dll.pdb" -exec cp '{}' "$collectTo" \;
+          find . -wholename "*ubuntu-*Release*.pdb" -exec cp '{}' "$collectTo" \;
+
       - name: Allow downloading sideload appxbundle
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -331,8 +331,12 @@ jobs:
         run: |
           set -eu
 
-          mkdir -p build-info/
-          cp -a ${{ env.artifactsPath }}/build-artifacts-*/*.md build-info/ || exit 0
+          mkdir -p build-info/ debug-databases/
+
+          cp -a ${{ env.artifactsPath }}/build-artifacts-*/*.md build-info/ || \
+           cp -a ${{ env.artifactsPath }}/debug-database-* debug-databases/ || \
+           exit 0
+
           echo "::set-output name=needs-wiki-update::true"
       - name: Sync wiki to repository documentation
         if: ${{ steps.modified-artifacts.outputs.needs-wiki-update == 'true' }}

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -178,7 +178,14 @@ jobs:
           for arch in "x64" "ARM64"; do
             collectTo="debug-database-${{ matrix.AppID }}/launcher/$arch"
             mkdir -p "$collectTo"
-            find "$arch/Release/" -name "*.pdb" -exec cp '{}' "$collectTo" \;
+
+            findDir="ARM64/Release/"
+            if [ $arch == "x64" ]; then
+              findDir="ARM64/Release/DistroLauncher-Appx/x64/"
+            fi
+
+            find "$findDir" -maxdepth 0 -name "*.pdb" -exec cp '{}' "$collectTo" \;
+            
           done
 
           # Flutter PDBs

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -334,7 +334,7 @@ jobs:
           mkdir -p build-info/ debug-databases/
 
           cp -a ${{ env.artifactsPath }}/build-artifacts-*/*.md build-info/ || \
-           cp -a ${{ env.artifactsPath }}/debug-database-* debug-databases/ || \
+           tar -cavf debug-databases/debug-database-${{ matrix.AppID }}.tar.zst ${{ env.artifactsPath }}/debug-database-* || \
            exit 0
 
           echo "::set-output name=needs-wiki-update::true"

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -172,7 +172,7 @@ jobs:
         shell: bash
         run: |
           set -eu
-          
+
           # Launcher PDBs
 
           for arch in "x64" "ARM64"; do
@@ -185,7 +185,7 @@ jobs:
             fi
 
             find "$findDir" -maxdepth 1 -name "*.pdb" -exec cp '{}' "$collectTo" \;
-            
+
           done
 
           # Flutter PDBs
@@ -331,13 +331,25 @@ jobs:
         run: |
           set -eu
 
-          mkdir -p build-info/ debug-databases/
+          mkdir -p build-info/
 
-          cp -a ${{ env.artifactsPath }}/build-artifacts-*/*.md build-info/ || \
-           tar -cavf debug-databases/debug-database-${{ matrix.AppID }}.tar.zst ${{ env.artifactsPath }}/debug-database-* || \
-           exit 0
+          cp -a ${{ env.artifactsPath }}/build-artifacts-*/*.md build-info/ || exit 0
+          echo "::set-output name=needs-wiki-update::true"
+
+      # Pushing PDB's to the wiki only makes sense if we uploaded new app versions to the store.
+      - name: Copy debug databases to base wiki
+        if: ${{ steps.detect-upload-to-store.outputs.needs-upload == 'true' }}
+        id: pdb-artifacts
+        run: |
+          set -eu
+
+          mkdir -p debug-databases/
+
+          find  ${{ env.artifactsPath }} -name "debug-database-*" -maxdepth 1 -exec sh -c 'tar -cavf debug-databases/"$(basename $1)".tar.zst' sh '{}' \; || \
+            exit 0
 
           echo "::set-output name=needs-wiki-update::true"
+
       - name: Sync wiki to repository documentation
         if: ${{ steps.modified-artifacts.outputs.needs-wiki-update == 'true' }}
         run: |

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -203,6 +203,13 @@ jobs:
           path: |
             ${{ env.workDir }}/AppPackages/Ubuntu/Ubuntu_*.appxupload
           retention-days: 7
+      - name: Allow downloading the program debug artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: debug-database-${{ matrix.AppID }}
+          path: |
+            ${{ env.workDir }}/debug-database-${{ matrix.AppID }}/
+          retention-days: 7
       - name: Check if we need to upload new build
         id: detect-upload-to-store
         if: ${{ matrix.Upload == 'yes' }}

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -176,7 +176,7 @@ jobs:
           # Launcher PDBs
 
           for arch in "x64" "ARM64"; do
-            collectTo="debug-database-${{ matrix.AppID }}/launcher/$arch"
+            collectTo="debug-database-${{ matrix.AppID }}/launcher/$arch/"
             mkdir -p "$collectTo"
 
             findDir="ARM64/Release/"
@@ -184,7 +184,7 @@ jobs:
               findDir="ARM64/Release/DistroLauncher-Appx/x64/"
             fi
 
-            find "$findDir" -maxdepth 0 -name "*.pdb" -exec cp '{}' "$collectTo" \;
+            find "$findDir" -maxdepth 1 -name "*.pdb" -exec cp '{}' "$collectTo" \;
             
           done
 


### PR DESCRIPTION
On top of the current practices of:
 1. uploading some build artifacts during `build-wsl` CI workflow and
 2. saving some metadata inside the repository wiki for further reuse during other runs of that workflow.

The proposed set of changes allows collecting program database files (.PDB) generated during compilation of the binaries bundled in the appx for easier crash analysis in the future.

PDBs are collected for each app built, always, and stored with a short retention policy (the same applied to the appx stored as part of the CI). Whenever those builds are pushed to the MS Store, their PDB's also go to the repository wiki as compressed tar balls, with the intent of allowing retrieving from the wiki the always up-to-date set of PDB's. 

Later, during a release, we can take those artifacts from the wiki and upload them as assets for longer retention.

[This run](https://github.com/ubuntu/WSL/actions/runs/2786577116) successfullty collected the PDB files and uploaded them together with the appx, as well as the wiki. After that I changed the part that pushes to the wiki to be skipped if there was no upload to the store. [This run](https://github.com/ubuntu/WSL/actions/runs/2786706011) is the most updated, skipping the wiki part.

In order to certify that the PDB's are realy inside the wiki, one can `git clone https://github.com/ubuntu/WSL.wiki.git` and check the contents of the `debug-databases` directory. It should contain one tarball per Ubuntu app from which we collected PDBs during build. Those tarballs won't show up in GitHub website, since they are not text files.

We need to merge https://github.com/ubuntu/ubuntu-wsl-splash/pull/27 (and refresh the submodule of course) in order to see the PDB's from the ubuntu-wsl-splash Flutter app. We should also push a new version of Ubuntu 22.04 whenever all those changes are in `main` in order to have a collection of PDB's matching the exact compilation of the app pushed to the store.