### PR TITLE
Removes `cloudimg-rootfs` label from all distros fstab's

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -98,6 +98,16 @@ TEST(AlgorithmTests, Concat)
     ASSERT_EQ(with_path, LR"(diff "/home/fox/documents/example.json" /home/fox/documents/example.json)");
 }
 
+void expectStreamEnding(std::istream& is)
+{
+    EXPECT_TRUE(is.good());
+    char maybelast = '+';
+    is >> maybelast;
+    EXPECT_EQ(maybelast, '+'); // unchanged
+    EXPECT_TRUE(is.fail());
+    EXPECT_TRUE(is.eof()) << "Still remains something on the stream.";
+}
+
 TEST(AlgorithmTests, GetlineSingleEnded)
 {
     std::string_view first = "Hello world!";
@@ -111,12 +121,7 @@ TEST(AlgorithmTests, GetlineSingleEnded)
     EXPECT_EQ(got, first);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
-    EXPECT_TRUE(ss.good());
-    char maybelast = '+';
-    ss >> maybelast;
-    EXPECT_EQ(maybelast, '+'); // unchanged
-    EXPECT_TRUE(ss.fail());
-    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+    expectStreamEnding(ss);
 }
 
 TEST(AlgorithmTests, GetlineSingleNotEnded)
@@ -131,12 +136,7 @@ TEST(AlgorithmTests, GetlineSingleNotEnded)
     EXPECT_EQ(got, first);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
-    EXPECT_TRUE(ss.good());
-    char maybelast = '+';
-    ss >> maybelast;
-    EXPECT_EQ(maybelast, '+'); // unchanged
-    EXPECT_TRUE(ss.fail());
-    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+    expectStreamEnding(ss);
 }
 
 TEST(AlgorithmTests, GetlineMulti)
@@ -159,12 +159,7 @@ TEST(AlgorithmTests, GetlineMulti)
     EXPECT_EQ(got, second);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
-    EXPECT_TRUE(ss.good());
-    char maybelast = '+';
-    ss >> maybelast;
-    EXPECT_EQ(maybelast, '+'); // unchanged
-    EXPECT_TRUE(ss.fail());
-    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+    expectStreamEnding(ss);
 }
 
 TEST(AlgorithmTests, GetlineEmpty)
@@ -177,12 +172,7 @@ TEST(AlgorithmTests, GetlineEmpty)
     EXPECT_EQ(got.size(), 0);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
-    EXPECT_TRUE(ss.good());
-    char maybelast = '+';
-    ss >> maybelast;
-    EXPECT_EQ(maybelast, '+'); // unchanged
-    EXPECT_TRUE(ss.fail());
-    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+    expectStreamEnding(ss);
 }
 TEST(AlgorithmTests, GetlineEmpty2)
 {
@@ -198,12 +188,7 @@ TEST(AlgorithmTests, GetlineEmpty2)
     EXPECT_EQ(got.size(), 0);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{}); // now it is EOF
 
-    EXPECT_TRUE(ss.good());
-    char maybelast = '+';
-    ss >> maybelast;
-    EXPECT_EQ(maybelast, '+'); // unchanged
-    EXPECT_TRUE(ss.fail());
-    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+    expectStreamEnding(ss);
 }
 TEST(AlgorithmTests, LeftTrimmedWCharT)
 {

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -106,7 +106,8 @@ TEST(AlgorithmTests, GetlineSingleEnded)
     std::istringstream ss{contents}; // "Hello world!\n"
     std::string got;
     std::istreambuf_iterator<char> it{ss};
-    getline(it, got);
+
+    it = getline(it, got);
     EXPECT_EQ(got, first);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
@@ -125,7 +126,8 @@ TEST(AlgorithmTests, GetlineSingleNotEnded)
     std::istringstream ss{contents}; // "Hello world!"
     std::string got;
     std::istreambuf_iterator<char> it{ss};
-    getline(it, got);
+
+    it = getline(it, got);
     EXPECT_EQ(got, first);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
@@ -148,11 +150,12 @@ TEST(AlgorithmTests, GetlineMulti)
     std::istringstream ss{contents}; // "Hello world!\nThis is a test\n"
     std::string got;
     std::istreambuf_iterator<char> it{ss};
-    getline(it, got);
+
+    it = getline(it, got);
     EXPECT_EQ(got, first);
     EXPECT_NE(it, std::istreambuf_iterator<char>{});
 
-    getline(it, got);
+    it = getline(it, got);
     EXPECT_EQ(got, second);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
@@ -169,7 +172,8 @@ TEST(AlgorithmTests, GetlineEmpty)
     std::istringstream ss{""};
     std::string got;
     std::istreambuf_iterator<char> it{ss};
-    getline(it, got);
+
+    it = getline(it, got);
     EXPECT_EQ(got.size(), 0);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{});
 
