### PR TITLE
Fix  `systemd-modules-load.service` on 18.04 via `ConditionVirtualization` for units

### DIFF
--- a/DistroLauncher/Patch.cpp
+++ b/DistroLauncher/Patch.cpp
@@ -38,6 +38,12 @@ namespace Ubuntu::PatchingFunctions
 
         return modified;
     }
+
+    bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> unused, std::ostream& conf)
+    {
+        conf << "[Unit]\nConditionVirtualization=!container\n";
+        return !conf.fail();
+    }
 }
 
 namespace Ubuntu

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -112,6 +112,9 @@ namespace Ubuntu
     {
         // Filters out lines from [fstab] which effectively start with "LABEL=cloudimg-rootfs"
         bool RemoveCloudImgLabel(std::istreambuf_iterator<char> fstab, std::ostream& tmp);
+
+        // Creates an override to prevent the matching unit to start in containers.
+        bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> unused, std::ostream& conf);
     }
     /// Collection of the patches that must be applied to all releases.
     static const inline std::array<const Patch, 1> releaseAgnosticPatches{
@@ -122,5 +125,13 @@ namespace Ubuntu
 
     /// All applicable patches specific to a specific Ubuntu app are defined in this data structure.
     /// Change here as new patch requirements are found.
-    static const inline std::unordered_map<std::wstring_view, std::vector<Patch>> releaseSpecificPatches{};
+    static const inline std::unordered_map<std::wstring_view, std::vector<Patch>> releaseSpecificPatches{
+      {
+        L"Ubuntu-18.04",
+        {
+          {"/etc/systemd/system/systemd-modules-load.service.d/00-wsl.conf",
+           PatchingFunctions::OverrideUnitVirtualizationContainer},
+        },
+      },
+    };
 }


### PR DESCRIPTION
Implements a patching function to write overrides to units preventing them to start on containers. Such as WSL distro instances.
That function is registered for `systemd-modules-load.service` on 18.04. Other releases already have that condition on the system unit file shipped with the distro rootfs.