### PR TITLE
fix: Prevents cloud-init from running once systemd is enabled

### DIFF
--- a/DistroLauncher/Patch.cpp
+++ b/DistroLauncher/Patch.cpp
@@ -106,6 +106,11 @@ namespace Ubuntu::PatchingFunctions
         output << "\naction=reboot\n";
         return true;
     }
+
+    bool Empty(std::istreambuf_iterator<char> /* unused */, std::ostream& /* unused */)
+    {
+        return true;
+    }
 }
 
 namespace Ubuntu

--- a/DistroLauncher/Patch.h
+++ b/DistroLauncher/Patch.h
@@ -127,6 +127,10 @@ namespace Ubuntu
 
         // Marks the distro as needing a reboot, but does not act on it.
         bool DeferReboot(std::istreambuf_iterator<char> input, std::ostream& output);
+
+        // Causes an empty file to be written, useful for disabling certain services such as cloud-init,
+        // where the mere presence of the empty file is enough to signal that it shouldn't run.
+        bool Empty(std::istreambuf_iterator<char> /* unused */, std::ostream& /* unused */);
     }
 
     /// Collection of the patches that must be applied to all releases.
@@ -139,6 +143,8 @@ namespace Ubuntu
       Patch{L"/etc/wsl.conf", PatchingFunctions::EnableSystemd},
       Patch{L"/etc/update-manager/release-upgrades", PatchingFunctions::SetDefaultUpgradePolicy},
       Patch{L"/run/launcher-command", PatchingFunctions::DeferReboot},
+      // See https://bugs.launchpad.net/cloud-init/+bug/2008727/comments/2 for the file path.
+      Patch{L"/etc/cloud/cloud-init.disabled", PatchingFunctions::Empty},
     };
 
     /// All applicable patches specific to a specific Ubuntu app are defined in this data structure.


### PR DESCRIPTION
Patch applied to all releases, even those without the OOBE. It doesn't harm them.

Keeps a single place to remove once we find how to support cloud-init properly. Otherwise we'd need to repeat the Patch declaration for Ubuntu, Ubuntu-Preview and UbuntuDev.WslID.Dev.

See https://bugs.launchpad.net/cloud-init/+bug/2008727/comments/2 for the file path.

With that patch we get:

```
Welcome to Ubuntu Mantic Minotaur (development branch) (GNU/Linux 5.15.90.1-microsoft-standard-WSL2 x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage


This message is shown once a day. To disable it please create the
/home/u/.hushlogin file.
u@Zero01:~$ ls /etc/cloud/
cloud-init.disabled
u@Zero01:~$ systemctl is-system-running
running
u@Zero01:~$ ps aux | grep cloud-init
u            539  0.0  0.0   4024  1900 pts/0    S+   11:42   0:00 grep --color=auto cloud-init
u@Zero01:~$ ps aux | grep cloud-init
u            543  0.0  0.0   4024  1936 pts/0    S+   11:43   0:00 grep --color=auto cloud-init
u@Zero01:~$ ps aux | grep cloud-init
u            545  0.0  0.0   4024  1804 pts/0    S+   11:44   0:00 grep --color=auto cloud-init
u@Zero01:~$
logout
```