### PR TITLE
Enable systemd by default on Ubuntu and Ubuntu-22.04 apps

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -38,8 +38,9 @@ HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
     }
 
     // Prepare distro for systemd enablement, and conditionally enable it
-    const bool enable_systemd =
-      ends_with(DistributionInfo::Name, L".Dev") || DistributionInfo::Name == L"Ubuntu-Preview";
+    const bool enable_systemd = ends_with(DistributionInfo::Name, L".Dev") ||
+      DistributionInfo::Name == L"Ubuntu" || DistributionInfo::Name == L"Ubuntu-22.04" ||
+      DistributionInfo::Name == L"Ubuntu-Preview";
     Systemd::Configure(enable_systemd);
 
     // Create a user account.


### PR DESCRIPTION
After building an appx with current jammy rootfs, the result should look like:

```
$> ubuntu2204.exe   
Installing, this may take a few minutes...
Please create a default UNIX user account. The username does not need to match your Windows username.
For more information visit: https://aka.ms/wslusers
Enter new UNIX username: u
New password:
Retype new password:
passwd: password updated successfully
The operation completed successfully.
Installation successful!
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

Welcome to Ubuntu 22.04.2 LTS (GNU/Linux 5.15.90.1-microsoft-standard-WSL2 x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage


This message is shown once a day. To disable it please create the
/home/u/.hushlogin file.
u@Zero01:~$ systemctl is-system-running
running
u@Zero01:~$ systemctl status
● Zero01
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Tue 2023-04-18 16:48:52 -03; 25s ago
   CGroup: /
           ├─user.slice
           │ └─user-1000.slice
           │   ├─user@1000.service
           │   │ └─init.scope
           │   │   ├─393 /lib/systemd/systemd --user
           │   │   └─394 (sd-pam)
```

I'm opening the PR against the `udi-update`  branch because I want to see all tests green, but this must be rebased on main eventually.