### PR TITLE
Add debugging info display to the notify-isotracker github action.

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -373,5 +373,5 @@ jobs:
           for build in $(git diff-tree --no-commit-id --name-only -r HEAD | grep buildid); do
             AppID=$(basename $build);
             AppID=${AppID%-buildid.md};
-            PYTHONPATH=${{ env.codeDir }}/uat ${{ env.codeDir }}/wsl-builder/notify-isotracker $AppID $GITHUB_RUN_ID
+            PYTHONPATH=${{ env.codeDir }}/uat ${{ env.codeDir }}/wsl-builder/notify-isotracker --debug $AppID $GITHUB_RUN_ID
           done


### PR DESCRIPTION
We're trying to debug why recent builds did not result in isotracker notifications. This will give a bit more context at least.