### PR TITLE
Disables snapd v2.57.4 before running the OOBE

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj
@@ -81,6 +81,7 @@ if EXIST "$(SharedIdb)" xcopy /Y /F "$(SharedIdb)" "$(IntDir)"</Command>
     <ClCompile Include="..\..\DistroLauncher\OOBE.cpp" />
     <ClCompile Include="..\..\DistroLauncher\ProcessRunner.cpp" />
     <ClCompile Include="..\..\DistroLauncher\SetOnceNamedEvent.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\snapd.cpp" />
     <ClCompile Include="..\..\DistroLauncher\stdafx.cpp" />
     <ClCompile Include="..\..\DistroLauncher\upgrade_policy.cpp" />
     <ClCompile Include="..\..\DistroLauncher\Win32Utils.cpp" />

--- a/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/DistroLauncher-Tests.vcxproj.filters
@@ -100,6 +100,7 @@
       <Filter>TestSources</Filter>
     </ClCompile>
     <ClCompile Include="..\..\DistroLauncher\AppConfig.cpp" />
+    <ClCompile Include="..\..\DistroLauncher\snapd.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="InstallerControllerTestPolicies.h" />

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "extended_cli_parser.h"
+#include "snapd.h"
 
 namespace Oobe
 {
@@ -68,6 +69,8 @@ namespace Oobe
         {
             using namespace internal;
             wprintf(L"Unpacking is complete!\n");
+            // any required clean-up action will be taken by this guard.
+            auto scopeGuard = TempDisableSnapd(g_wslApi, DistributionInfo::Name);
             HRESULT hr =
               std::visit(internal::overloaded{
                            [&](AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
@@ -102,6 +105,8 @@ namespace Oobe
         HRESULT reconfigure()
         {
             if (isReconfig()) {
+                // any required clean-up action will be taken by this guard.
+                auto scopeGuard = TempDisableSnapd(g_wslApi, DistributionInfo::Name);
                 return impl_.do_reconfigure();
             }
 

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -160,6 +160,7 @@
     <ClInclude Include="ProcessRunner.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SetOnceNamedEvent.h" />
+    <ClInclude Include="snapd.h" />
     <ClInclude Include="SplashEnabledStrategy.h" />
     <ClInclude Include="splash_controller.h" />
     <ClInclude Include="state_machine.h" />
@@ -193,6 +194,7 @@
     <ClCompile Include="find_main_thread_window.cpp" />
     <ClCompile Include="ini_find_value.cpp" />
     <ClCompile Include="SetOnceNamedEvent.cpp" />
+    <ClCompile Include="snapd.cpp" />
     <ClCompile Include="SplashEnabledStrategy.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>

--- a/DistroLauncher/snapd.cpp
+++ b/DistroLauncher/snapd.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "snapd.h"
+
+namespace Oobe::internal
+{
+    const std::wstring TempDisableSnapdImpl(WslApiLoader& api, const std::wstring& distroName)
+    {
+        // Disables snapd.service and patches wsl-setup to find the snaps inside the seed directory
+        // since most likely snap will have messed with the hard links.
+        // This fails (exit 1) if the snapd version doesn't match the bad one or the subsequent commands fail.
+        const wchar_t* disableSnapd_v2_57_4_script =
+          LR"( [[ "$(dpkg-query --show snapd | cut -f2) " == "2.57.4"* ]] && ln -sT /dev/null /etc/systemd/system/snapd.service && sed -i 's#/var/lib/snapd/snaps/#/var/lib/snapd/seed/snaps/#g' /usr/libexec/wsl-setup )";
+        const std::wstring script = concat(L"bash -ec ", std::quoted(disableSnapd_v2_57_4_script));
+
+        DWORD exitCode = 0;
+        api.WslLaunchInteractive(script.c_str(), FALSE, &exitCode);
+
+        if (exitCode == 0) {
+            const std::wstring cmd = concat(L"wsl -t", distroName);
+            _wsystem(cmd.c_str());
+        }
+
+        return L"rm /etc/systemd/system/snapd.service || true";
+    }
+
+}

--- a/DistroLauncher/snapd.h
+++ b/DistroLauncher/snapd.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+namespace Oobe
+{
+    /// Utility object class capable of running any callable in the exit scope.
+    /// Be careful when passing lambdas with reference-captures since it will be called during destruction,
+    /// thus the referenced objects may have been already destroyed.
+    /// Please capture only objects outliving this one!!! Otherwise, make copies.
+    template <typename OnScopeExit> class ScopeGuard
+    {
+      public:
+        ScopeGuard(OnScopeExit&& callable) : callable{std::forward<OnScopeExit>(callable)} {};
+        ~ScopeGuard()
+        {
+            callable();
+        }
+
+      private:
+        OnScopeExit callable;
+    };
+
+    namespace internal
+    {
+        /// Executes a script to check and disable the correct version of snapd conflicting with the OOBE.
+        /// Returns the clean-up command that must run in the end of the calling scope.
+        /// Warning: the distro instance may shut down.
+        const std::wstring TempDisableSnapdImpl(WslApiLoader& api, const std::wstring& distroName);
+    }
+
+    /// Checks and temporarily disables the correct version of snapd conflicting with the OOBE.
+    /// Returns an object that runs the matching clean up command when the caller scope exits.
+    auto TempDisableSnapd(WslApiLoader& api, const std::wstring& distroName)
+    {
+        auto command = internal::TempDisableSnapdImpl(api, distroName);
+        // api is a global and command is captured by copy.
+        return ScopeGuard([&api, command]() {
+            [[maybe_unused]] DWORD unused;
+            api.WslLaunchInteractive(command.c_str(), FALSE, &unused);
+        });
+    }
+}


### PR DESCRIPTION
We found out during development of the end-to-end test CI workflow that if enough time elapsed between enabling systemd in the `/etc/wsl.conf` file and actually running the OOBE, the distro would restart with systemd as PID 1, snapd service would try to run, but because the current version shipped with the Kinetic's rootfs is broken for WSL (v2.57.4), it left the distro filesystem in a bad state where the snaps we need to run the OOBE becomes not found on the expected directory.

That behavior was not easily discoverable through other kinds of tests, because it seems almost impossible to have enough time between enabling systemd and running the OOBE in production. I wonder if a much slower host computer would behave similar to the end-to-end test, but I still don't know at this point.

This is very similar to the state described in [this comment on Launchpad](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1990884/comments/11), but this time this is caused after the distro runs for the first time. Originally the rootfs had the snaps hardlinks in the proper place.

Thus, the solution is temporarily disable snapd service before running the OOBE and renabling them afterwards, no matter how the scope exits. Also, since it may have messed with the hardlinks at this point, we need to patch the `wsl-setup` scripts to look for the snaps in `/var/lib/snapd/seed/snaps` (the seed directory) instead of the expected place.

---
## Note on the tests

Notice that now our CI are failing for a proper reason:

- See the line 70 of the `e2e/Run tests` logs -- [this run](https://github.com/ubuntu/WSL/actions/runs/3299885195/jobs/5443769878)):

```
--- FAIL: TestBasicSetup (160.27s)
    runner_test.go:34: 
    runner_test.go:36: At least one language pack should have been installed or marked for installation, but apt-mark command output is empty.
```

- And see line 152 of the same run and step shows the extract of the SERVER log that reveals the reason for the assertion failure:

```
        2022-10-21 19:23:54,899 ERROR system_setup.server.controllers.configure:157 Misconfigured snap environment pointed L-S-C data dir to /snap/subiquity/current/usr/share/language-selector
        2022-10-21 19:23:54,899 ERROR system_setup.server.controllers.configure:186 Failed to detect recommended language packs.
        2022-10-21 19:23:54,899 ERROR system_setup.server.controllers.configure:293 Failed to install recommended language packs.
```

That issue is addressed in the following PR: 