### PR TITLE
Fix flutter build CI

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -62,7 +62,7 @@ jobs:
             echo "Skipping Flutter steps due hashes comparing equal:"
             echo "    Build tree:  ${BUILD_TREE_HASH}. Meta tree: ${META_TREE_HASH}"
           fi
-      - uses: subosito/flutter-action@v2.5.0
+      - uses: subosito/flutter-action@v2
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -151,7 +151,7 @@ jobs:
             echo "Skipping Flutter steps due hashes comparing equal:"
             echo "    Build tree:  ${BUILD_TREE_HASH}. Meta tree: ${META_TREE_HASH}"
           fi
-      - uses: subosito/flutter-action@v2.5.0
+      - uses: subosito/flutter-action@v2
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable


### PR DESCRIPTION
There was a breaking change in the package `flutter_html` that motivated the `ubuntu_desktop_installer` to pin a very specific version of that package. See https://github.com/canonical/ubuntu-desktop-installer/pull/1152. That is the reason for the current break in our CI build. Thus, we need to update the UDI submodule. 

I also took the freedom to unpin the flutter-action version from our CI.

[This run](https://github.com/ubuntu/WSL/actions/runs/3184611222) proves this work.