### PR TITLE
Adding test to validate most common installation procedure

### DIFF
--- a/e2e/test-runner/default_experience_test.go
+++ b/e2e/test-runner/default_experience_test.go
@@ -1,0 +1,81 @@
+package test_runner
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Parses the output of wsl -l -v to find the STATE of the current distro
+func assertGetDistroState(t *Tester) string {
+	// wsl -l -v outputs UTF-16 (See https://github.com/microsoft/WSL/issues/4607)
+	// We use $env:WSL_UTF8=1 to prevent this (Available from 0.64.0 onwards https://github.com/microsoft/WSL/releases/tag/0.64.0)
+	str := t.AssertOsCommand("powershell.exe", "-noninteractive", "-nologo", "-noprofile", "-command",
+		"$env:WSL_UTF8=1 ; wsl -l -v")
+
+	for _, line := range strings.Split(str, "\n")[1:] {
+		columns := strings.Fields(line)
+		// columns = {[*], distroName, state, WSL-version}
+		if len(columns) < 3 {
+			continue
+		}
+		idx := 0
+		if columns[idx] == "*" {
+			idx++
+		}
+		if columns[idx] == *distroName {
+			return columns[idx+1]
+		}
+	}
+	return "DistroNotFound"
+}
+
+// Waits until the current state (fromState) transitions into toState.
+// Fails if any other state is reached
+func assertWaitStateTransition(tester *Tester, outbuff *bytes.Buffer, fromState string, toState string) string {
+	state := assertGetDistroState(tester)
+	for state == fromState {
+		time.Sleep(1 * time.Second)
+		state = assertGetDistroState(tester)
+	}
+	if state != toState {
+		tester.Logf("In transition from '%s' to '%s': Unexpected state '%s'", fromState, toState, state)
+		tester.Logf("Output: %s", outbuff.String())
+		tester.Fatal("Unexpected Distro state transition")
+	}
+	return state
+}
+
+// This tests the experience that most users have:
+// opening WSL from the store or from the Start menu
+func TestDefaultExperience(t *testing.T) {
+	tester := WslTester(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	shellCommand := []string{"-noninteractive", "-nologo", "-noprofile", "-command",
+		*launcherName, "install --root --ui=none"} // TODO: Change to ...*launcherName, "--hide-console")
+	cmd := exec.CommandContext(ctx, "powershell.exe", shellCommand...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	cmd.Start()
+
+	// Completing installation
+	assertWaitStateTransition(&tester, &out, "DistroNotFound", "Installing")
+	assertWaitStateTransition(&tester, &out, "Installing", "Running")
+	assertWaitStateTransition(&tester, &out, "Running", "Stopped")
+
+	// Ensuring proper installation
+	if !strings.Contains(out.String(), "Installation successful!") { // TODO: Change this to parse MOTD
+		tester.Logf("Status: %s", assertGetDistroState(&tester))
+		tester.Logf("Output: %s", out.String())
+		tester.Fatal("Distro was shut down without finishing install")
+	}
+}

--- a/e2e/test-runner/default_experience_test.go
+++ b/e2e/test-runner/default_experience_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Parses the output of wsl -l -v to find the STATE of the current distro
+// Fails if the state cannot be parsed
 func assertGetDistroState(t *Tester, distro string) string {
 	// wsl -l -v outputs UTF-16 (See https://github.com/microsoft/WSL/issues/4607)
 	// We use $env:WSL_UTF8=1 to prevent this (Available from 0.64.0 onwards https://github.com/microsoft/WSL/releases/tag/0.64.0)
@@ -33,6 +34,7 @@ func assertGetDistroState(t *Tester, distro string) string {
 
 // Waits until the current state (fromState) transitions into toState.
 // Fails if any other state is reached
+// Fails if the state cannot be parsed
 func assertWaitStateTransition(tester *Tester, distro string, fromState string, toState string) string {
 	tester.Logf("Awaiting state transition: %s -> %s", fromState, toState)
 	state := assertGetDistroState(tester, distro)

--- a/e2e/test-runner/default_experience_test.go
+++ b/e2e/test-runner/default_experience_test.go
@@ -53,7 +53,7 @@ func assertWaitStateTransition(tester *Tester, distro string, fromState string, 
 // has finsihed.
 // Considerations:
 // - It fails if the log cannot be accessed.
-// - That the server may still run for a small amount of time after the log
+// - The server may still run for a small amount of time after the log
 //   says it has finished. Exeperimentally, it seems to be less than a second.
 // - The State of the ditro is assumed to be either Running or Stopped when called
 func assertWaitForInstaller(tester *Tester) {

--- a/e2e/test-runner/default_experience_test.go
+++ b/e2e/test-runner/default_experience_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Parses the output of wsl -l -v to find the STATE of the current distro
-func assertGetDistroState(t *Tester) string {
+func assertGetDistroState(t *Tester, distro string) string {
 	// wsl -l -v outputs UTF-16 (See https://github.com/microsoft/WSL/issues/4607)
 	// We use $env:WSL_UTF8=1 to prevent this (Available from 0.64.0 onwards https://github.com/microsoft/WSL/releases/tag/0.64.0)
 	str := t.AssertOsCommand("powershell.exe", "-noninteractive", "-nologo", "-noprofile", "-command",
@@ -26,7 +26,7 @@ func assertGetDistroState(t *Tester) string {
 		if columns[idx] == "*" {
 			idx++
 		}
-		if columns[idx] == *distroName {
+		if columns[idx] == distro {
 			return columns[idx+1]
 		}
 	}
@@ -35,11 +35,11 @@ func assertGetDistroState(t *Tester) string {
 
 // Waits until the current state (fromState) transitions into toState.
 // Fails if any other state is reached
-func assertWaitStateTransition(tester *Tester, outbuff *bytes.Buffer, fromState string, toState string) string {
-	state := assertGetDistroState(tester)
+func assertWaitStateTransition(tester *Tester, outbuff *bytes.Buffer, distro string, fromState string, toState string) string {
+	state := assertGetDistroState(tester, distro)
 	for state == fromState {
 		time.Sleep(1 * time.Second)
-		state = assertGetDistroState(tester)
+		state = assertGetDistroState(tester, distro)
 	}
 	if state != toState {
 		tester.Logf("In transition from '%s' to '%s': Unexpected state '%s'", fromState, toState, state)
@@ -68,13 +68,13 @@ func TestDefaultExperience(t *testing.T) {
 	cmd.Start()
 
 	// Completing installation
-	assertWaitStateTransition(&tester, &out, "DistroNotFound", "Installing")
-	assertWaitStateTransition(&tester, &out, "Installing", "Running")
-	assertWaitStateTransition(&tester, &out, "Running", "Stopped")
+	assertWaitStateTransition(&tester, &out, *distroName, "DistroNotFound", "Installing")
+	assertWaitStateTransition(&tester, &out, *distroName, "Installing", "Running")
+	assertWaitStateTransition(&tester, &out, *distroName, "Running", "Stopped")
 
 	// Ensuring proper installation
 	if !strings.Contains(out.String(), "Installation successful!") { // TODO: Change this to parse MOTD
-		tester.Logf("Status: %s", assertGetDistroState(&tester))
+		tester.Logf("State: %s", assertGetDistroState(&tester, *distroName))
 		tester.Logf("Output: %s", out.String())
 		tester.Fatal("Distro was shut down without finishing install")
 	}

--- a/e2e/test-runner/default_experience_test.go
+++ b/e2e/test-runner/default_experience_test.go
@@ -58,7 +58,7 @@ func TestDefaultExperience(t *testing.T) {
 	defer cancel()
 
 	shellCommand := []string{"-noninteractive", "-nologo", "-noprofile", "-command",
-		*launcherName, "install --root --ui=none"} // TODO: Change to ...*launcherName, "--hide-console")
+		*launcherName, "--hide-console"}
 	cmd := exec.CommandContext(ctx, "powershell.exe", shellCommand...)
 
 	var out bytes.Buffer
@@ -73,7 +73,7 @@ func TestDefaultExperience(t *testing.T) {
 	assertWaitStateTransition(&tester, &out, *distroName, "Running", "Stopped")
 
 	// Ensuring proper installation
-	if !strings.Contains(out.String(), "Installation successful!") { // TODO: Change this to parse MOTD
+	if !strings.Contains(out.String(), "Installation successful!") {
 		tester.Logf("State: %s", assertGetDistroState(&tester, *distroName))
 		tester.Logf("Output: %s", out.String())
 		tester.Fatal("Distro was shut down without finishing install")

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 func getDistroStatus(t *Tester) string {
+	// wsl -l -v outputs UTF-16 (See https://github.com/microsoft/WSL/issues/4607)
+	// We use $env:WSL_UTF8=1 to prevent this (Available from 0.64.0 onwards https://github.com/microsoft/WSL/releases/tag/0.64.0)
 	str := t.AssertOsCommand("powershell.exe", "-noninteractive", "-nologo", "-noprofile", "-command",
-		"(wsl -l -v) -replace '\\x00'")
+		"$env:WSL_UTF8=1 ; wsl -l -v")
 
 	for _, line := range strings.Split(str, "\n")[1:] {
 		columns := strings.Fields(line)

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -93,7 +93,7 @@ func TestDefaultExperience(t *testing.T) {
 		return status
 	}
 
-	// Polling until registration starts
+	// Completing installation
 	assertStatusTransition("DistroNotFound", "Installing")
 	assertStatusTransition("Installing", "Running")
 	assertStatusTransition("Running", "Stopped")

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -86,16 +86,16 @@ func assertSystemdEnabled(tester *Tester) {
 		return strings.TrimSpace(outputStr)
 	}
 
-	state := getSystemdStatus()
-	if state != "degraded" && state != "running" {
-		tester.Logf("%s", state)
+	status := getSystemdStatus()
+	if status != "degraded" && status != "running" {
+		tester.Logf("%s", status)
 		tester.Fatal("Systemd failed to start")
 	}
 }
 
 // Sysusers service fix
 func assertSysusersServiceWorks(tester *Tester) {
-	tester.AssertWslCommand("systemctl", "state", "systemd-sysusers.service")
+	tester.AssertWslCommand("systemctl", "status", "systemd-sysusers.service")
 }
 
 // Upgrade policy matches launcher

--- a/e2e/test-runner/runner_test.go
+++ b/e2e/test-runner/runner_test.go
@@ -70,7 +70,7 @@ func TestDefaultExperience(t *testing.T) {
 	defer cancel()
 
 	shellCommand := []string{"-noninteractive", "-nologo", "-noprofile", "-command",
-		*launcherName, "--hide-console"}
+		*launcherName, "install --root --ui=none"} // TODO: Change to ...*launcherName, "--hide-console")
 	cmd := exec.CommandContext(ctx, "powershell.exe", shellCommand...)
 
 	var out bytes.Buffer

--- a/e2e/test-runner/wsl_tester.go
+++ b/e2e/test-runner/wsl_tester.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ubuntu/wsl/e2e/constants"
 )
 
-const serverLogPath = "/var/log/installer/systemsetup-server-debug.log"
+const ServerLogPath = "/var/log/installer/systemsetup-server-debug.log"
 const clientLogPath = "ubuntu-desktop-installer/packages/ubuntu_wsl_setup/build/windows/runner/Debug/.ubuntu_wsl_setup.exe/ubuntu_wsl_setup.exe.log"
 
 var launcherName = flag.String("launcher-name", constants.DefaultLauncherName, "WSL distro launcher under test.")
@@ -43,7 +43,7 @@ func WslTester(t *testing.T) Tester {
 		// print debug logs
 		if tester.Failed() {
 			tester.Log("\n\n=== Server Debug Log ====")
-			output, err := exec.Command("wsl.exe", "-d", *distroName, "cat", serverLogPath).CombinedOutput()
+			output, err := exec.Command("wsl.exe", "-d", *distroName, "cat", ServerLogPath).CombinedOutput()
 			if err == nil {
 				tester.Logf("%s", output)
 			} else {


### PR DESCRIPTION
## Motivation

`launcher.exe --hide-console` is the command line used by the Start Menu and by the Store app installer to invoke the distro launcher. That is most likely the preferred way users interact with the distro launcher during the initial setup. When the setup is complete the launcher runs the shell, which depends on user interaction to exit.

## Initial (bad) idea
In order to mimick this, we launch the aforementioned command in a forked process and monitor it from the original process by capturing its StdErr, StdOut and the distro status as shown by `wsl -l -v`. Note that I have not found a way to capture the text written to console by WSL's interactive session, as it is sent neither to StdOut nor StdErr.

*Result*:  WSL knows it's not running in a terminal and hence does not run the same way. For instance, it's not held open indefinitely. (This is also likely the reason I didn't capture any text: it is never displayed).

## Current approach
Open a new tab in Windows Terminal. This is basically the same as forking the process, with the added bonus of WSL detecting it is running in a terminal:
```PS
wt.exe --window 0 -d . powershell.exe -noExit launcher.exe --hide-console
#                                     ^~~~~~~
#                                     WSL never shuts down without this 🤷 
```

I have not found how to read from this console either.
