### PR TITLE
Imports ui-driver.props if exists.

### DIFF
--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/Directory.build.props
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/Directory.build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)\ui-driver.props" Condition="Exists('$(MSBuildThisFileDirectory)\ui-driver.props')" />
+    <PropertyGroup>
 		<FlutterAppRoot>..\ubuntu-desktop-installer\packages\ubuntu_wsl_setup</FlutterAppRoot>
 		<FlutterAppDir>$(FlutterAppRoot)\build\windows\runner\Release\</FlutterAppDir>
 		<FlutterAppIconPath>$(FlutterAppRoot)\windows\runner\resources\app_icon.ico</FlutterAppIconPath>

--- a/meta/UbuntuPreview/src/DistroLauncher-Appx/Directory.build.props
+++ b/meta/UbuntuPreview/src/DistroLauncher-Appx/Directory.build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)\ui-driver.props" Condition="Exists('$(MSBuildThisFileDirectory)\ui-driver.props')" />
+    <PropertyGroup>
 		<FlutterAppRoot>..\ubuntu-desktop-installer\packages\ubuntu_wsl_setup</FlutterAppRoot>
 		<FlutterAppDir>$(FlutterAppRoot)\build\windows\runner\Release\</FlutterAppDir>
 		<FlutterAppIconPath>$(FlutterAppRoot)\windows\runner\resources\app_icon.ico</FlutterAppIconPath>


### PR DESCRIPTION
Enables the CI to inject the Go stub when running the e2e tests.

By default it does nothing.

For now that's only possible for Ubuntu-Preview, thus it goes into `meta` directory. Once Jammy gets the new OOBE backported, that will be the default behavior.