### PR TITLE
Gardening 🌱: Hide Winget's loooong output behind a log group

### DIFF
--- a/.github/actions/wsl-install/action.yaml
+++ b/.github/actions/wsl-install/action.yaml
@@ -14,7 +14,9 @@ runs:
       shell: powershell
       continue-on-error: true
       run: |
+        Write-Output "::group::Install Windows Subsystem for Linux"
         winget install --name 'Windows Subsystem for Linux' --accept-source-agreements --accept-package-agreements --silent --verbose
+        Write-Output "::endgroup::"
 
     - name: Install the new distro
       if: ${{ inputs.distro != '' }}
@@ -44,8 +46,9 @@ runs:
             wsl.exe --unregister ${{ inputs.distro }} 3>&1 2>&1 | Out-Null
         }
 
-        # Install a new distro
+        Write-Output "::group::Install a new distro"
         winget install --id "${storeId}" --accept-source-agreements --accept-package-agreements --silent
+        Write-Output "::endgroup::"
 
         # Register the new distro
         & ${launcher} install --root --ui=none


### PR DESCRIPTION
This'll fold Winget's output, which is needlessly long with its progress bar and all.