### PR TITLE
Closes the handle only at destructor

### DIFF
--- a/DistroLauncher/SetOnceNamedEvent.cpp
+++ b/DistroLauncher/SetOnceNamedEvent.cpp
@@ -26,6 +26,7 @@ namespace Win32Utils
         HANDLE handle = CreateEvent(nullptr, TRUE, FALSE, name);
         if (handle != nullptr) {
             event = handle;
+            setOnce = false;
         }
     }
 
@@ -34,12 +35,13 @@ namespace Win32Utils
         if (event != nullptr) {
             CloseHandle(event);
             event = nullptr;
+            setOnce = false;
         }
     }
 
     bool SetOnceNamedEvent::set() noexcept
     {
-        if (event == nullptr) {
+        if (setOnce == true) {
             return false;
         }
 
@@ -47,18 +49,17 @@ namespace Win32Utils
             return false;
         }
 
-        CloseHandle(event);
-        event = nullptr;
+        setOnce = true;
         return true;
     }
 
     SetOnceNamedEvent::SetOnceNamedEvent(SetOnceNamedEvent&& other) noexcept :
-        event{std::exchange(other.event, nullptr)}
+        event{std::exchange(other.event, nullptr)}, setOnce{std::exchange(other.setOnce, false)}
     {
     }
 
     bool SetOnceNamedEvent::isValid() const noexcept
     {
-        return event != nullptr;
+        return event != nullptr && setOnce == false;
     }
 }

--- a/DistroLauncher/SetOnceNamedEvent.cpp
+++ b/DistroLauncher/SetOnceNamedEvent.cpp
@@ -23,25 +23,19 @@ namespace Win32Utils
 
     SetOnceNamedEvent::SetOnceNamedEvent(const wchar_t* name) noexcept
     {
-        HANDLE handle = CreateEvent(nullptr, TRUE, FALSE, name);
-        if (handle != nullptr) {
-            event = handle;
-            setOnce = false;
-        }
+        event = CreateEvent(nullptr, TRUE, FALSE, name);
     }
 
     SetOnceNamedEvent::~SetOnceNamedEvent() noexcept
     {
         if (event != nullptr) {
             CloseHandle(event);
-            event = nullptr;
-            setOnce = false;
         }
     }
 
     bool SetOnceNamedEvent::set() noexcept
     {
-        if (setOnce == true) {
+        if (!isValid()) {
             return false;
         }
 
@@ -49,17 +43,17 @@ namespace Win32Utils
             return false;
         }
 
-        setOnce = true;
+        alreadySet = true;
         return true;
     }
 
     SetOnceNamedEvent::SetOnceNamedEvent(SetOnceNamedEvent&& other) noexcept :
-        event{std::exchange(other.event, nullptr)}, setOnce{std::exchange(other.setOnce, false)}
+        event{std::exchange(other.event, nullptr)}, alreadySet{std::exchange(other.alreadySet, false)}
     {
     }
 
     bool SetOnceNamedEvent::isValid() const noexcept
     {
-        return event != nullptr && setOnce == false;
+        return event != nullptr && !alreadySet;
     }
 }

--- a/DistroLauncher/SetOnceNamedEvent.h
+++ b/DistroLauncher/SetOnceNamedEvent.h
@@ -63,6 +63,6 @@ namespace Win32Utils
 
       private:
         HANDLE event = nullptr;
-        bool setOnce = false;
+        bool alreadySet = false;
     };
 }

--- a/DistroLauncher/SetOnceNamedEvent.h
+++ b/DistroLauncher/SetOnceNamedEvent.h
@@ -63,5 +63,6 @@ namespace Win32Utils
 
       private:
         HANDLE event = nullptr;
+        bool setOnce = false;
     };
 }


### PR DESCRIPTION
We previously tracked whether the event was set or not by assigning `nullptr` and to avoid leaks we close the handle right after setting it.

To preserve the semantics of being able to set it only once, we now track the set state using a boolean.

Deferring closing the handle to the destructor of this object allows for an OOBE GUI late in the initialization process to still find the event already set. Otherwise, closing the handle much earlier than any client would be able to check it, would allow the kernel to destroy the object.

This was never an issue because the OOBE inits very fast. But with the upcoming end to end test this would be a major block: the launcher would never be effective in communicating the registration completion event.