### PR TITLE
Applies all relevant patches to the distro being installed

### DIFF
--- a/DistroLauncher/ApplyConfigPatches.cpp
+++ b/DistroLauncher/ApplyConfigPatches.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "Patch.h"
+#include "ApplyConfigPatches.h"
+
+namespace Ubuntu
+{
+    void ApplyConfigPatches(std::wstring_view DistroName)
+    {
+        // I think the WslPathPrefix no longer belongs to Oobe namespace. But let's leave that for later.
+        std::filesystem::path pathPrefix{Oobe::WslPathPrefix()};
+        pathPrefix /= DistroName;
+
+        // Apply global patches
+        for (const auto& patch : releaseAgnosticPatches) {
+            patch.apply(pathPrefix);
+        }
+
+        // check for release specific patches.
+        const auto& releaseSpecific = releaseSpecificPatches.find(DistroName);
+        if (releaseSpecific == releaseSpecificPatches.end()) {
+            return;
+        }
+
+        // apply them if any.
+        for (const auto& patch : releaseSpecific->second) {
+            patch.apply(pathPrefix);
+        }
+    }
+}

--- a/DistroLauncher/ApplyConfigPatches.h
+++ b/DistroLauncher/ApplyConfigPatches.h
@@ -1,0 +1,44 @@
+#pragma once
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ubuntu
+{
+    /**
+     * The distro launcher is equipped with a simple mechanism to adapt the root filesystem contents to some WSL
+     * specificities through patching distro configuration files.
+     * Those patches are idempotent, small and atomic, in the sense that each patching action either completes
+     * successfully or does nothing to the system state. Patches are implemented as C++ functions. See
+     * [PatchConfig.h/cpp] for the implementation details.
+     *
+     * Those patches must only be applied right after registration, where:
+     * 1. Root filesystem access is guaranteed.
+     * 2. We can assume all existing patches are missing. No tracking of which patches were applied and when.
+     * 3. No decision making is necessary on to whether this is the right time to try patching the config files or not.
+     * 4. No pessimisation of regular boot time.
+     *
+     * Respecting the assumptions above allow for very simple patching functions.
+     *
+     * Patches may exist in two forms:
+     * 1. Release agnostic patches. Are required for all Ubuntu apps.
+     * 2. Release specific patches. Only the specific [DistroName] requires it.
+     *
+     */
+
+    /// Applies any relevant patch for the [DistroName].
+    void ApplyConfigPatches(std::wstring_view DistroName);
+}

--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -37,6 +37,7 @@ HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
         return hr;
     }
 
+    Ubuntu::ApplyConfigPatches(DistributionInfo::Name);
     // Prepare distro for systemd enablement, and conditionally enable it
     const bool enable_systemd = ends_with(DistributionInfo::Name, L".Dev") ||
       DistributionInfo::Name == L"Ubuntu" || DistributionInfo::Name == L"Ubuntu-22.04" ||

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -158,6 +158,7 @@
     <ClInclude Include="DistributionInfo.h" />
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="Patch.h" />
+    <ClInclude Include="ApplyConfigPatches.h" />
     <ClInclude Include="ProcessRunner.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SetOnceNamedEvent.h" />
@@ -191,6 +192,7 @@
     <ClCompile Include="NoSplashStrategy.cpp" />
     <ClCompile Include="OOBE.cpp" />
     <ClCompile Include="Patch.cpp" />
+    <ClCompile Include="ApplyConfigPatches.cpp" />
     <ClCompile Include="ProcessRunner.cpp" />
     <ClCompile Include="find_main_thread_window.cpp" />
     <ClCompile Include="ini_find_value.cpp" />

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -106,4 +106,11 @@ namespace Ubuntu
             }
         };
     };
-};
+
+    /// Collection of the patches that must be applied to all releases.
+    static const inline std::array<Patch, 0> releaseAgnosticPatches{};
+
+    /// All applicable patches specific to a specific Ubuntu app are defined in this data structure.
+    /// Change here as new patch requirements are found.
+    static const inline std::unordered_map<std::wstring_view, std::vector<Patch>> releaseSpecificPatches{};
+}

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -51,6 +51,7 @@
 #include "OobeDefs.h"
 #include "ExitStatus.h"
 #include "OOBE.h"
+#include "ApplyConfigPatches.h"
 #include "ProcessRunner.h"
 #include "WSLInfo.h"
 #include "Win32Utils.h"


### PR DESCRIPTION
A top-level function called from `InstallDistribution()` (see `DistroLauncher.cpp`). Calling at this place we can ensure we have the necessary file system permissions to perform any config patch.

Calls patches in two steps: globals and release specific.

The patch collections are defined, but empty for now. Thus, for now this does nothing.

The collections will be populated as we add specific patches at next.

Nothing will change on this function or its caller as we add more patches.