### PR TITLE
Having no updates to install should not break CI

### DIFF
--- a/.github/actions/wsl-install/action.yaml
+++ b/.github/actions/wsl-install/action.yaml
@@ -12,13 +12,11 @@ runs:
   steps:
     - name: Install WSL
       shell: powershell
+      continue-on-error: true
       run: |
         # Install or update WSL
         $env:WSL_UTF8=1
-        # Having no updates to install should not be an error.
-        $NoUpdateError=0x8A15002B
-        winget install --name 'Windows Subsystem for Linux' --accept-source-agreements --accept-package-agreements --silent
-        if ( ! $? -and $LastExitCode -ne $NoUpdateError ) { Exit(1) }
+        winget install --name 'Windows Subsystem for Linux' --accept-source-agreements --accept-package-agreements --silent --verbose
 
     - name: Install the new distro
       if: ${{ inputs.distro != '' }}

--- a/.github/actions/wsl-install/action.yaml
+++ b/.github/actions/wsl-install/action.yaml
@@ -15,8 +15,10 @@ runs:
       run: |
         # Install or update WSL
         $env:WSL_UTF8=1
+        # Having no updates to install should not be an error.
+        $NoUpdateError=0x8A15002B
         winget install --name 'Windows Subsystem for Linux' --accept-source-agreements --accept-package-agreements --silent
-        if ( ! $? ) { Exit(1) }
+        if ( ! $? -and $LastExitCode -ne $NoUpdateError ) { Exit(1) }
 
     - name: Install the new distro
       if: ${{ inputs.distro != '' }}


### PR DESCRIPTION
WSL-449

That value is winget's exit code when no updates are available to install. That means we have the latest and greatest installed. No reason for immediate crashing.
That error code might mean a real failure, though. Thus as an extra precaution we launch wsl --version and check.

See

https://github.com/microsoft/winget-cli/blob/bfcee8edba2853f5a11e96dd7c7f6b412afef26a/src/AppInstallerSharedLib/Public/AppInstallerErrors.h#L58

And

https://github.com/microsoft/winget-cli/blob/bfcee8edba2853f5a11e96dd7c7f6b412afef26a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp#L67