### PR TITLE
Considers "Current Stable Release" as Supported for LTS's.

### DIFF
--- a/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
-  <Identity Name="CanonicalGroupLimited.Ubuntu" Version="2004.4.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
+  <Identity Name="CanonicalGroupLimited.Ubuntu" Version="2204.1.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Ubuntu</DisplayName>

--- a/meta/Ubuntu/generated/store/en-us/ProductDescription.xml
+++ b/meta/Ubuntu/generated/store/en-us/ProductDescription.xml
@@ -18,7 +18,7 @@ Key features:
   - A consistent development to deployment workflow when using Ubuntu in the cloud
   - 5 years of security patching with Ubuntu Long Term Support (LTS) releases
 
-Ubuntu currently provides the 20.04.4 LTS release. When new LTS versions are released, Ubuntu can be upgraded once the first point release is available. This can be done from the command line by using:
+Ubuntu currently provides the 22.04.1 LTS release. When new LTS versions are released, Ubuntu can be upgraded once the first point release is available. This can be done from the command line by using:
 
     sudo do-release-upgrade
 
@@ -30,7 +30,7 @@ For more information about Ubuntu WSL and how Canonical supports developers plea
 
 https://ubuntu.com/wsl
 </Description>
-  <ReleaseNotes>http://www.ubuntu.com/getubuntu/releasenotes?os=ubuntu&amp;ver=20.04</ReleaseNotes>
+  <ReleaseNotes>http://www.ubuntu.com/getubuntu/releasenotes?os=ubuntu&amp;ver=22.04</ReleaseNotes>
   <DevStudio>Canonical Ltd. and the OpenSource community</DevStudio>
   <ScreenshotCaptions>
     <!-- Valid length: 200 character limit, up to 9 elements per platform -->

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
-  <Identity Name="CanonicalGroupLimited.Ubuntu20.04LTS" Version="2004.4.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
+  <Identity Name="CanonicalGroupLimited.Ubuntu20.04LTS" Version="2004.5.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
-    <DisplayName>Ubuntu 20.04.4 LTS</DisplayName>
+    <DisplayName>Ubuntu 20.04.5 LTS</DisplayName>
     <PublisherDisplayName>Canonical Group Limited</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -19,7 +19,7 @@
   </Resources>
   <Applications>
     <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
-      <uap:VisualElements DisplayName="Ubuntu 20.04.4 LTS" Description="Ubuntu 20.04.4 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
+      <uap:VisualElements DisplayName="Ubuntu 20.04.5 LTS" Description="Ubuntu 20.04.5 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
@@ -33,7 +33,7 @@
         <uap3:Extension Category="windows.appExtension">
           <uap3:AppExtension Name="com.microsoft.windows.terminal.settings"
                              Id="Ubuntu-20.04"
