### PR TITLE
Disable SSHD service in Ubuntu 20.04

### DIFF
--- a/DistroLauncher/Patch.cpp
+++ b/DistroLauncher/Patch.cpp
@@ -39,10 +39,11 @@ namespace Ubuntu::PatchingFunctions
         return modified;
     }
 
-    bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> unused, std::ostream& conf)
+    bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> input, std::ostream& output)
     {
-        conf << "[Unit]\nConditionVirtualization=!container\n";
-        return !conf.fail();
+        std::copy(input, std::istreambuf_iterator<char>{}, std::ostream_iterator<char>{output});
+        output << "\n[Unit]\nConditionVirtualization=!container\n";
+        return !output.fail();
     }
 }
 

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -138,6 +138,7 @@ namespace Ubuntu
         {
           {"/etc/systemd/system/multipathd.socket.d/00-wsl.conf",
            PatchingFunctions::OverrideUnitVirtualizationContainer},
+          {"/lib/systemd/system/ssh.service", PatchingFunctions::OverrideUnitVirtualizationContainer},
         },
       },
     };

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -114,7 +114,7 @@ namespace Ubuntu
         bool RemoveCloudImgLabel(std::istreambuf_iterator<char> fstab, std::ostream& tmp);
 
         // Creates an override to prevent the matching unit to start in containers.
-        bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> unused, std::ostream& conf);
+        bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> input, std::ostream& output);
     }
     /// Collection of the patches that must be applied to all releases.
     static const inline std::array<const Patch, 1> releaseAgnosticPatches{


### PR DESCRIPTION
Focal is shipped with OpenSSH server, whose systemd service fails to start because the setup process doesn’t setup the host key. This short-term solution disables the service, and the long-term solution will be to remove the openssh package from the seed.

UDENG-286