### PR TITLE
Pin Flutter version in CI

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -66,6 +66,7 @@ jobs:
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
+          flutter-version: '3.3.x'
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -155,6 +155,7 @@ jobs:
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
+          flutter-version: '3.3.x'
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="${{ env.AppxBundlePlatforms }}" /p:UapAppxPackageBuildMode=${{ env.UapAppxPackageBuildMode }} -verbosity:normal

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.3.x'
       - name: Install or update WSL
         uses: ./.github/actions/wsl-install
       - name: Build and install the appxbundle for testing


### PR DESCRIPTION
Flutter 3.7 released yesterday introduced some breaking changes.

UDI submodule is being updated and our CI is being pinned to the previous stable release until all the fixes arrive.

Ref: https://github.com/canonical/ubuntu-desktop-installer/pull/1340