-                             DisplayName="Ubuntu 20.04.4 LTS"
+                             DisplayName="Ubuntu 20.04.5 LTS"
                              PublicFolder="Terminal">
           </uap3:AppExtension>
         </uap3:Extension>

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -7,10 +7,10 @@
         "hidden": true
       },
       {
-        "name": "Ubuntu 20.04.4 LTS",
+        "name": "Ubuntu 20.04.5 LTS",
         "colorScheme": "Ubuntu-20.04-ColorScheme",
         "commandline": "ubuntu2004.exe",
-        "tabTitle": "Ubuntu 20.04.4 LTS",
+        "tabTitle": "Ubuntu 20.04.5 LTS",
         // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
         // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher/DistributionInfo.h
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher/DistributionInfo.h
@@ -16,7 +16,7 @@ namespace DistributionInfo
     const std::wstring Name = L"Ubuntu-20.04";
 
     // The title bar for the console window while the distribution is installing.
-    const std::wstring WindowTitle = L"Ubuntu 20.04.4 LTS";
+    const std::wstring WindowTitle = L"Ubuntu 20.04.5 LTS";
 
     // Create and configure a user account.
     bool CreateUser(std::wstring_view userName);

--- a/meta/Ubuntu20.04LTS/generated/store/en-us/ProductDescription.xml
+++ b/meta/Ubuntu20.04LTS/generated/store/en-us/ProductDescription.xml
@@ -18,11 +18,11 @@ Key features:
   - A consistent development to deployment workflow when using Ubuntu in the cloud
   - 5 years of security patching with Ubuntu Long Term Support (LTS) releases
 
-Ubuntu 20.04.4 LTS is the LTS version of Ubuntu and receives updates for five years. Upgrades to future LTS releases will not be proposed.
+Ubuntu 20.04.5 LTS is the LTS version of Ubuntu and receives updates for five years. Upgrades to future LTS releases will not be proposed.
 
 Installation tips:
   - Search for "Turn Windows features on or off" in the Windows search bar and ensure that "Windows Subsystem for Linux" is turned on before restarting your machine.
-  - To launch, use "ubuntu2004" on the command-line prompt or Windows Terminal, or click on the Ubuntu 20.04.4 LTS tile in the Start Menu.
+  - To launch, use "ubuntu2004" on the command-line prompt or Windows Terminal, or click on the Ubuntu 20.04.5 LTS tile in the Start Menu.
 
 For more information about Ubuntu WSL and how Canonical supports developers please visit:
 

--- a/wsl-builder/common/releasesinfo.go
+++ b/wsl-builder/common/releasesinfo.go
@@ -124,7 +124,7 @@ func buildWSLReleaseInfo(releases [][]string) (wslReleases []WslReleaseInfo, err
 		wslReleases = append(wslReleases, wsl)
 
 		// Pin latest supported (ie non in Active Development) LTS as the "Ubuntu" application
-		if release[9] > latestLTSReleasedDate && release[4] == "Supported" {
+		if release[9] > latestLTSReleasedDate && (release[4] == "Supported" || release[4] == "Current Stable Release") {
 			latestLTSReleasedDate = release[9]
 			ubuntuWSL = wsl
 		}


### PR DESCRIPTION
Releases information fetched from Launchpad API during the CI workflows currently looks like:

```
ver.	m.	code	full version	Status				Activ.	Sup.	LTS		Opened			Release			Milestone
22.10    0    kinetic    Ubuntu 22.10    Active Development    True    False    False    2022-04-26            
22.04    1    jammy    Ubuntu 22.04.1 LTS    Current Stable Release    True    True    True    2021-10-15    2022-04-21    2022-08-11    2023-02-09
20.04    4    focal    Ubuntu 20.04.4 LTS    Supported    True    True    True    2019-02-18    2020-04-23    2022-02-24    2022-09-01
18.04    5    bionic    Ubuntu 18.04.5 LTS    Supported    True    True    True    2017-10-04    2018-04-26    2020-08-06    
16.04    6    xenial    Ubuntu 16.04.6 LTS    Supported    True    True    True    2015-10-19    2016-04-21    2019-02-28    
14.04    6    trusty    Ubuntu 14.04.6 LTS    Supported    True    True    True    2012-10-01    2014-04-17    2019-03-07  
```

During the period of time between the LTS point-release and the next non-LTS release, the current LTS will appear as `Current Stable Release` instead of `Supported`. Thus, that version will only be assigned to the default app when the next non-LTS gets released.

```
ver.	m.	code	full version	Status
22.04    1    jammy    Ubuntu 22.04.1 LTS    Current Stable Release
```

It seems unfair to have to wait until a non-LTS release to be able to upgrade the default app to the latest LTS which already reached the point-release. For the Ubuntu Desktop, the point-release means it's time for the users running the previous LTS to upgrade. For Ubuntu WSL it means the same and should also mean that new users installing the default app should get the current LTS.

This PR changes one check that happens later in the loop that parses that information acquired from Launchpad, in which we set the default app ("Ubuntu") to the latest `Supported` version. We now allow it to also accept the `Current Stable Release`.

> That could have a side effect of allowing non-LTS versions to be assigned to the default app, but it won't happen because earlier in the loop we fast-forward the loop if the current line being parsed is a non-LTS release.

https://github.com/ubuntu/WSL/blob/b92552fbda202b184a10752d3c065dc60d1848db/wsl-builder/common/releasesinfo.go#L79-L82