### PR TITLE
Fixes for `FlutterGuardedError` seen in CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - name: Set up MSBuild (PATH)
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Install certificate


### PR DESCRIPTION
This PR addresses further issues with CI end-to-end tests:

1. `FlutterGuardedError` spuriously appearing. Recently became really recurrent. Partially addressed in https://github.com/canonical/ubuntu-desktop-installer/pull/1887.
2. Ensures the submodules are recursively updated for the end-to-end tests. The other workflows where this might be relevant update the submodules via git CLI.

While investigating 1 I noticed leftovers not being updated/removed from the UDI submodule. I suppose those leftovers are somehow related with the higher frequency the CI failed the past three days.