### PR TITLE
Integrates the end-to-end testing with the distro launcher

### DIFF
--- a/DistroLauncher/AppConfig.cpp
+++ b/DistroLauncher/AppConfig.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+
+namespace Oobe
+{
+    AppConfig appConfig()
+    {
+        // Initialized only once at compile-time and forever immutable.
+        static constexpr AppConfig instance =
+#ifdef OOBE_E2E_TESTING
+          AppConfig{L"ui-driver.exe", true, true};
+#else
+          AppConfig{L"ubuntu_wsl_setup.exe", false, false};
+#endif
+        return instance;
+    }
+}

--- a/DistroLauncher/AppConfig.h
+++ b/DistroLauncher/AppConfig.h
@@ -1,0 +1,35 @@
+#pragma once
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Oobe
+{
+    struct AppConfig
+    {
+        // The file name (including extension) of the executable that must be invoked as the OOBE.
+        wchar_t* appName;
+
+        // Whether or not the fallback method should be skipped on OOBE failure.
+        bool mustSkipFallback;
+
+        // Whether the child process requires its own console or not.
+        bool requiresNewConsole;
+    };
+
+    // Returns the global constant instance of the AppConfig.
+    AppConfig appConfig();
+}

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -84,6 +84,9 @@ namespace Oobe
             if (FAILED(hr) && hr != E_NOTIMPL && hr != E_INVALIDARG) {
                 wprintf(L"Installer did not complete successfully.\n");
                 Helpers::PrintErrorMessage(hr);
+                if (appConfig().mustSkipFallback) {
+                    exit(123);
+                }
                 wprintf(L"Applying fallback method.\n");
             }
 

--- a/DistroLauncher/ChildProcess.cpp
+++ b/DistroLauncher/ChildProcess.cpp
@@ -67,7 +67,8 @@ namespace Oobe
                                         WT_EXECUTEDEFAULT | WT_EXECUTEONLYONCE);
         }
 
-        return ok;
+        DWORD exitCode = 0;
+        return ok && TRUE == GetExitCodeProcess(procInfo.hProcess, &exitCode) && exitCode == STILL_ACTIVE; // success;
     }
 
     DWORD Win32ChildProcess::do_waitExitSync(DWORD timeout)

--- a/DistroLauncher/ChildProcess.cpp
+++ b/DistroLauncher/ChildProcess.cpp
@@ -48,12 +48,14 @@ namespace Oobe
             cli.append(arguments);
         }
 
+        const DWORD flags = appConfig().requiresNewConsole ? CREATE_NEW_CONSOLE : 0;
+
         BOOL res = CreateProcess(nullptr,                   // command line
                                  cli.data(),                // non-const CLI
                                  &sa,                       // process security attributes
                                  nullptr,                   // primary thread security attributes
                                  TRUE,                      // handles are inherited
-                                 0,                         // creation flags
+                                 flags,                     // creation flags
                                  nullptr,                   // use parent's environment
                                  nullptr,                   // use parent's current directory
                                  &startInfo,                // STARTUPINFO pointer

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -139,6 +139,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="algorithms.h" />
+    <ClInclude Include="AppConfig.h" />
     <ClInclude Include="Application.h" />
     <ClInclude Include="ApplicationStrategy.h" />
     <ClInclude Include="ApplicationStrategyCommon.h" />
@@ -174,6 +175,7 @@
     <ClInclude Include="local_named_pipe.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AppConfig.cpp" />
     <ClCompile Include="ApplicationStrategyCommon.cpp" />
     <ClCompile Include="ChildProcess.cpp" />
     <ClCompile Include="DistributionInfo.cpp" />

--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -212,8 +212,9 @@ namespace Oobe
             do_close_oobe();
             return EVENT_E_USER_EXCEPTION;
         }
