### PR TITLE
Simplify cleanup of leftover distros in wsl-install action

### DIFF
--- a/.github/actions/wsl-install/action.yaml
+++ b/.github/actions/wsl-install/action.yaml
@@ -33,18 +33,14 @@ runs:
             default          { Write-Output "Error: Unknown distro ${distro}" ; Exit(1) }
         }
 
-        # Unregister and uninstall pre-existing distro
+        # Uninstall pre-existing appx
         $pkgFullName = (Get-AppxPackage | Where-Object Name -like "CanonicalGroupLimited.${appxname}").PackageFullName
-        if ( "${pkg}" -ne '' ) {
-            Write-Output "Remove leftover APPX"
-            Remove-AppxPackage "${pkgFullName}" 3>&1 2>&1 | Out-Null
-        }
-
+        Remove-AppxPackage "${pkgFullName}" 3>&1 2>&1 | Out-Null
+        
+        # Unregister leftover distros
         $env:WSL_UTF8=1
-        if ( "$(wsl --list --all | Select-String "Ubuntu-Preview")" -ne '' ) {
-            Write-Output "Remove leftover distro"
-            wsl.exe --unregister ${{ inputs.distro }} 3>&1 2>&1 | Out-Null
-        }
+        wsl.exe --shutdown
+        wsl.exe --unregister ${{ inputs.distro }} 3>&1 2>&1 | Out-Null
 
         Write-Output "::group::Install a new distro"
         winget install --id "${storeId}" --accept-source-agreements --accept-package-agreements --silent


### PR DESCRIPTION
For some reason these if-checks are not working adequately, so instead I opt for a ask-for-forgiveness rather than ask-for-permission approach.

You can see the leftover distros interfering here: https://github.com/ubuntu/WSL/actions/runs/5118578090/jobs/9202785080?pr=397