### PR TITLE
Run update before installing in CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - run: |
           set -o pipefail
+          sudo apt update
           sudo apt install -y xvfb freerdp2-x11
           # detected empirically and confirmed here: https://github.com/FreeRDP/FreeRDP/blob/68ad8d5a1c8d52828095c2293acea1c76fa7fcb5/client/X11/xfreerdp.h#L350
           vmOfflineErrorCode=141 


### PR DESCRIPTION
We need to run apt update before running apt install in CI.

This should be picked in the new test workflow branch (with the `DEBIAN_FRONTEND=noninteractive` change too that I ignored here to avoid mix of concerns)