-
-        if (oobeProcess.value().waitExitSync() != 0) {
+        const auto exitCode = oobeProcess.value().waitExitSync();
+        do_show_console();
+        if (exitCode != 0) {
             return E_FAIL;
         }
 

--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -7,7 +7,7 @@ namespace Oobe
 
     std::filesystem::path getOobeExePath()
     {
-        return Win32Utils::thisAppRootdir() / L"ubuntu_wsl_setup.exe";
+        return Win32Utils::thisAppRootdir() / appConfig().appName;
     }
 
     std::filesystem::path getWslConfigPath()

--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -204,6 +204,10 @@ namespace Oobe
             prefill.write();
         }
 
+        if (!oobeProcess) {
+            return E_NOT_VALID_STATE;
+        }
+
         if (!hRegistrationEvent.set()) {
             do_close_oobe();
             return EVENT_E_USER_EXCEPTION;

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -55,6 +55,7 @@
 #include "WSLInfo.h"
 #include "Win32Utils.h"
 #include "ChildProcess.h"
+#include "AppConfig.h"
 #include "ApplicationStrategy.h"
 #include "Application.h"
 #include "named_mutex.h"

--- a/meta/UbuntuPreview/generated/DistroLauncher/Preprocessor.props
+++ b/meta/UbuntuPreview/generated/DistroLauncher/Preprocessor.props
@@ -3,6 +3,7 @@
     <ItemDefinitionGroup>
         <ClCompile>
             <PreprocessorDefinitions>WIN_OOBE_ENABLED</PreprocessorDefinitions>
+            <PreprocessorDefinitions Condition=" '$(OOBE_E2E_TESTING)' != '' ">%(PreprocessorDefinitions);OOBE_E2E_TESTING</PreprocessorDefinitions>
         </ClCompile>
     </ItemDefinitionGroup>
 </Project>

--- a/meta/UbuntuPreview/src/DistroLauncher/Preprocessor.props
+++ b/meta/UbuntuPreview/src/DistroLauncher/Preprocessor.props
@@ -3,6 +3,7 @@
     <ItemDefinitionGroup>
         <ClCompile>
             <PreprocessorDefinitions>WIN_OOBE_ENABLED</PreprocessorDefinitions>
+            <PreprocessorDefinitions Condition=" '$(OOBE_E2E_TESTING)' != '' ">%(PreprocessorDefinitions);OOBE_E2E_TESTING</PreprocessorDefinitions>
         </ClCompile>
     </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
This seems bigger than it really is. Let's go by parts:

- ubuntu-desktop-installer submodule is updated to latest main so we can incorporate the automation recently merged there. See PR https://github.com/canonical/ubuntu-desktop-installer/pull/1173
- A small change in `meta\UbuntuPreview\Preprocessor.props` allows defining `OOBE_E2E_TESTING` through msbuild CLI. That will only make sense in the context of running the end-to-end tests.
- AppConfig struct and a function to provide a global static constexpr instance carries the pieces of data that change between production and e2e testing.
- Fixes and enhancements on the launcher code revealed by the e2e testing experimentation. (2ceb9e3b640bbe641e8c3f8f8400f62a910515ef, a3e0f476881acfca9293b9a631449d5f740d3e41 and 57f465b0cbbb1b1eddc84456916cb585bc0f7754)

We are almost done. With those changes in place it's possible to generate an appx ready for end-to-end testing by following the recipe below on a Developer Powershell:

```powershell

 go build .\wsl-builder\prepare-build
 .\prepare-build Ubuntu-Preview ...
cp e2e\ui-driver\ui-driver.props DistroLauncher-Appx\
msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Debug /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal /p:OOBE_E2E_TESTING=1
.\AppPackages\Ubuntu\Ubuntu_<version>_Debug_Test\Install.ps1 -Force
$env:LAUNCHER_REPO_ROOT=$(pwd).Path
cd e2e
go test .\test-runner --distro-name Ubuntu-Preview --launcher-name ubuntupreview.exe

```

This will soon be turned into a script, on another PR, once experimentation with the parameters get more mature.