### PR TITLE
Default setup experience to bypass Ubuntu OOBE

### DIFF
--- a/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
+    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
       <uap:VisualElements DisplayName="UbuntuDev.FullName.Dev" Description="UbuntuDev.FullName.Dev on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -50,7 +50,15 @@ namespace Oobe
         /// That implies partial command line parsing, with the required actions deferred to the upstream code.
         bool shouldSkipInstaller()
         {
-            return std::holds_alternative<std::monostate>(arg);
+            using namespace internal;
+            if (DistributionInfo::Name == L"Ubuntu-Preview") {
+                return std::holds_alternative<std::monostate>(arg);
+            }
+            // `wsl --install` precaution: I don't know yet whether it follows the appxmanifest entry point CLI args
+            // or if it invokes the distro launcher with no command line parameters. So, OOBE will only be available if
+            // user commands `--ui=[gui/tui]`.
+            return std::holds_alternative<std::monostate>(arg) || std::holds_alternative<InstallDefault>(arg) ||
+                   std::holds_alternative<InstallOnlyDefault>(arg);
         }
 
         /// Constructs the initial state of the application. The [arguments] vector is assumed not to hold the argv[0]

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu" Executable="ubuntu.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
+    <Application Id="ubuntu" Executable="ubuntu.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
       <uap:VisualElements DisplayName="Ubuntu" Description="Ubuntu on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
+    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
       <uap:VisualElements DisplayName="Ubuntu 18.04.5 LTS" Description="Ubuntu 18.04.5 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
+    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
       <uap:VisualElements DisplayName="Ubuntu 20.04.5 LTS" Description="Ubuntu 20.04.5 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -18,7 +18,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu2204" Executable="ubuntu2204.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
+    <Application Id="ubuntu2204" Executable="ubuntu2204.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
       <uap:VisualElements DisplayName="Ubuntu 22.04.1 LTS" Description="Ubuntu 22.04.1 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/Directory.build.props
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/Directory.build.props
@@ -13,16 +13,10 @@
 	</ItemGroup>
 	<ItemGroup>
 		<FlutterAppFiles Include="$(FlutterAppDir)" />
-	</ItemGroup>
-	<Choose>
-		<When Condition=" '$(Platform)' == 'x64' ">
-			<ItemGroup>
-				<None Include="@(FlutterAppFiles)">
-					<DeploymentContent>true</DeploymentContent>
-				</None>
-			</ItemGroup>
-		</When>
-	</Choose>
+        <None Include="@(FlutterAppFiles)">
+            <DeploymentContent>true</DeploymentContent>
+        </None>
+    </ItemGroup>
 	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterAppDir))">
 		<Message Text="Building Flutter artifacts" Importance="high"/>
 		<Exec Command="git submodule update --init" />

--- a/meta/UbuntuPreview/src/DistroLauncher-Appx/Directory.build.props
+++ b/meta/UbuntuPreview/src/DistroLauncher-Appx/Directory.build.props
@@ -13,16 +13,10 @@
 	</ItemGroup>
 	<ItemGroup>
 		<FlutterAppFiles Include="$(FlutterAppDir)" />
-	</ItemGroup>
-	<Choose>
-		<When Condition=" '$(Platform)' == 'x64' ">
-			<ItemGroup>
-				<None Include="@(FlutterAppFiles)">
-					<DeploymentContent>true</DeploymentContent>
-				</None>
-			</ItemGroup>
-		</When>
-	</Choose>
+        <None Include="@(FlutterAppFiles)">
+            <DeploymentContent>true</DeploymentContent>
+        </None>
+    </ItemGroup>
 	<Target Name="CustomFlutterBuild" BeforeTargets="ResolveProjectReferences" Condition="!Exists($(FlutterAppDir))">
 		<Message Text="Building Flutter artifacts" Importance="high"/>
 		<Exec Command="git submodule update --init" />

--- a/meta/UbuntuPreview/src/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/UbuntuPreview/src/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+  <Identity Name="CanonicalGroupLimited.UbuntuDev.AppID.Dev" Version="4.10.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
+  <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>UbuntuDev.FullName.Dev</DisplayName>
+    <PublisherDisplayName>Canonical Group Limited</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+  </Dependencies>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--hide-console">
+      <uap:VisualElements DisplayName="UbuntuDev.FullName.Dev" Description="UbuntuDev.FullName.Dev on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
+        </uap:DefaultTile>
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap3:Extension Category="windows.appExecutionAlias" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="UbuntuDev.LauncherName.Dev.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
+        <uap3:Extension Category="windows.appExtension">
+          <uap3:AppExtension Name="com.microsoft.windows.terminal.settings"
+                             Id="UbuntuDev.WslID.Dev"
+                             DisplayName="UbuntuDev.FullName.Dev"
+                             PublicFolder="Terminal">
+          </uap3:AppExtension>
+        </uap3:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+</Package>


### PR DESCRIPTION
My original intent to implement this was to adjust only the appxmanifest files. But then I got a question: is `wsl --install` supposed to execute the appxmanifest entry point or invoke the distro launcher directly (most likely with no arguments)? I don't really know the answer, but I suspect it is the latest and that requires consistency between that behavior and installation through the store.

Thus, in the following set of changes I'm preparing both scenarios:

1. The one-line change in the `DistroLauncher-Appx/MyDistro.appxmanifest` makes the entry point for all apps to be `<launcher.exe> --ui=none`, thus following the upstream setup experience (the one existing in Ubuntu 18.04 and 20.04 - prior to the Ubuntu OOBE) [d08bdc84135e0c3b8a7b5f8f24cc5d2b48de558a]
2. The same change is applied to `meta/*/generated/DistroLauncher-Appx/MyDistro.appxmanifest` as that's the way `wsl-builder` is supposed to parameterize the builds. That's a consequence of the change mentioned above (1). [f2d90f1912f16e98a566d9b114c770067221a500]
3. `meta/UbuntuPreview/src/DistroLauncher-Appx/MyDistro.appxmanifest` was created to preserve the Ubuntu-Preview app from those changes. For that app the entry point remains `ubuntupreview.exe --hide-console` (that's the way the Start Menu and the App Installer invoke it) and the OOBE is implicitly enabled as used to be before this pull request. The file just created act as the override for the changes above preserving the current behavior for the Ubuntu Preview app.  [767d39ee3d44e6b63ee56de28ce93dd658161c59]
4. Covers the scenario in which `wsl --install` would invoke the distro launcher directly (with empty args) instead of following the appxmanifest entry point. [dc69de3741297f7217c575c005ff356c25c6ffc6] The end result of this change is that any of the following launcher invocations would result in the default upstream setup experience being following instead of our OOBE:

```
<launcher.exe>
<launcher.exe> install
<launcher.exe> <any invalid combination of parameters> -- as used to be.
```

Notice that the OOBE can still be invoked with `--ui=gui` or `--ui=tui` with the Ubuntu and Ubuntu22.04LTS applications. Nothing changes for Ubuntu-Preview.