### PR TITLE
(fix) Cannot read output from previous job steps

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -89,6 +89,8 @@ jobs:
     env:
       buildInfoPath: 'wiki/build-info'
       workDir: 'C:/Temp/builddir'
+    outputs:
+      store-needs-upload: ${{ steps.detect-upload-to-store.outputs.needs-upload }}
     steps:
       - name: Checkout WSL
         shell: bash
@@ -329,7 +331,7 @@ jobs:
 
       # Pushing PDB's to the wiki only makes sense if we uploaded new app versions to the store.
       - name: Copy debug databases to base wiki
-        if: ${{ steps.detect-upload-to-store.outputs.needs-upload == 'true' }}
+        if: ${{ needs.build-wsl.outputs.store-needs-upload == 'true' }}
         id: pdb-artifacts
         run: |
           set -eu


### PR DESCRIPTION
Basic GitHub actions mistake. 🙈 

We are attempting to store the debug symbols of the latest published apps in the wiki.
For that we need to know whether this build lead to a new submission to the store: `steps.detect-upload-to-store.outputs.needs-upload`.

The problem is that we were attempting to read the output of a step that belongs to another job. That can only work if the job who owns that step makes the output available.