### PR TITLE
Fixed internal imports in actions

### DIFF
--- a/.github/actions/wsl-bash/action.yaml
+++ b/.github/actions/wsl-bash/action.yaml
@@ -38,7 +38,7 @@ runs:
         if ( "${exit}" -eq "$False" ) { Exit(1) }
 
     - name: Run linux script
-      uses: ./.github/actions/wsl-powershell
+      uses: Ubuntu/WSL/.github/actions/wsl-powershell
       with:
         max-attempts: 5
         exec: |

--- a/.github/actions/wsl-bash/action.yaml
+++ b/.github/actions/wsl-bash/action.yaml
@@ -38,7 +38,7 @@ runs:
         if ( "${exit}" -eq "$False" ) { Exit(1) }
 
     - name: Run linux script
-      uses: Ubuntu/WSL/.github/actions/wsl-powershell@main
+      uses: ubuntu/WSL/.github/actions/wsl-powershell@main
       with:
         max-attempts: 5
         exec: |

--- a/.github/actions/wsl-bash/action.yaml
+++ b/.github/actions/wsl-bash/action.yaml
@@ -38,7 +38,7 @@ runs:
         if ( "${exit}" -eq "$False" ) { Exit(1) }
 
     - name: Run linux script
-      uses: Ubuntu/WSL/.github/actions/wsl-powershell
+      uses: Ubuntu/WSL/.github/actions/wsl-powershell@main
       with:
         max-attempts: 5
         exec: |

--- a/.github/actions/wsl-checkout/action.yaml
+++ b/.github/actions/wsl-checkout/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clone repo
-      uses: Ubuntu/WSL/.github/actions/wsl-bash
+      uses: Ubuntu/WSL/.github/actions/wsl-bash@main
       with:
         max-attempts: 5
         exec: |

--- a/.github/actions/wsl-checkout/action.yaml
+++ b/.github/actions/wsl-checkout/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clone repo
-      uses: Ubuntu/WSL/.github/actions/wsl-bash@main
+      uses: ubuntu/WSL/.github/actions/wsl-bash@main
       with:
         max-attempts: 5
         exec: |

--- a/.github/actions/wsl-checkout/action.yaml
+++ b/.github/actions/wsl-checkout/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Clone repo
-      uses: ./.github/actions/wsl-bash
+      uses: Ubuntu/WSL/.github/actions/wsl-bash
       with:
         max-attempts: 5
         exec: |

--- a/.github/actions/wsl-install/action.yaml
+++ b/.github/actions/wsl-install/action.yaml
@@ -20,7 +20,7 @@ runs:
 
     - name: Install the new distro
       if: ${{ inputs.distro != '' }}
-      uses: Ubuntu/WSL/.github/actions/wsl-powershell
+      uses: Ubuntu/WSL/.github/actions/wsl-powershell@main
       with:
         exec: |
           # Install the new distro

--- a/.github/actions/wsl-install/action.yaml
+++ b/.github/actions/wsl-install/action.yaml
@@ -20,7 +20,7 @@ runs:
 
     - name: Install the new distro
       if: ${{ inputs.distro != '' }}
-      uses: Ubuntu/WSL/.github/actions/wsl-powershell@main
+      uses: ubuntu/WSL/.github/actions/wsl-powershell@main
       with:
         exec: |
           # Install the new distro

--- a/.github/actions/wsl-install/action.yaml
+++ b/.github/actions/wsl-install/action.yaml
@@ -20,7 +20,7 @@ runs:
 
     - name: Install the new distro
       if: ${{ inputs.distro != '' }}
-      uses: ./.github/actions/wsl-powershell
+      uses: Ubuntu/WSL/.github/actions/wsl-powershell
       with:
         exec: |
           # Install the new distro


### PR DESCRIPTION
Internal imports need to be absolute for external repositories to be able to use them.

Follow-up to #337.