### PR TITLE
Testing Psexec -h option for elevated token

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Hello World
         shell: powershell
         run: |
-          $higherSession=0
+         <# $higherSession=0
           $count = 0
           While ($higherSession -lt 2) {
             Sleep 5
@@ -51,9 +51,9 @@ jobs:
               $higherSession=$( $sessions )[0].ToString()[-1]
             }
 
-          }
+          } #>
           
-          c:\sysinternalssuite\psexec.exe -nobanner -accepteula -w $PWD.Path -i $higherSession powershell.exe -Command `
+          c:\sysinternalssuite\psexec.exe -nobanner -accepteula -w $PWD.Path -h -i 1 powershell.exe -Command `
             "&{ `$env:WSL_UTF8=1`; wsl.exe --version; wsl.exe --list --online;} 3>&1 2>&1 > .\test.log"
 
           Get-Content ".\test.log"


### PR DESCRIPTION
-h option should avoid UAC issues. It is testing to see if UAC is the root cause for the access denied