### PR TITLE
End-to-end testing bed preparation script

### DIFF
--- a/e2e/pre-e2e-testing.ps1
+++ b/e2e/pre-e2e-testing.ps1
@@ -13,7 +13,8 @@
 #   e2e testing enabled appx is installed.
 
 param (
-    [Parameter(Mandatory=$true, HelpMessage="UbuntuPreview, Ubuntu22.04LTS etc etc.")]
+    [Parameter(Mandatory=$true, HelpMessage="UbuntuPreview, Ubuntu22.04LTS, etc.")]
+
     [string]$AppID,
     [Parameter(Mandatory=$true, HelpMessage="the URL to fetch the rootfs from used for this build")]
     [string]$RootFsX64,

--- a/e2e/pre-e2e-testing.ps1
+++ b/e2e/pre-e2e-testing.ps1
@@ -3,6 +3,7 @@
 # Parameters:
 #   AppID = UbuntuPreview, Ubuntu22.04LTS etc etc.
 #   RootFsX64 = URL for the rootfs used for this build
+#   CertificateThumbprint = Optional: Thumbprint of the local certificate to use when signing the package.
 #
 # Preconditions:
 #   PWD=$env:LAUNCHER_REPO_ROOT
@@ -12,10 +13,12 @@
 #   e2e testing enabled appx is installed.
 
 param (
-    [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+    [Parameter(Mandatory=$true, HelpMessage="UbuntuPreview, Ubuntu22.04LTS etc etc.")]
     [string]$AppID,
-    [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-    [string]$RootFsX64
+    [Parameter(Mandatory=$true, HelpMessage="the URL to fetch the rootfs from used for this build")]
+    [string]$RootFsX64,
+    [Parameter(Mandatory=$false, HelpMessage="Optional: Thumbprint of the local certificate to use when signing the package.")]
+    [string]$CertificateThumbprint
 )
 
 function FailFast($exitCode){
@@ -39,15 +42,26 @@ FailFast ($LastExitCode)
 # Remove ARM64 contents out of the solution file
 Set-Content -Path "DistroLauncher.sln" -Value (get-content -Path "DistroLauncher.sln" | Select-String -Pattern 'ARM64' -NotMatch)
 
-# Actions should inherit Secrets even in the case of self-hosted runners. Not touching it here.
+# Actions should inherit Secrets even in the case of self-hosted runners. Not touching it here, unless another thumbprint is set.
+# Useful for local development.
+If ( -Not [string]::IsNullOrEmpty($CertificateThumbprint)) {
+    Write-Output "Modifying signing certificate"
+    $vcxprojFile = "DistroLauncher-Appx/DistroLauncher-Appx.vcxproj"
+    $thumbprintEntry = "<PackageCertificateThumbprint>@</PackageCertificateThumbprint>"
+    $wildCard = $thumbprintEntry.replace("@", ".*")
+    $replacement = $thumbprintEntry.replace("@", $CertificateThumbprint)
+
+    [regex]::replace($(Get-Content -Path $vcxprojFile), $wildCard, $replacement) | Set-Content -Path $vcxprojFile
+}
 
 # Copies the ui-driver.props file to force MSBuild to bundle that binary inside the appx.
 cp ./e2e/ui-driver/ui-driver.props DistroLauncher-Appx/
 
 # Build the appx bundle for E2E testing
-msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Debug /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal /p:OOBE_E2E_TESTING=True
+msbuild ./DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Debug /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal /p:OOBE_E2E_TESTING=True
 FailFast ($LastExitCode)
 
 # Install the appx
-./AppPackages/Ubuntu/*/Install.ps1 -Force
+$OutputDir = $(Get-ChildItem -Directory .\AppPackages\Ubuntu\ | Sort-Object -Property {$_.LastWriteTime} -Descending)[0].Name
+Invoke-Expression "./AppPackages/Ubuntu/$OutputDir/Install.ps1 -Force"
 FailFast ($LastExitCode)

--- a/e2e/pre-e2e-testing.ps1
+++ b/e2e/pre-e2e-testing.ps1
@@ -1,0 +1,53 @@
+# Builds and installs the appx for end-to-end testing.
+#
+# Parameters:
+#   AppID = UbuntuPreview, Ubuntu22.04LTS etc etc.
+#   RootFsX64 = URL for the rootfs used for this build
+#
+# Preconditions:
+#   PWD=$env:LAUNCHER_REPO_ROOT
+#   No ARM64 testing
+#
+# Postconditions:
+#   e2e testing enabled appx is installed.
+
+param (
+    [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+    [string]$AppID,
+    [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+    [string]$RootFsX64
+)
+
+function FailFast($exitCode){
+    If ($exitCode) {
+        exit $exitCode
+    }
+}
+
+#
+# Main script entry point
+#
+
+# Builds the meta build system
+go build ./wsl-builder/prepare-build
+FailFast ($LastExitCode)
+
+# Prepares the build system for the desired AppID
+./prepare-build prepare build.txt $AppID "$RootFsX64::amd64"
+FailFast ($LastExitCode)
+
+# Remove ARM64 contents out of the solution file
+Set-Content -Path "DistroLauncher.sln" -Value (get-content -Path "DistroLauncher.sln" | Select-String -Pattern 'ARM64' -NotMatch)
+
+# Actions should inherit Secrets even in the case of self-hosted runners. Not touching it here.
+
+# Copies the ui-driver.props file to force MSBuild to bundle that binary inside the appx.
+cp ./e2e/ui-driver/ui-driver.props DistroLauncher-Appx/
+
+# Build the appx bundle for E2E testing
+msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Debug /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal /p:OOBE_E2E_TESTING=True
+FailFast ($LastExitCode)
+
+# Install the appx
+./AppPackages/Ubuntu/*/Install.ps1 -Force
+FailFast ($LastExitCode)

--- a/e2e/pre-e2e-testing.ps1
+++ b/e2e/pre-e2e-testing.ps1
@@ -56,7 +56,7 @@ If ( -Not [string]::IsNullOrEmpty($CertificateThumbprint)) {
 }
 
 # Copies the ui-driver.props file to force MSBuild to bundle that binary inside the appx.
-cp ./e2e/ui-driver/ui-driver.props DistroLauncher-Appx/
+Copy-Item ./e2e/ui-driver/ui-driver.props DistroLauncher-Appx/
 
 # Build the appx bundle for E2E testing
 msbuild ./DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Debug /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal /p:OOBE_E2E_TESTING=True


### PR DESCRIPTION
This PR adds a script to be invoked either locally or via CI to build the end-to-end testing enabled application package bundle.

I'd love to receive a recommendation for a better way to `FailFast`. That looks ugly to me, but Powershell is not on my skillset. 😅 

To test it locally, run from the repository root:

> ### I'd really appreciate if you guys could do some local tests before approving this.

```
.\e2e\pre-e2e-testing.ps1 -AppID "UbuntuPreview" -RootfsX64 <rootfs_URL> -CertificateThumbprint <your_pfx_thumbprint>

$env:LAUNCHER_REPO_ROOT=$(pwd).Path

cd .\e2e

go test .\test-runner --distro-name Ubuntu-Preview --launcher-name ubuntupreview.exe
```

Rootfs URL can be a local path.



### Why not making the script run the tests as well?

My reasoning was that we will more often touch the interpreted code (`test-runner` Go module and the Flutter automation code) then the compiled one (`ui-driver` Go module and the C++ distro launcher or even the rootfs) when interacting with the end-to-end test. Thus, using this script as a convenient way to invoke the test runner would be an overkill.

The script should simplify getting from the pristine repository to a working test setup by building and installing the appx. After that, the developer should be free to iterate over the testing scenarios. CI will do the same soon.
