### PR TITLE
Prevents Ubuntu and Ubuntu-22.04 installation problem

### DIFF
--- a/DistroLauncher-Appx/Directory.build.props
+++ b/DistroLauncher-Appx/Directory.build.props
@@ -12,16 +12,10 @@
 	</ItemGroup>
 	<ItemGroup>
 		<FlutterAppFiles Include="$(FlutterAppDir)" />
+		<None Include="@(FlutterAppFiles)">
+			<DeploymentContent>true</DeploymentContent>
+		</None>
 	</ItemGroup>
-	<Choose>
-		<When Condition=" '$(Platform)' == 'x64' ">
-			<ItemGroup>
-				<None Include="@(FlutterAppFiles)">
-					<DeploymentContent>true</DeploymentContent>
-				</None>
-			</ItemGroup>
-		</When>
-	</Choose>
 	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterAppDir))">
 		<Message Text="Building Flutter artifacts" Importance="high"/>
 		<Exec Command="git submodule update --init" />


### PR DESCRIPTION
The failure was a very strange complain about not being able to merge a resource.pri file from some inner asset package of the bundle.

```
Merge failure for shared merged PRI file: error 0x80070490: no se puede registrar el paquete CanonicalGroupLimited.Ubuntu_2204.1.9999.0_x64__79rhkp1fndgsc porque 
hubo un error de combinación con el siguiente archivo: C:\Program
Files\WindowsApps\CanonicalGroupLimited.Ubuntu_2204.1.9999.0_neutral_split.scale-150_79rhkp1fndgsc\resources.pri
```

Removing the conditional inclusion of the Flutter app prevented the error (making it unconditionally being included for both architectures, even though it won't run on ARM64). The relationship between the problem and the fix is not apparent. Also, the Ubuntu-Preview has the same conditional but installs correctly. Further troubleshooting will be required later.

For now let's get the problem sorted out.