### PR TITLE
Addresses loss of comm between splash and launcher

### DIFF
--- a/DistroLauncher/ChildProcess.cpp
+++ b/DistroLauncher/ChildProcess.cpp
@@ -62,7 +62,11 @@ namespace Oobe
                                  &procInfo);                // output: PROCESS_INFORMATION
         auto ok = res != 0 && procInfo.hProcess != nullptr; // success
         if (ok) {
-            WaitForInputIdle(procInfo.hProcess, INFINITE);
+            if (appConfig().requiresNewConsole) {
+                // This doesn't seem useful if the child is a window application. But showed useful when dealing with the PoC e2e test.
+                // See https://github.com/ubuntu/WSL/pull/278
+                WaitForInputIdle(procInfo.hProcess, INFINITE);
+            }
             RegisterWaitForSingleObject(&waiterHandle, procInfo.hProcess, onClose, this, INFINITE,
                                         WT_EXECUTEDEFAULT | WT_EXECUTEONLYONCE);
         }

--- a/DistroLauncher/ChildProcess.cpp
+++ b/DistroLauncher/ChildProcess.cpp
@@ -63,8 +63,8 @@ namespace Oobe
         auto ok = res != 0 && procInfo.hProcess != nullptr; // success
         if (ok) {
             if (appConfig().requiresNewConsole) {
-                // This doesn't seem useful if the child is a window application. But showed useful when dealing with the PoC e2e test.
-                // See https://github.com/ubuntu/WSL/pull/278
+                // This doesn't seem useful if the child is a window application. But showed useful when dealing with
+                // the PoC e2e test. See https://github.com/ubuntu/WSL/pull/278
                 WaitForInputIdle(procInfo.hProcess, INFINITE);
             }
             RegisterWaitForSingleObject(&waiterHandle, procInfo.hProcess, onClose, this, INFINITE,


### PR DESCRIPTION
The wait introduced in https://github.com/ubuntu/WSL/pull/278 broke the communication between the splash app (the slide show only) and launcher. The splash communicates its HWND on creation, through a named pipe created by the launcher. The wait caused the splash window to try to communicate before the named pipe was created. That wait is only useful if the child is a console app (the case for E2E). Thus, the appConfig check makes sense.

In the certainty that we will soon backport the OOBE on Windows to Jammy and thus deprecate the slide-show-only splash application, a more robust fix would be an overkill.