@@ -186,11 +190,11 @@ TEST(AlgorithmTests, GetlineEmpty2)
     std::string got;
     std::istreambuf_iterator<char> it{ss};
 
-    getline(it, got);
+    it = getline(it, got);
     EXPECT_EQ(got.size(), 0);
     EXPECT_NE(it, std::istreambuf_iterator<char>{}); // not EOF yet.
 
-    getline(it, got);
+    it = getline(it, got);
     EXPECT_EQ(got.size(), 0);
     EXPECT_EQ(it, std::istreambuf_iterator<char>{}); // now it is EOF
 

--- a/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/algorithms_tests.cpp
@@ -97,3 +97,133 @@ TEST(AlgorithmTests, Concat)
     auto with_path = concat(L"diff ", example_file, L" ", example_file.wstring()); // Only first one to be quoted
     ASSERT_EQ(with_path, LR"(diff "/home/fox/documents/example.json" /home/fox/documents/example.json)");
 }
+
+TEST(AlgorithmTests, GetlineSingleEnded)
+{
+    std::string_view first = "Hello world!";
+    std::string contents{first};
+    contents += '\n';
+    std::istringstream ss{contents}; // "Hello world!\n"
+    std::string got;
+    std::istreambuf_iterator<char> it{ss};
+    getline(it, got);
+    EXPECT_EQ(got, first);
+    EXPECT_EQ(it, std::istreambuf_iterator<char>{});
+
+    EXPECT_TRUE(ss.good());
+    char maybelast = '+';
+    ss >> maybelast;
+    EXPECT_EQ(maybelast, '+'); // unchanged
+    EXPECT_TRUE(ss.fail());
+    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+}
+
+TEST(AlgorithmTests, GetlineSingleNotEnded)
+{
+    std::string_view first = "Hello world!";
+    std::string contents{first};
+    std::istringstream ss{contents}; // "Hello world!"
+    std::string got;
+    std::istreambuf_iterator<char> it{ss};
+    getline(it, got);
+    EXPECT_EQ(got, first);
+    EXPECT_EQ(it, std::istreambuf_iterator<char>{});
+
+    EXPECT_TRUE(ss.good());
+    char maybelast = '+';
+    ss >> maybelast;
+    EXPECT_EQ(maybelast, '+'); // unchanged
+    EXPECT_TRUE(ss.fail());
+    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+}
+
+TEST(AlgorithmTests, GetlineMulti)
+{
+    std::string_view first = "Hello world!";
+    std::string_view second = "This is a test";
+    std::string contents{first};
+    contents += '\n';
+    contents += second;
+    contents += '\n';
+    std::istringstream ss{contents}; // "Hello world!\nThis is a test\n"
+    std::string got;
+    std::istreambuf_iterator<char> it{ss};
+    getline(it, got);
+    EXPECT_EQ(got, first);
+    EXPECT_NE(it, std::istreambuf_iterator<char>{});
+
+    getline(it, got);
+    EXPECT_EQ(got, second);
+    EXPECT_EQ(it, std::istreambuf_iterator<char>{});
+
+    EXPECT_TRUE(ss.good());
+    char maybelast = '+';
+    ss >> maybelast;
+    EXPECT_EQ(maybelast, '+'); // unchanged
+    EXPECT_TRUE(ss.fail());
+    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+}
+
+TEST(AlgorithmTests, GetlineEmpty)
+{
+    std::istringstream ss{""};
+    std::string got;
+    std::istreambuf_iterator<char> it{ss};
+    getline(it, got);
+    EXPECT_EQ(got.size(), 0);
+    EXPECT_EQ(it, std::istreambuf_iterator<char>{});
+
+    EXPECT_TRUE(ss.good());
+    char maybelast = '+';
+    ss >> maybelast;
+    EXPECT_EQ(maybelast, '+'); // unchanged
+    EXPECT_TRUE(ss.fail());
+    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+}
+TEST(AlgorithmTests, GetlineEmpty2)
+{
+    std::istringstream ss{"\n\n"};
+    std::string got;
+    std::istreambuf_iterator<char> it{ss};
+
+    getline(it, got);
+    EXPECT_EQ(got.size(), 0);
+    EXPECT_NE(it, std::istreambuf_iterator<char>{}); // not EOF yet.
+
+    getline(it, got);
+    EXPECT_EQ(got.size(), 0);
+    EXPECT_EQ(it, std::istreambuf_iterator<char>{}); // now it is EOF
+
+    EXPECT_TRUE(ss.good());
+    char maybelast = '+';
+    ss >> maybelast;
+    EXPECT_EQ(maybelast, '+'); // unchanged
+    EXPECT_TRUE(ss.fail());
+    EXPECT_TRUE(ss.eof()) << "Still remains something on the stream.";
+}
+TEST(AlgorithmTests, LeftTrimmedWCharT)
+{
+    std::wstring_view view{L"no left spaces at all"};
+    EXPECT_EQ(left_trimmed(view), view);
+
+    std::wstring spaced{L"\t\r\n"};
+    spaced += view;
+    EXPECT_EQ(left_trimmed(std::wstring_view{spaced}), view);
+
+    std::wstring rightSpaced{view};
+    rightSpaced += L"\t\r\n";
+    EXPECT_EQ(left_trimmed(std::wstring_view{rightSpaced}), rightSpaced);
+}
+TEST(AlgorithmTests, LeftTrimmedChar)
+{
+    std::string_view view{"no left spaces at all"};
+    EXPECT_EQ(left_trimmed(view), view);
+
+    std::string spaced{"\t\r\n"};
+    spaced += view;
+    EXPECT_EQ(left_trimmed(std::string_view{spaced}), view);
+
+    std::string rightSpaced{view};
+    rightSpaced += "\t\r\n";
+    EXPECT_EQ(left_trimmed(std::string_view{rightSpaced}), rightSpaced);
+}

