### PR TITLE
Backporting systemd-sysusers.service fix to older distros

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -37,10 +37,10 @@ HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
         return hr;
     }
 
-    // Enable systemd
-    if (DistributionInfo::Name == L"UbuntuDev.WslID.Dev" || DistributionInfo::Name == L"Ubuntu-Preview") {
-        Systemd::Enable(true);
-    }
+    // Prepare distro for systemd enablement, and conditionally enable it
+    const bool enable_systemd =
+      DistributionInfo::Name == L"UbuntuDev.WslID.Dev" || DistributionInfo::Name == L"Ubuntu-Preview";
+    Systemd::Configure(enable_systemd);
 
     // Create a user account.
     if (createUser) {

--- a/DistroLauncher/systemd_config.cpp
+++ b/DistroLauncher/systemd_config.cpp
@@ -44,17 +44,15 @@ namespace Systemd
         return AppendToFile(L"\n[Service]\nLoadCredential=\n", sysusers_override);
     }
 
-    bool Enable(const bool enable)
+    bool Configure(const bool enable)
     {
+        SysUsersDisableLoadCredential();
         if (!ConfigureSystemd(enable)) {
             return false;
         }
-
-        if (!SysUsersDisableLoadCredential()) {
+        if (enable && !AppendToFile(L"\naction=reboot\n", L"/run/launcher-command")) {
             return false;
         }
-
-        return AppendToFile(L"\naction=reboot\n", L"/run/launcher-command");
+        return true;
     }
-
 }

--- a/DistroLauncher/systemd_config.cpp
+++ b/DistroLauncher/systemd_config.cpp
@@ -22,11 +22,10 @@ namespace Systemd
     }
 
     // Enables or disables systemd in config file
-    bool ConfigureSystemd(const bool enable)
+    bool EnableSystemd()
     {
         const std::filesystem::path wsl_conf{L"/etc/wsl.conf"};
-        const std::wstring config = concat(L"\n[boot]\nsystemd=", std::boolalpha, enable, L'\n');
-        return AppendToFile(config, wsl_conf);
+        return AppendToFile(L"\n[boot]\nsystemd=true\n", wsl_conf);
     }
 
     /**
@@ -44,15 +43,18 @@ namespace Systemd
         return AppendToFile(L"\n[Service]\nLoadCredential=\n", sysusers_override);
     }
 
-    bool Configure(const bool enable)
+    void Configure(const bool enable)
     {
         SysUsersDisableLoadCredential();
-        if (!ConfigureSystemd(enable)) {
-            return false;
+
+        if (!enable) {
+            return;
         }
-        if (enable && !AppendToFile(L"\naction=reboot\n", L"/run/launcher-command")) {
-            return false;
+
+        if (!EnableSystemd()) {
+            return;
         }
-        return true;
+
+        AppendToFile(L"\naction=reboot\n", L"/run/launcher-command");
     }
 }

--- a/DistroLauncher/systemd_config.h
+++ b/DistroLauncher/systemd_config.h
@@ -19,5 +19,5 @@
 
 namespace Systemd
 {
-    bool Configure(bool enable);
+    void Configure(bool enable);
 }

--- a/DistroLauncher/systemd_config.h
+++ b/DistroLauncher/systemd_config.h
@@ -19,5 +19,5 @@
 
 namespace Systemd
 {
-    bool Enable(bool enable = true);
+    bool Configure(bool enable);
 }


### PR DESCRIPTION
The service `systemd-sysusers` fails at startup when trying to load credentials. To fix this, we overrode its conf file in `/etc/systemd/system/sytemd-sysusers.d/override.conf` in UbuntuPreview.

This patch enables this fix in all distros. Note that systemd is still only enabled by default on Preview and Dev.

The function `Systemd::Enable` has been renamed to `Systemd::Configure` to reflect the fact that it permorms this action even when systemd is not enabled. 