### PR TITLE
Avoid triggering Refresh releases and assets

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -39,7 +39,7 @@ HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
 
     // Prepare distro for systemd enablement, and conditionally enable it
     const bool enable_systemd =
-      DistributionInfo::Name == L"UbuntuDev.WslID.Dev" || DistributionInfo::Name == L"Ubuntu-Preview";
+      ends_with(DistributionInfo::Name, L".Dev") || DistributionInfo::Name == L"Ubuntu-Preview";
     Systemd::Configure(enable_systemd);
 
     // Create a user account.


### PR DESCRIPTION
Refresh releases and assets is an automated action that looks for the string "UbuntuDev.WslID.Dev". If this string is found, then multiple copies of the file are generated in which this string is replaced with "Ubuntu-18.08", "Ubuntu-20.04", etc. To avoid triggering this, I changed the code so it does not contain string "UbuntuDev.WslID.Dev".

You can see an undesired trigger here: https://github.com/ubuntu/WSL/pull/290
