### PR TITLE
Move the 'flutter build' commands from CI into MSBuild

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -50,25 +50,25 @@ jobs:
           $pwd = ConvertTo-SecureString  '${{ secrets.CERTIFICATE_PASSWORD }}' -AsPlainText -Force
           Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:LocalMachine\Trust -FilePath certificate\certificate.pfx
           Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:CurrentUser\My -FilePath certificate\certificate.pfx
-      - name: Check if packaging the splash app is necessary
+      - name: Check if packaging the Flutter app is necessary
         working-directory: ${{ env.workDir }}
         shell: bash
         run: |
           BUILD_TREE_HASH=$(sha256sum DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
           META_TREE_HASH=$(sha256sum meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
           if [ ${BUILD_TREE_HASH} != ${META_TREE_HASH} ]; then
-            echo "withFlutterSplash=true" >> $GITHUB_ENV
+            echo "withFlutterApp=true" >> $GITHUB_ENV
           else
             echo "Skipping Flutter steps due hashes comparing equal:"
             echo "    Build tree:  ${BUILD_TREE_HASH}. Meta tree: ${META_TREE_HASH}"
           fi
       - uses: subosito/flutter-action@v2.5.0
-        if: ${{ env.withFlutterSplash == 'true' }}
+        if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
       - name: Build the splash screen
         working-directory: ${{ env.workDir }}
-        if: ${{ env.withFlutterSplash == 'true' }}
+        if: ${{ env.withFlutterApp == 'true' }}
         run: |
           flutter config --enable-windows-desktop
           cp "DistroLauncher/images/icon.ico" "ubuntu-wsl-splash/windows/runner/resources/app_icon.ico"

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -66,15 +66,6 @@ jobs:
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
-      - name: Build the splash screen
-        working-directory: ${{ env.workDir }}
-        if: ${{ env.withFlutterApp == 'true' }}
-        run: |
-          flutter config --enable-windows-desktop
-          cp "DistroLauncher/images/icon.ico" "ubuntu-wsl-splash/windows/runner/resources/app_icon.ico"
-          cd "ubuntu-wsl-splash"
-          flutter gen-l10n
-          flutter build windows --release
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -155,15 +155,6 @@ jobs:
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
-      - name: Build the splash screen
-        working-directory: ${{ env.workDir }}
-        if: ${{ env.withFlutterApp == 'true' }}
-        run: |
-          flutter config --enable-windows-desktop
-          cp "DistroLauncher/images/icon.ico" "ubuntu-wsl-splash/windows/runner/resources/app_icon.ico"
-          cd "ubuntu-wsl-splash"
-          flutter gen-l10n
-          flutter build windows --release
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="${{ env.AppxBundlePlatforms }}" /p:UapAppxPackageBuildMode=${{ env.UapAppxPackageBuildMode }} -verbosity:normal

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -139,25 +139,25 @@ jobs:
           $pwd = ConvertTo-SecureString  '${{ secrets.CERTIFICATE_PASSWORD }}' -AsPlainText -Force
           Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:LocalMachine\Trust -FilePath certificate\certificate.pfx
           Import-PfxCertificate -Password $pwd -CertStoreLocation Cert:CurrentUser\My -FilePath certificate\certificate.pfx
-      - name: Check if packaging the splash app is necessary
+      - name: Check if packaging the Flutter app is necessary
         working-directory: ${{ env.workDir }}
         shell: bash
         run: |
           BUILD_TREE_HASH=$(sha256sum DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
           META_TREE_HASH=$(sha256sum meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Directory.build.props | cut -f1 -d' ')
           if [ ${BUILD_TREE_HASH} != ${META_TREE_HASH} ]; then
-            echo "withFlutterSplash=true" >> $GITHUB_ENV
+            echo "withFlutterApp=true" >> $GITHUB_ENV
           else
             echo "Skipping Flutter steps due hashes comparing equal:"
             echo "    Build tree:  ${BUILD_TREE_HASH}. Meta tree: ${META_TREE_HASH}"
           fi
       - uses: subosito/flutter-action@v2.5.0
-        if: ${{ env.withFlutterSplash == 'true' }}
+        if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
       - name: Build the splash screen
         working-directory: ${{ env.workDir }}
-        if: ${{ env.withFlutterSplash == 'true' }}
+        if: ${{ env.withFlutterApp == 'true' }}
         run: |
           flutter config --enable-windows-desktop
           cp "DistroLauncher/images/icon.ico" "ubuntu-wsl-splash/windows/runner/resources/app_icon.ico"

--- a/DistroLauncher-Appx/Directory.build.props
+++ b/DistroLauncher-Appx/Directory.build.props
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<FlutterSplashRoot>..\ubuntu-wsl-splash</FlutterSplashRoot>
-		<FlutterSplashDir>$(FlutterSplashRoot)\build\windows\runner\Release\</FlutterSplashDir>
+		<FlutterAppRoot>..\ubuntu-wsl-splash</FlutterAppRoot>
+		<FlutterAppDir>$(FlutterAppRoot)\build\windows\runner\Release\</FlutterAppDir>
 	</PropertyGroup>
-	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterSplashDir))">
+	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterAppDir))">
 		<Message Text="Building Flutter artifacts" Importance="high"/>
 		<Exec Command="git submodule update --init --recursive" />
