### PR TITLE
Ensures the child process has at least one thread available for input

### DIFF
--- a/DistroLauncher/ChildProcess.cpp
+++ b/DistroLauncher/ChildProcess.cpp
@@ -60,6 +60,7 @@ namespace Oobe
                                  &procInfo);                // output: PROCESS_INFORMATION
         auto ok = res != 0 && procInfo.hProcess != nullptr; // success
         if (ok) {
+            WaitForInputIdle(procInfo.hProcess, INFINITE);
             RegisterWaitForSingleObject(&waiterHandle, procInfo.hProcess, onClose, this, INFINITE,
                                         WT_EXECUTEDEFAULT | WT_EXECUTEONLYONCE);
         }


### PR DESCRIPTION
This doesn't seem useful if the child is a window application. But showed useful when dealing with the PoC e2e test.

This approach is quite controversial though. See the following links for the downside of doing such.

https://devblogs.microsoft.com/oldnewthing/20100325-00/?p=14493

https://devblogs.microsoft.com/oldnewthing/20100326-00/?p=14483

Still seems as harmful as doing nothing (the previous behavior) for GUI child processes.