### PR TITLE
Removes the dependency on the UAP10 namespace

### DIFF
--- a/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.UbuntuDev.AppID.Dev" Version="4.10.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -17,7 +17,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
+    <Application Id="UbuntuDev.LauncherName.Dev" Executable="UbuntuDev.LauncherName.Dev.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="UbuntuDev.FullName.Dev" Description="UbuntuDev.FullName.Dev on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/DistroLauncher/Application.h
+++ b/DistroLauncher/Application.h
@@ -80,7 +80,8 @@ namespace Oobe
               std::visit(internal::overloaded{
                            [&](AutoInstall& option) { return impl_.do_autoinstall(option.autoInstallFile); },
                            [&](ManifestMatchedInstall& option) { return impl_.do_install(Mode::AutoDetect); },
-                           [&](InstallDefault& option) { return impl_.do_install(Mode::AutoDetect); },
+                           // Default empty CLI invocation goes to the upstream install ux on all apps instead of the OOBE.
+                           [&](InstallDefault& option) { return E_NOTIMPL; },
                            [&](InstallOnlyDefault& option) { return impl_.do_install(Mode::AutoDetect); },
                            [&](InteractiveInstallOnly<OobeGui>& option) { return impl_.do_install(Mode::Gui); },
                            [&](InteractiveInstallOnly<OobeTui>& option) { return impl_.do_install(Mode::Text); },

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu" Version="2204.2.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -17,7 +17,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu" Executable="ubuntu.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
+    <Application Id="ubuntu" Executable="ubuntu.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="Ubuntu" Description="Ubuntu on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu18.04LTS" Version="1804.6.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -17,7 +17,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
+    <Application Id="ubuntu1804" Executable="ubuntu1804.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="Ubuntu 18.04.6 LTS" Description="Ubuntu 18.04.6 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu20.04LTS" Version="2004.6.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -17,7 +17,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
+    <Application Id="ubuntu2004" Executable="ubuntu2004.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="Ubuntu 20.04.6 LTS" Description="Ubuntu 20.04.6 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/MyDistro.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp uap2 uap3 rescap desktop">
   <Identity Name="CanonicalGroupLimited.Ubuntu22.04LTS" Version="2204.2.42.0" Publisher="CN=23596F84-C3EA-4CD8-A7DF-550DCE37BCD0" ProcessorArchitecture="x64" />
   <mp:PhoneIdentity PhoneProductId="160867c6-4e75-4e36-85c6-1543de07d5f3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -17,7 +17,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="ubuntu2204" Executable="ubuntu2204.exe" EntryPoint="Windows.FullTrustApplication" uap10:Parameters="--ui=none">
+    <Application Id="ubuntu2204" Executable="ubuntu2204.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="Ubuntu 22.04.2 LTS" Description="Ubuntu 22.04.2 LTS on Windows" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png" Square71x71Logo="Assets\SmallTile.png">
         </uap:DefaultTile>


### PR DESCRIPTION
Deploying Ubuntu 22.04 to Windows Server 2019 fails due what seems to be an invalid `AppxManifest.xml`. The truth behind that message is that the namespace `http://schemas.microsoft.com/appx/manifest/uap/windows10/10` is not supported on that OS version.

We only used that namespace to pass command line parameters to the application.

This PR:
1. changes the CLI parsing to ensure the previously desired behavior is now matched when no CLI parameters are passed 
2. Removes the dependency on that namespace from the `MyDistro.appxmanifest` of all LTSs and the main Ubuntu app.
3. Preserves the above dependency for the Ubuntu Preview application.

The point 3 ensures that Ubuntu Preview invokes the OOBE by default. That behavior is being herein preserved under the assumption that the users willing to install Ubuntu WSL apps on Windows Server SKUs won't play with the unstable `Ubuntu Preview` app.

I did a manual sanity check over 22.04, the default Ubuntu, 18.04 and Preview to ensure the intended behavior remains. The gist of it is:

- Ubuntu Preview by default invokes the OOBE.
- The LTSs and Ubuntu default app by default go to the upstream setup. They go otherwise to OOBE if invoked with the `--ui` option.