--- a/DistroLauncher/Patch.cpp
+++ b/DistroLauncher/Patch.cpp
@@ -25,7 +25,7 @@ namespace Ubuntu::PatchingFunctions
     {
         bool modified = false;
         for (std::string line; fstab != std::istreambuf_iterator<char>{};) {
-            getline(fstab, line);
+            fstab = getline(fstab, line);
             auto trimmedLeft = left_trimmed(std::string_view{line});
             // Write line if doesn't contain the offending label.
             if (!starts_with(trimmedLeft, "LABEL=cloudimg-rootfs")) {

--- a/DistroLauncher/Patch.cpp
+++ b/DistroLauncher/Patch.cpp
@@ -18,6 +18,28 @@
 #include "stdafx.h"
 #include "Patch.h"
 
+// The meat: the catalog of patches we may need to perform on a distro.
+namespace Ubuntu::PatchingFunctions
+{
+    bool RemoveCloudImgLabel(std::istreambuf_iterator<char> fstab, std::ostream& tmp)
+    {
+        bool modified = false;
+        for (std::string line; fstab != std::istreambuf_iterator<char>{};) {
+            getline(fstab, line);
+            auto trimmedLeft = left_trimmed(std::string_view{line});
+            // Write line if doesn't contain the offending label.
+            if (!starts_with(trimmedLeft, "LABEL=cloudimg-rootfs")) {
+                tmp.write(line.c_str(), static_cast<std::streamsize>(line.length()));
+                tmp << '\n'; // getline never adds the newline.
+                continue;
+            }
+            modified = true; // only set if we skip writing a line.
+        }
+
+        return modified;
+    }
+}
+
 namespace Ubuntu
 {
 

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -107,8 +107,18 @@ namespace Ubuntu
         };
     };
 
+    /// The catalog of all existing patching functions the launcher might need to execute.
+    namespace PatchingFunctions
+    {
+        // Filters out lines from [fstab] which effectively start with "LABEL=cloudimg-rootfs"
+        bool RemoveCloudImgLabel(std::istreambuf_iterator<char> fstab, std::ostream& tmp);
+    }
     /// Collection of the patches that must be applied to all releases.
-    static const inline std::array<Patch, 0> releaseAgnosticPatches{};
+    static const inline std::array<const Patch, 1> releaseAgnosticPatches{
+      {
+        {"/etc/fstab", PatchingFunctions::RemoveCloudImgLabel},
+      },
+    };
 
     /// All applicable patches specific to a specific Ubuntu app are defined in this data structure.
     /// Change here as new patch requirements are found.

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -134,8 +134,11 @@ template <typename T, typename... Args> void push_back_many(std::vector<T>& vec,
 // Follows the semantics of std::getline(stream&, string&) while implemented for an iterator instead of the stream
 // itself, i.e. reads from [input] iterator until [delim] is found. Although it doesn't go to the string, it's
 // extracted from the underlying stream pointed by the [input] iterator. [str] is also erased before insertion.
+// Iterator is taken by copy, as all algorithms accepting iterators are, but one must remember that the underlying
+// stream linked to the iterator will still have it's internal state changed as the iterator advances, i.e.
+// contents are going to be extracted.
 template <class CharT, class Traits, class Allocator>
-std::istreambuf_iterator<CharT, Traits>& getline(std::istreambuf_iterator<CharT, Traits>& input,
+std::istreambuf_iterator<CharT, Traits> getline(std::istreambuf_iterator<CharT, Traits> input,
                                                  std::basic_string<CharT, Traits, Allocator>& str, CharT delim = '\n')
 {
     str.erase();

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -141,11 +141,11 @@ std::istreambuf_iterator<CharT, Traits>& getline(std::istreambuf_iterator<CharT,
     str.erase();
     // missing std::copy_until - a copy_if that stops when the predicate evaluates to true :(
     while (input != std::istreambuf_iterator<CharT, Traits>{}) {
-        char c = *input++;
-        if (c == delim) {
+        char elem = *input++;
+        if (elem == delim) {
             break;
         }
-        str.append(1, c);
+        str.append(1, elem);
     }
     return input;
     // We could, but let's not make it a template for now (at least until we find a need for reading another char type).

--- a/DistroLauncher/algorithms.h
+++ b/DistroLauncher/algorithms.h
@@ -139,7 +139,7 @@ template <typename T, typename... Args> void push_back_many(std::vector<T>& vec,
 // contents are going to be extracted.
 template <class CharT, class Traits, class Allocator>
 std::istreambuf_iterator<CharT, Traits> getline(std::istreambuf_iterator<CharT, Traits> input,
-                                                 std::basic_string<CharT, Traits, Allocator>& str, CharT delim = '\n')
+                                                std::basic_string<CharT, Traits, Allocator>& str, CharT delim = '\n')
 {
     str.erase();
     // missing std::copy_until - a copy_if that stops when the predicate evaluates to true :(


### PR DESCRIPTION
A patching function is implemented and registered for all distros to remove all lines from `/etc/fstab` which start with `LABEL=cloudimg-rootfs`.

The existence of that line causes the `systemd-remount-fs.service` to fail. That's been observed on 20.04 but might happen to any distro.

Builds on top of the Patcher machinery presented in #368 .

Now it becomes easy to understand how that whole thing pays off (IMHO).