### PR TITLE
[e2e] More info printed on error

### DIFF
--- a/e2e/test-runner/wsl_tester.go
+++ b/e2e/test-runner/wsl_tester.go
@@ -84,7 +84,7 @@ func (t *Tester) AssertOsCommand(name string, args ...string) string {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		argsStr := strings.Join(args, " ")
-		t.Fatalf("Failed to run command:\n > %s %s\nError: %s", name, argsStr, err)
+		t.Fatalf("Failed to run command:\n > %s %s\nError: %s\nOutput: %s", name, argsStr, err, output)
 	}
 	return string(output[:])
 }


### PR DESCRIPTION
I continue my quest to improve the test debugging experience.
This time, I added the result of the failed command to the output:

## Before vs. after
```diff
=== RUN   TestBasicSetup
    wsl_tester.go:87: Failed to run command:
         > wsl.exe -d UbuntuDev.WslID.Dev systemctl is-system-running
        Error: exit status 127
+       Output: /bin/bash: line 1: systemctl is-system-running: command not found
    wsl_tester.go:40: 
        
        === Server Debug Log ====
[...]
```