### PR TITLE
Ensures serverExitStatusCheck is called for the gui setup

### DIFF
--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -213,7 +213,7 @@ namespace Oobe
             return E_FAIL;
         }
 
-        return S_OK;
+        return serverExitStatusCheck();
     }
 
     HRESULT WinOobeStrategy::do_tui_install()


### PR DESCRIPTION
TUI currently does that internally (via its installer policy), so no need to touch just now. When the Win32 Flutter OOBE gets ported to Jammy we need to revisit this topic since the TUI routine will be drastically simplified.

I guess this was a kind of leftover between rebases. The function (`serverExitStatusCheck()`) was there, but never called.