-		<Exec Command="flutter build windows --release" WorkingDirectory="$(FlutterSplashRoot)" />
+		<Exec Command="flutter build windows --release" WorkingDirectory="$(FlutterAppRoot)" />
 	</Target>
 	<ItemGroup>
-		<FlutterSplashFiles Include="$(FlutterSplashDir)" /> 
+		<FlutterAppFiles Include="$(FlutterAppDir)" /> 
 	</ItemGroup>
 	<ItemGroup>
-		<None Include="@(FlutterSplashFiles)">
+		<None Include="@(FlutterAppFiles)">
 			<DeploymentContent>true</DeploymentContent>
 		</None>
 	</ItemGroup>

--- a/DistroLauncher-Appx/Directory.build.props
+++ b/DistroLauncher-Appx/Directory.build.props
@@ -3,26 +3,30 @@
 	<PropertyGroup>
 		<FlutterAppRoot>..\ubuntu-wsl-splash</FlutterAppRoot>
 		<FlutterAppDir>$(FlutterAppRoot)\build\windows\runner\Release\</FlutterAppDir>
-        <FlutterAppIconPath>$(FlutterAppRoot)\windows\runner\resources\app_icon.ico</FlutterAppIconPath>
-        <ThisAppIconPath>..\DistroLauncher\images\icon.ico</ThisAppIconPath>
+		<FlutterAppIconPath>$(FlutterAppRoot)\windows\runner\resources\app_icon.ico</FlutterAppIconPath>
+		<ThisAppIconPath>..\DistroLauncher\images\icon.ico</ThisAppIconPath>
 	</PropertyGroup>
-    <ItemGroup>
-        <FlutterAppIcon Include="$(FlutterAppIconPath)" />
-        <ThisAppIcon Include="$(ThisAppIconPath)" />
-    </ItemGroup>
+	<ItemGroup>
+		<FlutterAppIcon Include="$(FlutterAppIconPath)" />
+		<ThisAppIcon Include="$(ThisAppIconPath)" />
+	</ItemGroup>
+	<ItemGroup>
+		<FlutterAppFiles Include="$(FlutterAppDir)" />
+	</ItemGroup>
+	<Choose>
+		<When Condition=" '$(Platform)' == 'x64' ">
+			<ItemGroup>
+				<None Include="@(FlutterAppFiles)">
+					<DeploymentContent>true</DeploymentContent>
+				</None>
+			</ItemGroup>
+		</When>
+	</Choose>
 	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterAppDir))">
 		<Message Text="Building Flutter artifacts" Importance="high"/>
 		<Exec Command="git submodule update --init" />
-        <Copy SourceFiles="@(ThisAppIcon)" DestinationFiles="@(FlutterAppIcon)" />
-        <Exec Command="flutter gen-l10n" WorkingDirectory="$(FlutterAppRoot)" />
+		<Copy SourceFiles="@(ThisAppIcon)" DestinationFiles="@(FlutterAppIcon)" />
+		<Exec Command="flutter gen-l10n" WorkingDirectory="$(FlutterAppRoot)" />
 		<Exec Command="flutter build windows --release" WorkingDirectory="$(FlutterAppRoot)" />
 	</Target>
-	<ItemGroup>
-		<FlutterAppFiles Include="$(FlutterAppDir)" /> 
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="@(FlutterAppFiles)">
-			<DeploymentContent>true</DeploymentContent>
-		</None>
-	</ItemGroup>
 </Project>

--- a/DistroLauncher-Appx/Directory.build.props
+++ b/DistroLauncher-Appx/Directory.build.props
@@ -3,10 +3,18 @@
 	<PropertyGroup>
 		<FlutterAppRoot>..\ubuntu-wsl-splash</FlutterAppRoot>
 		<FlutterAppDir>$(FlutterAppRoot)\build\windows\runner\Release\</FlutterAppDir>
+        <FlutterAppIconPath>$(FlutterAppRoot)\windows\runner\resources\app_icon.ico</FlutterAppIconPath>
+        <ThisAppIconPath>..\DistroLauncher\images\icon.ico</ThisAppIconPath>
 	</PropertyGroup>
+    <ItemGroup>
+        <FlutterAppIcon Include="$(FlutterAppIconPath)" />
+        <ThisAppIcon Include="$(ThisAppIconPath)" />
+    </ItemGroup>
 	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterAppDir))">
 		<Message Text="Building Flutter artifacts" Importance="high"/>
-		<Exec Command="git submodule update --init --recursive" />
+		<Exec Command="git submodule update --init" />
+        <Copy SourceFiles="@(ThisAppIcon)" DestinationFiles="@(FlutterAppIcon)" />
+        <Exec Command="flutter gen-l10n" WorkingDirectory="$(FlutterAppRoot)" />
 		<Exec Command="flutter build windows --release" WorkingDirectory="$(FlutterAppRoot)" />
 	</Target>
 	<ItemGroup>


### PR DESCRIPTION
The CI workflow is meant to provide the resources and execute the build system. Having it to know which Flutter project to builder (it could be either the current slide show or the new OOBE coming soon) and build it before invoking the actual build system that will output the appx bundle is a bad smell.

Instead we can let the build system (MSBuild) to handle building whatever dependencies the appx might have, only requiring the CI workflow to know that it must provide the Flutter command and that’s it.

This PR applies some renaming to turn it more subproject-agnostic in terms of whether we build the slide show or the OOBE application, as well as removing the build commands from CI workflow YAML files, leaving that to the actual build system (MSBuild) to handle.