### PR TITLE
Fix CI crash due empty milestone.date_targeted

### DIFF
--- a/wsl-builder/lp-distro-info
+++ b/wsl-builder/lp-distro-info
@@ -65,7 +65,9 @@ def releases(lpconn, all, active, supported, devel, lts):
                 m = milestone.name.split('-')[1]
                 if m == "updates":
                     continue
-                if milestone.date_targeted and milestone.date_targeted > datetime.now():
+                if not milestone.date_targeted:
+                    continue
+                if milestone.date_targeted > datetime.now():
                     next_milestone = milestone.date_targeted.strftime("%Y-%m-%d")
                     continue
                 milestone_ids = m.split('.')


### PR DESCRIPTION
This change should prevent CI from crashing if the current development release doesn't have yet a milestone target date.

Example of a crash: https://github.com/ubuntu/WSL/actions/runs/4859862714/jobs/8663001776?pr=372