### PR TITLE
Fix obscure Git error in wsl-checkout

### DIFF
--- a/.github/actions/wsl-checkout/action.yaml
+++ b/.github/actions/wsl-checkout/action.yaml
@@ -30,7 +30,7 @@ runs:
           git clone --quiet --depth 1 https://github.com/${{ github.repository }}.git ${{ inputs.working-dir }}
 
           cd ${{ inputs.working-dir }}
-          git fetch --quiet --depth 1 --no-tags --prune origin +${{ github.sha }}:${{ github.ref }}
+          git fetch --quiet --depth 1 --no-tags --prune --update-head-ok origin +${{ github.sha }}:${{ github.ref }}
           git checkout --quiet ${{ github.sha }}
 
           if [ "${{ inputs.submodules }}" = true ] ; then


### PR DESCRIPTION
Apparently you cannot fetch the branch you're in. This is not an issue when this action is called in a PR:
- `git clone ...` clones into main
- `git fetch ...` fetches the PR ref

However, when this action is ran on main (for instance, after merging the PR), the fetch will try to fetch main, and fail.

See here:
https://github.com/ubuntu/wsl-actions-example/actions/runs/5120947427/jobs/9208564434

See a Stackoverflow thread about this:
https://stackoverflow.com/questions/2236743/git-refusing-to-fetch-into-current-branch