### PR TITLE
(fix): Pin Flutter Version in CI

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -66,6 +66,7 @@ jobs:
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
+          flutter-version: '3.7.x'
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="x64" /p:UapAppxPackageBuildMode=SideloadOnly -verbosity:normal

--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -157,6 +157,7 @@ jobs:
         if: ${{ env.withFlutterApp == 'true' }}
         with:
           channel: stable
+          flutter-version: '3.7.x'
       - name: Build Bundle
         working-directory: ${{ env.workDir }}
         run:  msbuild .\DistroLauncher.sln /t:Build /m /nr:false /p:Configuration=Release /p:AppxBundle=Always /p:AppxBundlePlatforms="${{ env.AppxBundlePlatforms }}" /p:UapAppxPackageBuildMode=${{ env.UapAppxPackageBuildMode }} -verbosity:normal

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,6 +55,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.7.x'
       - name: Install or update WSL
         uses: ./.github/actions/wsl-install
       - name: Build and install the appxbundle for testing

--- a/e2e/launchertester/test_cases.go
+++ b/e2e/launchertester/test_cases.go
@@ -50,7 +50,7 @@ func testCorrectReleaseRootfs(t *testing.T) { //nolint: thelper, this is a test
 		"Ubuntu-22.04":   "22.04",
 		"Ubuntu-20.04":   "20.04",
 		"Ubuntu-18.04":   "18.04",
-		"Ubuntu-Preview": "23.04",
+		"Ubuntu-Preview": "23.10",
 	}
 
 	expectedRelease, ok := distroNameToRelease[*distroName]


### PR DESCRIPTION
Aligned with UDI, because some dependencies are broken with Flutter 3.10 (just released).
Also, CI expected Ubuntu-Preview to be Lunar, but we are now at Mantic.
Having two unrelated fixes together is the only way to see the CI checks all going green :)