### PR TITLE
Adding e2e testing relating to config 

### DIFF
--- a/e2e/test-runner/go.mod
+++ b/e2e/test-runner/go.mod
@@ -2,8 +2,8 @@ module github.com/ubuntu/wsl/e2e/test-runner
 
 go 1.18
 
-require github.com/ubuntu/wsl/e2e/constants v0.0.0
-
-require gopkg.in/ini.v1 v1.67.0 // indirect
-
+require (
+    github.com/ubuntu/wsl/e2e/constants v0.0.0
+    gopkg.in/ini.v1 v1.67.0 // indirect
+)
 replace github.com/ubuntu/wsl/e2e/constants => ../constants

--- a/e2e/test-runner/go.mod
+++ b/e2e/test-runner/go.mod
@@ -3,4 +3,7 @@ module github.com/ubuntu/wsl/e2e/test-runner
 go 1.18
 
 require github.com/ubuntu/wsl/e2e/constants v0.0.0
+
+require gopkg.in/ini.v1 v1.67.0 // indirect
+
 replace github.com/ubuntu/wsl/e2e/constants => ../constants

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -23,7 +23,7 @@ func TestBasicSetup(t *testing.T) {
 	tester := WslTester(t)
 
 	// Invoke the launcher as if the user did: `<launcher>.exe install --ui=gui`
-	outStr := tester.AssertLauncherCommand("install --root --ui=none") // without install the launcher will run bash.
+	outStr := tester.AssertLauncherCommand("install --ui=gui") // without install the launcher will run bash.
 	if len(outStr) == 0 {
 		tester.Fatal("Failed to install the distro: No output produced.")
 	}

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -79,15 +79,17 @@ func assertCorrectReleaseRootfs(tester *Tester) {
 
 // Ensures systemd was enabled.
 func assertSystemdEnabled(tester *Tester) {
+	tester.AssertWslCommand("busctl", "list", "--no-pager")
+
 	getSystemdStatus := func() string {
-		outputStr := tester.AssertWslCommand("bash", "-ec", "systemctl is-system-running || exit 0")
+		outputStr := tester.AssertWslCommand("bash", "-ec", "systemctl is-system-running --wait || exit 0")
 		return strings.TrimSpace(outputStr)
 	}
 
 	status := getSystemdStatus()
-	if status != "starting" && status != "degraded" && status != "running" {
+	if status != "degraded" && status != "running" {
 		tester.Logf("%s", status)
-		tester.Fatal("Systemd was not enabled")
+		tester.Fatal("Systemd failed to start")
 	}
 }
 

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -130,10 +130,19 @@ func TestBasicSetup(t *testing.T) {
 			tester.Fatal("Failed to parse ini file")
 		}
 
-		val := cfg.Section("DEFAULT").Key("Prompt").String()
-		if val != expectedUpgradePolicy() {
+		section, err := cfg.GetSection("DEFAULT")
+		if err != nil {
 			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
-			tester.Logf("Parsed policy: %s", val)
+			tester.Fatal("Failed to find section DEFAULT in /etc/update-manager/release-upgrades")
+		}
+		value, err := section.GetKey("Prompt")
+		if err != nil {
+			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+			tester.Fatal("Failed to find key 'Prompt' in DEFAULT section of /etc/update-manager/release-upgrades")
+		}
+		if value.String() != expectedUpgradePolicy() {
+			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+			tester.Logf("Parsed policy: %s", value.String())
 			tester.Logf("Expected policy: %s", expectedUpgradePolicy())
 			tester.Fatal("Wrong upgrade policy")
 		}

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 )
 
-func expectedUpgradePolicy() string {
-	if *distroName == "Ubuntu" {
+func expectedUpgradePolicy(distro string) string {
+	if distro == "Ubuntu" {
 		return "lts"
 	}
-	if strings.HasPrefix(*distroName, "Ubuntu") && strings.HasSuffix(*distroName, "LTS") {
+	if strings.HasPrefix(distro, "Ubuntu") && strings.HasSuffix(distro, "LTS") {
 		return "never"
 	}
 	// Preview and Dev
@@ -120,10 +120,12 @@ func assertCorrectUpgradePolicy(tester *Tester) {
 		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
 		tester.Fatal("Failed to find key 'Prompt' in DEFAULT section of /etc/update-manager/release-upgrades")
 	}
-	if value.String() != expectedUpgradePolicy() {
+
+	expectedPolicy := expectedUpgradePolicy(*distroName)
+	if value.String() != expectedUpgradePolicy(expectedPolicy) {
 		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
 		tester.Logf("Parsed policy: %s", value.String())
-		tester.Logf("Expected policy: %s", expectedUpgradePolicy())
+		tester.Logf("Expected policy: %s", expectedUpgradePolicy(expectedPolicy))
 		tester.Fatal("Wrong upgrade policy")
 	}
 }

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -4,7 +4,6 @@ import (
 	"gopkg.in/ini.v1"
 	"strings"
 	"testing"
-	"time"
 )
 
 func expectedUpgradePolicy() string {
@@ -18,6 +17,134 @@ func expectedUpgradePolicy() string {
 	return "normal"
 }
 
+// After completing the setup, the OOBE must have created a new user and the distro launcher must have set it as the default.
+func assertUserNotRoot(tester *Tester) {
+	outputStr := tester.AssertWslCommand("whoami")
+	notRoot := strings.Fields(outputStr)[0]
+	if notRoot == "root" {
+		tester.Logf("%s", outputStr)
+		tester.Fatal("Default user should not be root.")
+	}
+}
+
+// Subiquity either installs or marks for installation the relevant language packs for the chosen language.
+func assertLanguagePacksMarked(tester *Tester) {
+	outputStr := tester.AssertWslCommand("apt-mark", "showinstall", "language-pack\\*")
+	packs := strings.Fields(outputStr)
+	tester.Logf("%s", outputStr) // I'd like to see what packs were installed in the end, just in case.
+	if len(packs) == 0 {
+		tester.Fatal("At least one language pack should have been installed or marked for installation, but apt-mark command output is empty.")
+	}
+}
+
+// Proper release. Ensures the right tarball was used as rootfs.
+func assertCorrectReleaseRootfs(tester *Tester) {
+	expectedRelease := func() string {
+		if *distroName == "Ubuntu-Preview" || *distroName == "UbuntuDev.WslID.Dev" {
+			return "Ubuntu Kinetic Kudu (development branch)"
+		}
+		if *distroName == "Ubuntu" {
+			return "Ubuntu 22.04.1 LTS"
+		}
+		if *distroName == "Ubuntu22.04LTS" {
+			return "Ubuntu 22.04.1 LTS"
+		}
+		if *distroName == "Ubuntu20.04LTS" {
+			return "Ubuntu 20.04.5 LTS"
+		}
+		if *distroName == "Ubuntu18.04LTS" {
+			return "Ubuntu 18.04.6 LTS"
+		}
+		return ""
+	}()
+	if len(expectedRelease) == 0 {
+		tester.Logf("Unknown Ubuntu release corresponding to distro name '%s'", *distroName)
+		tester.Fatal("Unexpected value provided via --distro-name")
+	}
+	outputStr := tester.AssertWslCommand("cat", "/etc/os-release")
+	cfg, err := ini.Load([]byte(outputStr))
+	if err != nil {
+		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
+		tester.Fatal("Failed to parse ini file")
+	}
+
+	release, err := cfg.Section(ini.DefaultSection).GetKey("PRETTY_NAME")
+	if err != nil {
+		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
+		tester.Fatal("Failed to find PRETTY_NAME")
+	}
+
+	if release.String() != expectedRelease {
+		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
+		tester.Logf("Parsed release:   %s", release.String())
+		tester.Logf("Expected release: %s", expectedRelease)
+		tester.Fatal("Unexpected release string")
+	}
+}
+
+// Ensures systemd was enabled.
+func assertSystemdEnabled(tester *Tester) {
+	getSystemdStatus := func() string {
+		outputStr := tester.AssertWslCommand("bash", "-ec", "systemctl is-system-running || exit 0")
+		return strings.TrimSpace(outputStr)
+	}
+
+	status := getSystemdStatus()
+	if status != "starting" && status != "degraded" && status != "running" {
+		tester.Logf("%s", status)
+		tester.Fatal("Systemd was not enabled")
+	}
+}
+
+// Sysusers service fix
+func assertSysusersServiceWorks(tester *Tester) {
+	tester.AssertWslCommand("systemctl", "status", "systemd-sysusers.service")
+}
+
+// Upgrade policy matches launcher
+func assertCorrectUpgradePolicy(tester *Tester) {
+	outputStr := tester.AssertWslCommand("cat", "/etc/update-manager/release-upgrades")
+	cfg, err := ini.Load([]byte(outputStr))
+	if err != nil {
+		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+		tester.Fatal("Failed to parse ini file")
+	}
+
+	section, err := cfg.GetSection("DEFAULT")
+	if err != nil {
+		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+		tester.Fatal("Failed to find section DEFAULT in /etc/update-manager/release-upgrades")
+	}
+	value, err := section.GetKey("Prompt")
+	if err != nil {
+		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+		tester.Fatal("Failed to find key 'Prompt' in DEFAULT section of /etc/update-manager/release-upgrades")
+	}
+	if value.String() != expectedUpgradePolicy() {
+		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+		tester.Logf("Parsed policy: %s", value.String())
+		tester.Logf("Expected policy: %s", expectedUpgradePolicy())
+		tester.Fatal("Wrong upgrade policy")
+	}
+}
+
+// Upgrade policy is not overriden every launch
+func assertUpgradePolicyAppliedOnce(tester *Tester, creationTimestamp string) {
+	tester.AssertOsCommand("wsl.exe", "-t", *distroName)
+	tester.AssertLauncherCommand("run echo Hello")
+
+	newTimestamp := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
+	if creationTimestamp != newTimestamp {
+		tester.Logf("Launcher is modifying release upgrade file more than once")
+	}
+}
+
+// Shuts down, then boots with the launcher
+func assertRebootWithLauncher(tester *Tester) {
+	tester.AssertOsCommand("wsl.exe", "-t", *distroName)
+	tester.AssertLauncherCommand("run echo Hello")
+}
+
 func TestBasicSetup(t *testing.T) {
 	// Wrapping testing.T to get the friendly additions to its API as declared in `wsl_tester.go`.
 	tester := WslTester(t)
@@ -28,135 +155,16 @@ func TestBasicSetup(t *testing.T) {
 		tester.Fatal("Failed to install the distro: No output produced.")
 	}
 
-	// After completing the setup, the OOBE must have created a new user and the distro launcher must have set it as the default.
-	{
-		outputStr := tester.AssertWslCommand("whoami")
-		notRoot := strings.Fields(outputStr)[0]
-		if notRoot == "root" {
-			tester.Logf("%s", outputStr)
-			tester.Fatal("Default user should not be root.")
-		}
-	}
+	assertUserNotRoot(&tester)
+	// assertLanguagePacksMarked(&tester)
+	assertCorrectReleaseRootfs(&tester)
+	assertSystemdEnabled(&tester)
+	assertSysusersServiceWorks(&tester)
 
-	// Subiquity either installs or marks for installation the relevant language packs for the chosen language.
-	{
-		outputStr := tester.AssertWslCommand("apt-mark", "showinstall", "language-pack\\*")
-		packs := strings.Fields(outputStr)
-		tester.Logf("%s", outputStr) // I'd like to see what packs were installed in the end, just in case.
-		if len(packs) == 0 {
-			tester.Fatal("At least one language pack should have been installed or marked for installation, but apt-mark command output is empty.")
-		}
-	}
+	assertRebootWithLauncher(&tester)
+	assertCorrectUpgradePolicy(&tester)
 
-	// Proper release. Ensures the right tarball was used as rootfs
-	{
-		expectedRelease := func() string {
-			if *distroName == "Ubuntu-Preview" || *distroName == "UbuntuDev.WslID.Dev" {
-				return "Ubuntu Kinetic Kudu (development branch)"
-			}
-			if *distroName == "Ubuntu" {
-				return "Ubuntu 22.04.1 LTS"
-			}
-			if *distroName == "Ubuntu22.04LTS" {
-				return "Ubuntu 22.04.1 LTS"
-			}
-			if *distroName == "Ubuntu20.04LTS" {
-				return "Ubuntu 20.04.5 LTS"
-			}
-			if *distroName == "Ubuntu18.04LTS" {
-				return "Ubuntu 18.04.6 LTS"
-			}
-			return ""
-		}()
-		if len(expectedRelease) == 0 {
-			tester.Logf("Unknown Ubuntu release corresponding to distro name '%s'", *distroName)
-			tester.Fatal("Unexpected value provided via --distro-name")
-		}
-		outputStr := tester.AssertWslCommand("cat", "/etc/os-release")
-		cfg, err := ini.Load([]byte(outputStr))
-		if err != nil {
-			tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
-			tester.Fatal("Failed to parse ini file")
-		}
-
-		release, err := cfg.Section(ini.DefaultSection).GetKey("PRETTY_NAME")
-		if err != nil {
-			tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
-			tester.Fatal("Failed to find PRETTY_NAME")
-		}
-
-		if release.String() != expectedRelease {
-			tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
-			tester.Logf("Parsed release:   %s", release.String())
-			tester.Logf("Expected release: %s", expectedRelease)
-			tester.Fatal("Unexpected release string")
-		}
-	}
-
-	// Systemd enabled.
-	{
-		getSystemdStatus := func() string {
-			outputStr := tester.AssertWslCommand("bash", "-ec", "systemctl is-system-running || exit 0")
-			return strings.TrimSpace(outputStr)
-		}
-
-		status := getSystemdStatus()
-		for status == "starting" {
-			time.Sleep(1 * time.Second)
-			status = getSystemdStatus()
-		}
-
-		if status != "degraded" && status != "running" {
-			tester.Logf("%s", status)
-			tester.Fatal("Systemd should have been enabled")
-		}
-	}
-
-	// Sysusers service fix
-	{
-		tester.AssertWslCommand("systemctl", "status", "systemd-sysusers.service")
-	}
-
-	// ---------------- Reboot with launcher -----------------
-	tester.AssertOsCommand("wsl.exe", "-t", *distroName)
-	tester.AssertLauncherCommand("run echo Hello")
-
-	// Upgrade policy
-	{
-		outputStr := tester.AssertWslCommand("cat", "/etc/update-manager/release-upgrades")
-		cfg, err := ini.Load([]byte(outputStr))
-		if err != nil {
-			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
-			tester.Fatal("Failed to parse ini file")
-		}
-
-		section, err := cfg.GetSection("DEFAULT")
-		if err != nil {
-			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
-			tester.Fatal("Failed to find section DEFAULT in /etc/update-manager/release-upgrades")
-		}
-		value, err := section.GetKey("Prompt")
-		if err != nil {
-			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
-			tester.Fatal("Failed to find key 'Prompt' in DEFAULT section of /etc/update-manager/release-upgrades")
-		}
-		if value.String() != expectedUpgradePolicy() {
-			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
-			tester.Logf("Parsed policy: %s", value.String())
-			tester.Logf("Expected policy: %s", expectedUpgradePolicy())
-			tester.Fatal("Wrong upgrade policy")
-		}
-
-		release_upgrades_date := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
-
-		// ---------------- Reboot with launcher -----------------
-		tester.AssertOsCommand("wsl.exe", "-t", *distroName)
-		tester.AssertLauncherCommand("run echo Hello")
-
-		new_date := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
-		if release_upgrades_date != new_date {
-			tester.Logf("Launcher is modifying release upgrade file more than once")
-		}
-	}
-
+	release_upgrades_date := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
+	assertRebootWithLauncher(&tester)
+	assertUpgradePolicyAppliedOnce(&tester, release_upgrades_date)
 }

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -32,4 +32,17 @@ func TestBasicSetup(t *testing.T) {
 	}
 
 	// TODO: Assert more. We have other expectations about the most basic setup.
+	// Systemd enabled. AssertWslCommand failure is allowed because degraded status exits with code 3
+	outputStr = tester.AssertWslCommand("bash", "-ec", "systemctl is-system-running || exit 0")
+	lines := strings.Fields(outputStr)
+	if len(lines) == 0 {
+		tester.Fatal("systemctl is-system-running printed nothing")
+	}
+	if lines[0] != "degraded" && lines[0] != "running" {
+		tester.Logf("%s", lines[0])
+		tester.Fatal("Systemd should have been enabled")
+	}
+
+	// Sysusers service fix
+	tester.AssertWslCommand("systemctl", "status", "systemd-sysusers.service")
 }

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -40,40 +40,35 @@ func assertLanguagePacksMarked(tester *Tester) {
 // Proper release. Ensures the right tarball was used as rootfs.
 func assertCorrectReleaseRootfs(tester *Tester) {
 	expectedRelease := func() string {
-		if *distroName == "Ubuntu-Preview" || *distroName == "UbuntuDev.WslID.Dev" {
-			return "Ubuntu Kinetic Kudu (development branch)"
+		if *distroName == "Ubuntu-Preview" {
+			return "22.10"
 		}
 		if *distroName == "Ubuntu" {
-			return "Ubuntu 22.04.1 LTS"
+			return "22.04"
 		}
 		if *distroName == "Ubuntu22.04LTS" {
-			return "Ubuntu 22.04.1 LTS"
+			return "22.04"
 		}
 		if *distroName == "Ubuntu20.04LTS" {
-			return "Ubuntu 20.04.5 LTS"
+			return "20.04"
 		}
 		if *distroName == "Ubuntu18.04LTS" {
-			return "Ubuntu 18.04.6 LTS"
+			return "18.04"
 		}
-		return ""
+		return "22.10" // Development version
 	}()
 	if len(expectedRelease) == 0 {
 		tester.Logf("Unknown Ubuntu release corresponding to distro name '%s'", *distroName)
 		tester.Fatal("Unexpected value provided via --distro-name")
 	}
-	outputStr := tester.AssertWslCommand("cat", "/etc/os-release")
+	outputStr := tester.AssertWslCommand("lsb_release", "-r")
 	cfg, err := ini.Load([]byte(outputStr))
 	if err != nil {
 		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
 		tester.Fatal("Failed to parse ini file")
 	}
 
-	release, err := cfg.Section(ini.DefaultSection).GetKey("PRETTY_NAME")
-	if err != nil {
-		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
-		tester.Fatal("Failed to find PRETTY_NAME")
-	}
-
+	release := cfg.Section(ini.DefaultSection).Key("Release")
 	if release.String() != expectedRelease {
 		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
 		tester.Logf("Parsed release:   %s", release.String())

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -86,7 +86,7 @@ func TestBasicSetup(t *testing.T) {
 		}
 
 		if release.String() != expectedRelease {
-			tester.Logf("Output from lsb_release -a:\n%s", outputStr)
+			tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
 			tester.Logf("Parsed release:   %s", release.String())
 			tester.Logf("Expected release: %s", expectedRelease)
 			tester.Fatal("Unexpected release string")

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -158,7 +158,7 @@ func TestBasicSetup(t *testing.T) {
 	}
 
 	assertUserNotRoot(&tester)
-	// assertLanguagePacksMarked(&tester)
+	assertLanguagePacksMarked(&tester)
 	assertCorrectReleaseRootfs(&tester)
 	assertSystemdEnabled(&tester)
 	assertSysusersServiceWorks(&tester)

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -22,111 +22,125 @@ func TestBasicSetup(t *testing.T) {
 	tester := WslTester(t)
 
 	// Invoke the launcher as if the user did: `<launcher>.exe install --ui=gui`
-	outStr := tester.AssertLauncherCommand("install --ui=gui") // without install the launcher will run bash.
+	outStr := tester.AssertLauncherCommand("install --root --ui=none") // without install the launcher will run bash.
 	if len(outStr) == 0 {
 		tester.Fatal("Failed to install the distro: No output produced.")
 	}
 
 	// After completing the setup, the OOBE must have created a new user and the distro launcher must have set it as the default.
-	outputStr := tester.AssertWslCommand("whoami")
-	notRoot := strings.Fields(outputStr)[0]
-	if notRoot == "root" {
-		tester.Logf("%s", outputStr)
-		tester.Fatal("Default user should not be root.")
+	{
+		outputStr := tester.AssertWslCommand("whoami")
+		notRoot := strings.Fields(outputStr)[0]
+		if notRoot == "root" {
+			tester.Logf("%s", outputStr)
+			tester.Fatal("Default user should not be root.")
+		}
 	}
 
 	// Subiquity either installs or marks for installation the relevant language packs for the chosen language.
-	outputStr = tester.AssertWslCommand("apt-mark", "showinstall", "language-pack\\*")
-	packs := strings.Fields(outputStr)
-	tester.Logf("%s", outputStr) // I'd like to see what packs were installed in the end, just in case.
-	if len(packs) == 0 {
-		tester.Fatal("At least one language pack should have been installed or marked for installation, but apt-mark command output is empty.")
+	{
+		outputStr := tester.AssertWslCommand("apt-mark", "showinstall", "language-pack\\*")
+		packs := strings.Fields(outputStr)
+		tester.Logf("%s", outputStr) // I'd like to see what packs were installed in the end, just in case.
+		if len(packs) == 0 {
+			tester.Fatal("At least one language pack should have been installed or marked for installation, but apt-mark command output is empty.")
+		}
+	}
+
 	// Proper release. Ensures the right tarball was used as rootfs
-	expectedRelease := func() string {
-		if *distroName == "Ubuntu-Preview" || *distroName == "UbuntuDev.WslID.Dev" {
-			return "Ubuntu Kinetic Kudu (development branch)"
+	{
+		expectedRelease := func() string {
+			if *distroName == "Ubuntu-Preview" || *distroName == "UbuntuDev.WslID.Dev" {
+				return "Ubuntu Kinetic Kudu (development branch)"
+			}
+			if *distroName == "Ubuntu" {
+				return "Ubuntu 22.04.1 LTS"
+			}
+			if *distroName == "Ubuntu22.04LTS" {
+				return "Ubuntu 22.04.1 LTS"
+			}
+			if *distroName == "Ubuntu20.04LTS" {
+				return "Ubuntu 20.04.5 LTS"
+			}
+			if *distroName == "Ubuntu18.04LTS" {
+				return "Ubuntu 18.04.6 LTS"
+			}
+			return ""
+		}()
+		if len(expectedRelease) == 0 {
+			tester.Logf("Unknown Ubuntu release corresponding to distro name '%s'", *distroName)
+			tester.Fatal("Unexpected value provided via --distro-name")
 		}
-		if *distroName == "Ubuntu" {
-			return "Ubuntu 22.04.1 LTS"
+		outputStr := tester.AssertWslCommand("lsb_release", "-a")
+		release := string("")
+		prefix := "Description:"
+		for _, line := range strings.Split(outputStr, "\n") {
+			if strings.HasPrefix(line, prefix) {
+				release = strings.TrimSpace(line[len(prefix):])
+				break
+			}
 		}
-		if *distroName == "Ubuntu22.04LTS" {
-			return "Ubuntu 22.04.1 LTS"
+		if len(release) == 0 {
+			tester.Logf("Output from lsb_release -a:\n%s", outputStr)
+			tester.Fatal("Could not parse release")
 		}
-		if *distroName == "Ubuntu20.04LTS" {
-			return "Ubuntu 20.04.5 LTS"
+		if release != expectedRelease {
+			tester.Logf("Output from lsb_release -a:\n%s", outputStr)
+			tester.Logf("Parsed release:   %s", release)
+			tester.Logf("Expected release: %s", expectedRelease)
+			tester.Fatal("Unexpected release string")
 		}
-		if *distroName == "Ubuntu18.04LTS" {
-			return "Ubuntu 18.04.6 LTS"
-		}
-		return ""
-	}()
-	if len(expectedRelease) == 0 {
-		tester.Logf("Unknown Ubuntu release corresponding to distro name '%s'", *distroName)
-		tester.Fatal("Unexpected value provided via --distro-name")
-	}
-	outputStr = tester.AssertWslCommand("lsb_release", "-a")
-	release := string("")
-	prefix := "Description:"
-	for _, line := range strings.Split(outputStr, "\n") {
-		if strings.HasPrefix(line, prefix) {
-			release = strings.TrimSpace(line[len(prefix):])
-			break
-		}
-	}
-	if len(release) == 0 {
-		tester.Logf("Output from lsb_release -a:\n%s", outputStr)
-		tester.Fatal("Could not parse release")
-	}
-	if release != expectedRelease {
-		tester.Logf("Output from lsb_release -a:\n%s", outputStr)
-		tester.Logf("Parsed release:   %s", release)
-		tester.Logf("Expected release: %s", expectedRelease)
-		tester.Fatal("Unexpected release string")
 	}
 
 	// Systemd enabled. AssertWslCommand failure is allowed because degraded status exits with code 3
-	outputStr = tester.AssertWslCommand("bash", "-ec", "systemctl is-system-running || exit 0")
-	lines := strings.Fields(outputStr)
-	if len(lines) == 0 {
-		tester.Fatal("systemctl is-system-running printed nothing")
-	}
-	if lines[0] != "degraded" && lines[0] != "running" {
-		tester.Logf("%s", lines[0])
-		tester.Fatal("Systemd should have been enabled")
+	{
+		outputStr := tester.AssertWslCommand("bash", "-ec", "systemctl is-system-running || exit 0")
+		lines := strings.Fields(outputStr)
+		if len(lines) == 0 {
+			tester.Fatal("systemctl is-system-running printed nothing")
+		}
+		if lines[0] != "degraded" && lines[0] != "running" {
+			tester.Logf("%s", lines[0])
+			tester.Fatal("Systemd should have been enabled")
+		}
 	}
 
 	// Sysusers service fix
-	tester.AssertWslCommand("systemctl", "status", "systemd-sysusers.service")
+	{
+		tester.AssertWslCommand("systemctl", "status", "systemd-sysusers.service")
+	}
 
 	// ---------------- Reboot with launcher -----------------
 	tester.AssertOsCommand("wsl.exe", "-t", *distroName)
 	tester.AssertLauncherCommand("run echo Hello")
 
 	// Upgrade policy
-	outputStr = tester.AssertWslCommand("cat", "/etc/update-manager/release-upgrades")
-	cfg, err := ini.Load([]byte(outputStr))
-	if err != nil {
-		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
-		tester.Fatal("Failed to parse ini file")
-	}
+	{
+		outputStr := tester.AssertWslCommand("cat", "/etc/update-manager/release-upgrades")
+		cfg, err := ini.Load([]byte(outputStr))
+		if err != nil {
+			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+			tester.Fatal("Failed to parse ini file")
+		}
 
-	val := cfg.Section("DEFAULT").Key("Prompt").String()
-	if val != expectedUpgradePolicy() {
-		tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
-		tester.Logf("Parsed policy: %s", val)
-		tester.Logf("Expected policy: %s", expectedUpgradePolicy())
-		tester.Fatal("Wrong upgrade policy")
-	}
+		val := cfg.Section("DEFAULT").Key("Prompt").String()
+		if val != expectedUpgradePolicy() {
+			tester.Logf("Contents of /etc/update-manager/release-upgrades:\n%s", outputStr)
+			tester.Logf("Parsed policy: %s", val)
+			tester.Logf("Expected policy: %s", expectedUpgradePolicy())
+			tester.Fatal("Wrong upgrade policy")
+		}
 
-	release_upgrades_date := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
+		release_upgrades_date := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
 
-	// ---------------- Reboot with launcher -----------------
-	tester.AssertOsCommand("wsl.exe", "-t", *distroName)
-	tester.AssertLauncherCommand("run echo Hello")
+		// ---------------- Reboot with launcher -----------------
+		tester.AssertOsCommand("wsl.exe", "-t", *distroName)
+		tester.AssertLauncherCommand("run echo Hello")
 
-	new_date := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
-	if release_upgrades_date != new_date {
-		tester.Logf("Launcher is modifying release upgrade file more than once")
+		new_date := tester.AssertWslCommand("date", "-r", "/etc/update-manager/release-upgrades")
+		if release_upgrades_date != new_date {
+			tester.Logf("Launcher is modifying release upgrade file more than once")
+		}
 	}
 
 }

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -64,13 +64,13 @@ func assertCorrectReleaseRootfs(tester *Tester) {
 	outputStr := tester.AssertWslCommand("lsb_release", "-r")
 	cfg, err := ini.Load([]byte(outputStr))
 	if err != nil {
-		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
+		tester.Logf("Output of lsb_release -r:\n%s", outputStr)
 		tester.Fatal("Failed to parse ini file")
 	}
 
 	release := cfg.Section(ini.DefaultSection).Key("Release")
 	if release.String() != expectedRelease {
-		tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
+		tester.Logf("Output of lsb_release -r:\n%s", outputStr)
 		tester.Logf("Parsed release:   %s", release.String())
 		tester.Logf("Expected release: %s", expectedRelease)
 		tester.Fatal("Unexpected release string")

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -72,22 +72,22 @@ func TestBasicSetup(t *testing.T) {
 			tester.Logf("Unknown Ubuntu release corresponding to distro name '%s'", *distroName)
 			tester.Fatal("Unexpected value provided via --distro-name")
 		}
-		outputStr := tester.AssertWslCommand("lsb_release", "-a")
-		release := string("")
-		prefix := "Description:"
-		for _, line := range strings.Split(outputStr, "\n") {
-			if strings.HasPrefix(line, prefix) {
-				release = strings.TrimSpace(line[len(prefix):])
-				break
-			}
+		outputStr := tester.AssertWslCommand("cat", "/etc/os-release")
+		cfg, err := ini.Load([]byte(outputStr))
+		if err != nil {
+			tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
+			tester.Fatal("Failed to parse ini file")
 		}
-		if len(release) == 0 {
-			tester.Logf("Output from lsb_release -a:\n%s", outputStr)
-			tester.Fatal("Could not parse release")
+
+		release, err := cfg.Section(ini.DefaultSection).GetKey("PRETTY_NAME")
+		if err != nil {
+			tester.Logf("Contents of /etc/os-release:\n%s", outputStr)
+			tester.Fatal("Failed to find PRETTY_NAME")
 		}
-		if release != expectedRelease {
+
+		if release.String() != expectedRelease {
 			tester.Logf("Output from lsb_release -a:\n%s", outputStr)
-			tester.Logf("Parsed release:   %s", release)
+			tester.Logf("Parsed release:   %s", release.String())
 			tester.Logf("Expected release: %s", expectedRelease)
 			tester.Fatal("Unexpected release string")
 		}


### PR DESCRIPTION
The launcher modifies some config files in WSL. These tests verify this happens.

Feature commits:
- [96dc60f](https://github.com/ubuntu/WSL/pull/292/commits/96dc60fed90c6e378b7a75c28bef92b7b8a8c180) tests that systemd is enabled and that the fixes the launcher applies to to sysusers service work.
- [8acfd93](https://github.com/ubuntu/WSL/pull/292/commits/8acfd9380b3c1698bbf99fa154d86940e15e11ae) tests that the upgrade policy is set according to the distro name
- [5f1d754](https://github.com/ubuntu/WSL/pull/292/commits/5f1d754a91c292480008406d5571fabb2ef7befc) tests that we used the right rootfs link. This test will have to be updated every time there is new release. I didn't want to automate it because the point of this test is to test this very automation.

Cleanup commits:
- [7cf259e](https://github.com/ubuntu/WSL/pull/292/commits/7cf259e33d6b861e82a6feda516e7283cd61516f). This commit is best viewed without whitespace diffs. I enclosed each set of assertions in their own scope to avoid bleeding variables from one test to the next one. This commit makes big enough changes that merging the latter cleanup commits with the previous ones is too much of a hassle.

Later commits are bugfixes and smaller changes.