### PR TITLE
Removes the `PackageDependency` entry from manifest

### DIFF
--- a/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,7 +9,6 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,7 +9,6 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,7 +9,6 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,7 +9,6 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -9,7 +9,6 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16215.0" MaxVersionTested="10.0.16240.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />


### PR DESCRIPTION
To support Windows Server, we cannot rely on the store to deliver VClibs.
The launcher vcxproj is already configured the way we want. The Flutter binaries are now, since #338 and #339 .
