### PR TITLE
Updates rootfs URL generation for Jammy

### DIFF
--- a/wsl-builder/prepare-build/buildGHMatrix.go
+++ b/wsl-builder/prepare-build/buildGHMatrix.go
@@ -36,10 +36,10 @@ func buildGHMatrix(csvPath, metaPath string) error {
 			if i == 0 {
 				t = ""
 			}
-			// Currently only Kinetic (22.10) and later are published to "https://cloud-images.ubuntu.com/wsl/"
+			// Currently only Jammy (22.04) and later are published to "https://cloud-images.ubuntu.com/wsl/"
 			codeNameSubUri := r.CodeName
 			imageBaseName := fmt.Sprintf("%s-server-cloudimg", r.CodeName)
-			if strings.Compare(r.BuildVersion, "2210") >= 0 {
+			if strings.Compare(r.BuildVersion, "2204") >= 0 {
 				codeNameSubUri = filepath.Join("wsl", r.CodeName)
 				// The image base name scheme also changed.
 				imageBaseName = fmt.Sprintf("ubuntu-%s-wsl", r.CodeName)


### PR DESCRIPTION
Previously only Kinetic was published on WSL pipeline. Jammy has also been ported.
This PR changes the URL generation in `wsl-builder/prepare-build` to acknowledge the new rootfs location.

That's the reason why the CI is failing to build the 22.04 LTS app.