### PR TITLE
Fix CI failure due prefill file not found

### DIFF
--- a/DistroLauncher/WinOobeStrategy.cpp
+++ b/DistroLauncher/WinOobeStrategy.cpp
@@ -201,6 +201,9 @@ namespace Oobe
     HRESULT WinOobeStrategy::do_gui_install()
     {
         if (!prefill.isEmpty()) {
+            // make sure the distro is awaken before attempting to write a file into it:
+            DWORD exitCode = 0;
+            g_wslApi.WslLaunchInteractive(concat(L"touch ", prefill.linuxPath).c_str(), FALSE, &exitCode);
             prefill.write();
         }
 


### PR DESCRIPTION
In https://github.com/ubuntu/WSL/pull/297#issuecomment-1289899832 it was mentioned that CI started to present failures very often due launcher failing to write the prefill file.

This PR aims to address that condition by running a command through WSL API to make sure the distro is awakened before attempting to write the prefill file. Two successful runs in a row ( [this](https://github.com/ubuntu/WSL/actions/runs/3324081695) and [and this one](https://github.com/ubuntu/WSL/actions/runs/3324295570)  ) seem to confirm the suspicious is right.