### PR TITLE
Updates the link to jammy rootfs

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     if: ${{ !github.event.pull_request.draft }}
     env:
-      rootfs64: 'http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64-wsl.rootfs.tar.gz'
+      rootfs64: 'http://cloud-images.ubuntu.com/wsl/jammy/current/ubuntu-jammy-wsl-amd64-wsl.rootfs.tar.gz'
       workDir: 'C:/Temp/builddir'
     steps:
       - name: Checkout WSL


### PR DESCRIPTION
Due that being moved to WSL pipeline.

Later we'd address the build-wsl workflow.  That's slightly more complex. This one is very straightforward and blocks other pull requests.