### PR TITLE
Disables `multipathd.socket` on Ubuntu-20.04

### DIFF
--- a/DistroLauncher-Tests/DistroLauncher-Tests/PatchTests.cpp
+++ b/DistroLauncher-Tests/DistroLauncher-Tests/PatchTests.cpp
@@ -290,4 +290,13 @@ options=metadata
         // That function is currently so simple that, if we consider the rest of the patching feature well tested, then
         // there is no reason to test it.
     }
+    TEST(PatchWiringTest, CondVirt2004)
+    {
+        // Makes sure the function PatchingFunctions::OverrideUnitVirtualizationContainer is associated with the file
+        // "/etc/systemd/system/multipathd.socket.d/00-wsl.conf" for 18.04.
+        EXPECT_TRUE(isRegisteredFor(L"Ubuntu-20.04", {
+                                                       "/etc/systemd/system/multipathd.socket.d/00-wsl.conf",
+                                                       PatchingFunctions::OverrideUnitVirtualizationContainer,
+                                                     }));
+    }
 }

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -133,5 +133,12 @@ namespace Ubuntu
            PatchingFunctions::OverrideUnitVirtualizationContainer},
         },
       },
+      {
+        L"Ubuntu-20.04",
+        {
+          {"/etc/systemd/system/multipathd.socket.d/00-wsl.conf",
+           PatchingFunctions::OverrideUnitVirtualizationContainer},
+        },
+      },
     };
 }


### PR DESCRIPTION
By reusing `OverrideUnitVirtualizationContainer()` supplied in #371 but registering it to write an override for `multipathd.socket`.

When enabling systemd on Ubuntu 20.04, `multipathd.service` reports failure because of the socket. The service itself has the `ConditionVirtualization` on the unit file, but the socket doesn't. Something else might be trying to talk through that socket, causing systemd to try to start it and fail. Only 20.04 was observed with that behavior.


Before:
![Captura de tela 2023-04-26 171350](https://user-images.githubusercontent.com/11138291/234750935-0d60accb-8839-4799-adc8-b75d5a121a0c.png)

After:
![Captura de tela 2023-04-26 225809](https://user-images.githubusercontent.com/11138291/234750852-f695b124-8e9f-43b9-9caa-b93a4bc2371a.png)
