### PR TITLE
WindowTitle is the one which may have LTS in

### DIFF
--- a/DistroLauncher/upgrade_policy.cpp
+++ b/DistroLauncher/upgrade_policy.cpp
@@ -22,7 +22,7 @@ namespace internal
 
     std::wstring GetUpgradePolicy()
     {
-        std::wstring_view name = DistributionInfo::Name;
+        std::wstring_view name = DistributionInfo::WindowTitle;
         if (name == L"Ubuntu") {
             return L"lts";
         }


### PR DESCRIPTION
At the eleventh hour we got this paramter wrong in the upgrade policy feature.

For example, a sample DistributionInfo.h from 22.04.1 contains the following:

```cpp
    const std::wstring Name = L"Ubuntu-22.04";

    // The title bar for the console window while the distribution is installing.
    const std::wstring WindowTitle = L"Ubuntu 22.04.1 LTS";
```

The intended behavior cannot be achieved with `DistributionInfo::Name`, but with `DistributionInfo::WindowTitle` instead.

```cpp
        if (starts_with(name, L"Ubuntu") && ends_with(name, L"LTS")) {
            return L"never";
        }
```