### PR TITLE
Enables systemd by default on Ubuntu Preview

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -37,6 +37,11 @@ HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
         return hr;
     }
 
+    // Enable systemd
+    if (DistributionInfo::Name == L"UbuntuDev.WslID.Dev" || DistributionInfo::Name == L"Ubuntu-Preview") {
+        Systemd::Enable(true);
+    }
+
     // Create a user account.
     if (createUser) {
         if (!app.shouldSkipInstaller()) {
@@ -50,6 +55,7 @@ HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
             userName = Helpers::GetUserInput(MSG_ENTER_USERNAME, 32);
 
         } while (!DistributionInfo::CreateUser(userName));
+        Oobe::ExitStatusHandling();
 
         // Set this user account as the default.
         hr = SetDefaultUser(userName);

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="systemd_config.cpp" />
     <ClCompile Include="upgrade_policy.cpp" />
     <ClCompile Include="Win32Utils.cpp" />
     <ClCompile Include="WindowsUserInfo.cpp" />

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -60,6 +60,7 @@
 #include "named_mutex.h"
 #include "sudo.h"
 #include "upgrade_policy.h"
+#include "systemd_config.h"
 // Message strings compiled from .MC file.
 #include "messages.h"
 #include "extended_messages.h"

--- a/DistroLauncher/systemd_config.cpp
+++ b/DistroLauncher/systemd_config.cpp
@@ -1,0 +1,60 @@
+#include "stdafx.h"
+
+namespace Systemd
+{
+
+    // Appends text to file in the distro. Returns a success boolean.
+    bool AppendToFile(std::wstring const& text, std::filesystem::path const& file)
+    {
+        const auto command = concat(L"printf ", std::quoted(text), L" >> ", file);
+        DWORD exitCode;
+        const HRESULT hr = g_wslApi.WslLaunchInteractive(command.c_str(), FALSE, &exitCode);
+        return SUCCEEDED(hr) && exitCode == 0;
+    }
+
+    // Calls mkdir. Returns a success boolean.
+    bool Mkdir(std::wstring_view flags, std::filesystem::path const& linux_path)
+    {
+        const auto command = concat(L"mkdir ", flags, L" ", linux_path);
+        DWORD exitCode;
+        const HRESULT hr = g_wslApi.WslLaunchInteractive(command.c_str(), FALSE, &exitCode);
+        return SUCCEEDED(hr) && exitCode == 0;
+    }
+
+    // Enables or disables systemd in config file
+    bool ConfigureSystemd(const bool enable)
+    {
+        const std::filesystem::path wsl_conf{L"/etc/wsl.conf"};
+        const std::wstring config = concat(L"\n[boot]\nsystemd=", std::boolalpha, enable, L'\n');
+        return AppendToFile(config, wsl_conf);
+    }
+
+    /**
+     * Overrides LoadCredential setting for systemd-sysusers.service
+     * See related bug report: https://bugs.launchpad.net/ubuntu/+source/lxd/+bug/1950787
+     * See related solution: https://git.launchpad.net/~ubuntu-core-dev/ubuntu/+source/systemd/commit/?id=d4e05ecbc
+     */
+    bool SysUsersDisableLoadCredential()
+    {
+        const std::filesystem::path sysusers_override = L"/etc/systemd/system/systemd-sysusers.service.d/override.conf";
+
+        if (!Mkdir(L"-p", sysusers_override.parent_path())) {
+            return false;
+        }
+        return AppendToFile(L"\n[Service]\nLoadCredential=\n", sysusers_override);
+    }
+
+    bool Enable(const bool enable)
+    {
+        if (!ConfigureSystemd(enable)) {
+            return false;
+        }
+
+        if (!SysUsersDisableLoadCredential()) {
+            return false;
+        }
+
+        return AppendToFile(L"\naction=reboot\n", L"/run/launcher-command");
+    }
+
+}

--- a/DistroLauncher/systemd_config.h
+++ b/DistroLauncher/systemd_config.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+namespace Systemd
+{
+    bool Enable(bool enable = true);
+}


### PR DESCRIPTION
Co-authored by Edu Gómez Escandell <edu.gomez.escandell@canonical.com>

https://ubuntu.com/blog/ubuntu-wsl-enable-systemd