### PR TITLE
fix: Disable SSH unit on 20.04 via `systemctl disable`

### DIFF
--- a/DistroLauncher/ConfigRootFs.cpp
+++ b/DistroLauncher/ConfigRootFs.cpp
@@ -17,10 +17,15 @@
 
 #include "stdafx.h"
 #include "Patch.h"
-#include "ApplyConfigPatches.h"
+#include "ConfigRootfs.h"
 
 namespace Ubuntu
 {
+    void ConfigRootFs(const std::wstring& DistroName, WslApiLoader& wsl)
+    {
+        ApplyConfigPatches(DistroName);
+    }
+
     void ApplyConfigPatches(std::wstring_view DistroName)
     {
         // I think the WslPathPrefix no longer belongs to Oobe namespace. But let's leave that for later.

--- a/DistroLauncher/ConfigRootFs.cpp
+++ b/DistroLauncher/ConfigRootFs.cpp
@@ -17,7 +17,7 @@
 
 #include "stdafx.h"
 #include "Patch.h"
-#include "ConfigRootfs.h"
+#include "ConfigRootFs.h"
 
 namespace Ubuntu
 {
@@ -59,6 +59,6 @@ namespace Ubuntu
     void DisableSystemdUnits(WslApiLoader& wsl)
     {
         DWORD exitCode;
-        auto hr = wsl.WslLaunchInteractive(L"systemctl disable ssh &>/dev/null", true, &exitCode);
+        wsl.WslLaunchInteractive(L"systemctl disable ssh &>/dev/null", TRUE, &exitCode);
     }
 }

--- a/DistroLauncher/ConfigRootFs.cpp
+++ b/DistroLauncher/ConfigRootFs.cpp
@@ -24,6 +24,13 @@ namespace Ubuntu
     void ConfigRootFs(const std::wstring& DistroName, WslApiLoader& wsl)
     {
         ApplyConfigPatches(DistroName);
+        // Currently the only systemd unit mapped for explicit disablement is ssh on 20.04.
+        // If other cases appear, we should follow some strategy similar to the ApplyConfigPatches
+        // to properly select which units to disable for which distro release. The selection should still
+        // be internal, i.e. non visible from DistroLauncher.cpp.
+        if (DistroName == L"Ubuntu-20.04") {
+            DisableSystemdUnits(wsl);
+        }
     }
 
     void ApplyConfigPatches(std::wstring_view DistroName)
@@ -47,5 +54,11 @@ namespace Ubuntu
         for (const auto& patch : releaseSpecific->second) {
             patch.apply(pathPrefix);
         }
+    }
+
+    void DisableSystemdUnits(WslApiLoader& wsl)
+    {
+        DWORD exitCode;
+        auto hr = wsl.WslLaunchInteractive(L"systemctl disable ssh &>/dev/null", true, &exitCode);
     }
 }

