### PR TITLE
[DEENG-544] Disable systemd-binfmt.service

### DIFF
--- a/DistroLauncher/systemd_config.cpp
+++ b/DistroLauncher/systemd_config.cpp
@@ -43,9 +43,22 @@ namespace Systemd
         return AppendToFile(L"\n[Service]\nLoadCredential=\n", sysusers_override);
     }
 
+    /**
+     * Disables systemd-binfmt.service to avoid breaking interop.
+     * See related bug report: https://github.com/ubuntu/WSL/issues/334
+     */
+    bool MaskSystemdBinfmtService() noexcept
+    {
+        DWORD exitCode;
+        auto hr =
+          Sudo::WslLaunchInteractive(L"ln -s /dev/null /etc/systemd/system/systemd-binfmt.service", FALSE, &exitCode);
+        return SUCCEEDED(hr) && exitCode == 0;
+    }
+
     void Configure(const bool enable)
     {
         SysUsersDisableLoadCredential();
+        MaskSystemdBinfmtService();
 
         if (!enable) {
             return;

--- a/e2e/launchertester/basic_setup_test.go
+++ b/e2e/launchertester/basic_setup_test.go
@@ -28,6 +28,7 @@ func TestBasicSetupGUI(t *testing.T) {
 		"SystemdUnits":            testSystemdUnits,
 		"CorrectUpgradePolicy":    testCorrectUpgradePolicy,
 		"UpgradePolicyIdempotent": testUpgradePolicyIdempotent,
+		"InteropIsEnabled":        testInteropIsEnabled,
 	}
 
 	for name, tc := range testCases {
@@ -55,6 +56,7 @@ func TestBasicSetupFallbackUI(t *testing.T) {
 		"SystemdUnits":            testSystemdUnits,
 		"CorrectUpgradePolicy":    testCorrectUpgradePolicy,
 		"UpgradePolicyIdempotent": testUpgradePolicyIdempotent,
+		"InteropIsEnabled":        testInteropIsEnabled,
 	}
 
 	for name, tc := range testCases {

--- a/e2e/launchertester/default_experience_test.go
+++ b/e2e/launchertester/default_experience_test.go
@@ -61,6 +61,7 @@ func TestDefaultExperience(t *testing.T) {
 		"SystemdUnits":            testSystemdUnits,
 		"CorrectUpgradePolicy":    testCorrectUpgradePolicy,
 		"UpgradePolicyIdempotent": testUpgradePolicyIdempotent,
+		"InteropIsEnabled":        testInteropIsEnabled,
 	}
 
 	for name, tc := range testCases {

--- a/e2e/launchertester/test_cases.go
+++ b/e2e/launchertester/test_cases.go
@@ -221,6 +221,18 @@ func testUpgradePolicyIdempotent(t *testing.T) { //nolint: thelper, this is a te
 	require.Equal(t, string(wantsDate), string(gotDate), "Launcher is modifying release upgrade every boot")
 }
 
+// testInteropIsEnabled ensures interop works fine.
+// See related issue: https://github.com/ubuntu/WSL/issues/334
+func testInteropIsEnabled(t *testing.T) { //nolint: thelper, this is a test
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), systemdBootTimeout)
+	defer cancel()
+
+	got, err := wslCommand(ctx, "powershell.exe", "-Command", `Write-Output "Hello, world!"`).CombinedOutput()
+	require.NoError(t, err, "Failed to launch powershell from WSL. Does interop work? %s", got)
+	require.Equal(t, "Hello, world!\r\n", string(got), "Unexpected output from powershell")
+}
+
 // systemdIsExpected returns true if systemd is expected to be enabled by default on this distro.
 func systemdIsExpected() bool {
 	distroNameToExpectSystemd := map[string]bool{


### PR DESCRIPTION
Disables systemd-binfmt.service to avoid breaking interop. This is a temporary solution, as we're still vulnerable to other distros breaking interop.

Fixes https://github.com/ubuntu/WSL/issues/334