### PR TITLE
Printing more info when E2E tests fail

### DIFF
--- a/e2e/test-runner/wsl_tester.go
+++ b/e2e/test-runner/wsl_tester.go
@@ -38,16 +38,21 @@ func WslTester(t *testing.T) Tester {
 		// print debug logs
 		if tester.Failed() {
 			tester.Log("\n\n=== Server Debug Log ====")
-			logContents := tester.AssertWslCommand("cat", serverLogPath)
-			tester.Logf("%s", logContents)
+			output, err := exec.Command("wsl.exe", "-d", *distroName, "cat", serverLogPath).CombinedOutput()
+			if err == nil {
+				tester.Logf("%s", output)
+			} else {
+				tester.Logf("Failed to retrieve server debug log: %s: %s", err, output)
+			}
 			tester.Log("\n\n=== Client Debug Log ====")
 			rootDir := os.Getenv(constants.LauncherRepoEnvVar)
 			path := filepath.Join(rootDir, clientLogPath)
 			clientLogContents, err := ioutil.ReadFile(path)
 			if err != nil {
-				tester.Fatalf("%s", err)
+				tester.Fatalf("Failed to retrieve client debug log: %s", err)
+			} else {
+				tester.Logf("%s", clientLogContents)
 			}
-			tester.Logf("%s", clientLogContents)
 		}
 		// attempts to unregister the instance.
 		cmd := exec.Command("wsl.exe", "--shutdown")

--- a/e2e/test-runner/wsl_tester.go
+++ b/e2e/test-runner/wsl_tester.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ubuntu/wsl/e2e/constants"
@@ -77,7 +78,8 @@ func (t *Tester) AssertOsCommand(name string, args ...string) string {
 	cmd := exec.Command(name, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("Failed to run the command: %s. Error %s", name, err)
+		argsStr := strings.Join(args, " ")
+		t.Fatalf("Failed to run command:\n > %s %s\nError: %s", name, argsStr, err)
 	}
 	return string(output[:])
 }

--- a/e2e/test-runner/wsl_tester.go
+++ b/e2e/test-runner/wsl_tester.go
@@ -42,14 +42,14 @@ func WslTester(t *testing.T) Tester {
 			if err == nil {
 				tester.Logf("%s", output)
 			} else {
-				tester.Logf("Failed to retrieve server debug log: %s: %s", err, output)
+				tester.Logf("Failed to retrieve server debug log:\n%s: %s", err, output)
 			}
 			tester.Log("\n\n=== Client Debug Log ====")
 			rootDir := os.Getenv(constants.LauncherRepoEnvVar)
 			path := filepath.Join(rootDir, clientLogPath)
 			clientLogContents, err := ioutil.ReadFile(path)
 			if err != nil {
-				tester.Logf("Failed to retrieve client debug log: %s", err)
+				tester.Logf("Failed to retrieve client debug log:\n%s", err)
 			} else {
 				tester.Logf("%s", clientLogContents)
 			}

--- a/e2e/test-runner/wsl_tester.go
+++ b/e2e/test-runner/wsl_tester.go
@@ -49,7 +49,7 @@ func WslTester(t *testing.T) Tester {
 			path := filepath.Join(rootDir, clientLogPath)
 			clientLogContents, err := ioutil.ReadFile(path)
 			if err != nil {
-				tester.Fatalf("Failed to retrieve client debug log: %s", err)
+				tester.Logf("Failed to retrieve client debug log: %s", err)
 			} else {
 				tester.Logf("%s", clientLogContents)
 			}


### PR DESCRIPTION
Three changes I made for debugging that I thought would be useful in general, each corresponds to a commit, in order:
1. When an Os comand assertion fails: It prints command + arguments instead of only printing the command (which is most often going to be either `powershell.exe` or `wsl.exe`).
2. When any of the logs cannot be accessed: Do not print it as a failed assertion but rather say that the log could not be found.
3. When the client logs cannot be found: Use `Logf` instead of `Fatalf` so that unregistering is not skipped.
4. Last commit simply adds a couple of line breaks so the new output it is a bit more readbale.

## Before
```
PS> go test .\test-runner\
--- FAIL: TestBasicSetup (3.61s)
    wsl_tester.go:80: Failed to run the command: powershell.exe. Error exit status 1
    wsl_tester.go:39:

        === Server Debug Log ====
    wsl_tester.go:80: Failed to run the command: wsl.exe. Error exit status 1
FAIL
FAIL    github.com/ubuntu/wsl/e2e/test-runner   3.949s
FAIL
```

## After
```
PS> go test .\test-runner\
--- FAIL: TestBasicSetup (1.10s)
    wsl_tester.go:87: Failed to run command:
         > powershell.exe -noninteractive -nologo -noprofile -command UbuntuDev.LauncherName.Dev.exe install --ui=gui
        Error: exit status 1
    wsl_tester.go:40:

        === Server Debug Log ====
    wsl_tester.go:45: Failed to retrieve server debug log:
        exit status 0xffffffff: There is no distribution with the supplied name.
        Error code: Wsl/Service/WSL_E_DISTRO_NOT_FOUND

    wsl_tester.go:47:

        === Client Debug Log ====
    wsl_tester.go:52: Failed to retrieve client debug log:
        open C:\Users\edu19\Work\WSL\ubuntu-desktop-installer\packages\ubuntu_wsl_setup\build\windows\runner\Debug\.ubuntu_wsl_setup.exe\ubuntu_wsl_setup.exe.log: The system cannot find the path specified.
```