--- a/DistroLauncher/ConfigRootFs.h
+++ b/DistroLauncher/ConfigRootFs.h
@@ -18,6 +18,10 @@
 
 namespace Ubuntu
 {
+    /// Performs post-registration file system configuration and tweaks to optimize the behavior of the distro image to WSL.
+    /// The actions come in two distinct natures: config file patching and systemd unit disabling.
+    /// See [ApplyConfigPatches] and [DisableSystemdUnits] for details.
+    void ConfigRootFs(const std::wstring& DistroName, WslApiLoader& wsl);
     /**
      * The distro launcher is equipped with a simple mechanism to adapt the root filesystem contents to some WSL
      * specificities through patching distro configuration files.

--- a/DistroLauncher/ConfigRootFs.h
+++ b/DistroLauncher/ConfigRootFs.h
@@ -18,9 +18,9 @@
 
 namespace Ubuntu
 {
-    /// Performs post-registration file system configuration and tweaks to optimize the behavior of the distro image to WSL.
-    /// The actions come in two distinct natures: config file patching and systemd unit disabling.
-    /// See [ApplyConfigPatches] and [DisableSystemdUnits] for details.
+    /// Performs post-registration file system configuration and tweaks to optimize the behavior of the distro image to
+    /// WSL. The actions come in two distinct natures: config file patching and systemd unit disabling. See
+    /// [ApplyConfigPatches] and [DisableSystemdUnits] for details.
     void ConfigRootFs(const std::wstring& DistroName, WslApiLoader& wsl);
     /**
      * The distro launcher is equipped with a simple mechanism to adapt the root filesystem contents to some WSL

--- a/DistroLauncher/ConfigRootFs.h
+++ b/DistroLauncher/ConfigRootFs.h
@@ -45,4 +45,7 @@ namespace Ubuntu
 
     /// Applies any relevant patch for the [DistroName].
     void ApplyConfigPatches(std::wstring_view DistroName);
+
+    /// Disables the relevant systemd units by means of running `systemctl disable`.
+    void DisableSystemdUnits(WslApiLoader& wsl);
 }

--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -37,7 +37,7 @@ HRESULT InstallDistribution(bool createUser, Oobe::Application<>& app)
         return hr;
     }
 
-    Ubuntu::ApplyConfigPatches(DistributionInfo::Name);
+    Ubuntu::ConfigRootFs(DistributionInfo::Name, g_wslApi);
 
     // Create a user account.
     if (createUser) {

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -157,7 +157,7 @@
     <ClInclude Include="DistributionInfo.h" />
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="Patch.h" />
-    <ClInclude Include="ApplyConfigPatches.h" />
+    <ClInclude Include="ConfigRootFs.h" />
     <ClInclude Include="ProcessRunner.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SetOnceNamedEvent.h" />
@@ -188,7 +188,7 @@
     <ClCompile Include="named_mutex.cpp" />
     <ClCompile Include="OOBE.cpp" />
     <ClCompile Include="Patch.cpp" />
-    <ClCompile Include="ApplyConfigPatches.cpp" />
+    <ClCompile Include="ConfigRootFs.cpp" />
     <ClCompile Include="ProcessRunner.cpp" />
     <ClCompile Include="ini_find_value.cpp" />
     <ClCompile Include="SetOnceNamedEvent.cpp" />

--- a/DistroLauncher/Patch.cpp
+++ b/DistroLauncher/Patch.cpp
@@ -39,11 +39,10 @@ namespace Ubuntu::PatchingFunctions
         return modified;
     }
 
-    bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> input, std::ostream& output)
+    bool OverrideUnitVirtualizationContainer(std::istreambuf_iterator<char> unused, std::ostream& conf)
     {
-        std::copy(input, std::istreambuf_iterator<char>{}, std::ostream_iterator<char>{output});
-        output << "\n[Unit]\nConditionVirtualization=!container\n";
-        return !output.fail();
+        conf << "[Unit]\nConditionVirtualization=!container\n";
+        return !conf.fail();
     }
 
     /**

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -156,7 +156,6 @@ namespace Ubuntu
         {
           {"/etc/systemd/system/multipathd.socket.d/00-wsl.conf",
            PatchingFunctions::OverrideUnitVirtualizationContainer},
-          {"/lib/systemd/system/ssh.service", PatchingFunctions::OverrideUnitVirtualizationContainer},
         },
       },
     };

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -51,7 +51,7 @@
 #include "OobeDefs.h"
 #include "ExitStatus.h"
 #include "OOBE.h"
-#include "ApplyConfigPatches.h"
+#include "ConfigRootFs.h"
 #include "ProcessRunner.h"
 #include "WSLInfo.h"
 #include "Win32Utils.h"


### PR DESCRIPTION
After a team discussion we concluded that the way we closed #382 was inappropriate (thus this PR reverts it) and we should disable the SSH `systemd` unit via `systemctl disable`.

That cannot be made into the existing patching feature.

So I took the simplest approach of just running the command explicitly, but I placed the code where it's easily amendable to a more involved solution, if we start to mix and match different releases and `systemd` units to disable and require something similar to the patching feature into selecting the units per release and forming the `systemctl`command line accordingly. For now that would be an overkill since we only have one `systemd` unit and one release to match.

---

The result of a sideload installation of 20.04 after this looks like the following:

```
Installing, this may take a few minutes...
Please create a default UNIX user account. The username does not need to match your Windows username.
For more information visit: https://aka.ms/wslusers
Enter new UNIX username: u
New password:
Retype new password:
passwd: password updated successfully
The operation completed successfully.
Installation successful!
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

Welcome to Ubuntu 20.04.6 LTS (GNU/Linux 5.15.90.1-microsoft-standard-WSL2 x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Tue May 23 15:19:55 -03 2023

  System load:  2.97                Processes:             69
  Usage of /:   0.1% of 1006.85GB   Users logged in:       0
  Memory usage: 3%                  IPv4 address for eth0: 172.25.228.251
  Swap usage:   0%

Expanded Security Maintenance for Applications is not enabled.

0 updates can be applied immediately.

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status


The list of available updates is more than a week old.
To check for new updates run: sudo apt update


This message is shown once a day. To disable it please create the
/home/u/.hushlogin file.
u@Zero01:~$ systemctl status
● Zero01
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Tue 2023-05-23 15:19:48 -03; 11s ago
   CGroup: /
           ├─user.slice
           │ └─user-1000.slice
           │   ├─user@1000.service
           │   │ └─init.scope
           │   │   ├─797 /lib/systemd/systemd --user
           │   │   └─798 (sd-pam)
           │   └─session-c1.scope
           │     ├─623 /bin/login -f
           │     └─805 -bash
           ├─init.scope
           │ └─1 /sbin/init
           └─system.slice
             ├─systemd-networkd.service
             │ └─102 /lib/systemd/systemd-networkd
             ├─systemd-udevd.service
             │ ├─ 76 /lib/systemd/systemd-udevd
             │ ├─ 81 /lib/systemd/systemd-udevd
             │ ├─ 82 /lib/systemd/systemd-udevd
             │ ├─ 83 /lib/systemd/systemd-udevd
             │ ├─ 84 /lib/systemd/systemd-udevd
             │ ├─ 85 /lib/systemd/systemd-udevd
             │ ├─ 86 /lib/systemd/systemd-udevd
             │ ├─ 87 /lib/systemd/systemd-udevd
u@Zero01:~$ systemctl status ssh
● ssh.service - OpenBSD Secure Shell server
     Loaded: loaded (/lib/systemd/system/ssh.service; disabled; vendor preset: enabled)
     Active: inactive (dead)
       Docs: man:sshd(8)
             man:sshd_config(5)
u@Zero01:~$
```
