### PR TITLE
Install debug control hook

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -109,6 +109,9 @@ int wmain(int argc, wchar_t const *argv[])
 
     // Initialize a vector of arguments.
     std::vector<std::wstring_view> arguments;
+    
+    arguments[5];
+
     for (int index = 1; index < argc; index += 1) {
         arguments.push_back(argv[index]);
     }

--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -81,8 +81,29 @@ HRESULT SetDefaultUser(std::wstring_view userName)
     return hr;
 }
 
+int DebugReportHook(int reportType, char *message, int *returnValue)
+{
+    const auto type = [=]() -> std::string_view {
+        switch (reportType) {
+        case _CRT_WARN:
+            return "[WARNING]";
+        case _CRT_ERROR:
+            return "[ERROR]";
+        case _CRT_ASSERT:
+            return "[ASSERT]";
+        default:
+            return "[UNKNOWN]";
+        }
+    }();
+
+    std::cerr << type << " " << message;
+    exit(EXIT_FAILURE);
+}
+
 int wmain(int argc, wchar_t const *argv[])
 {
+    _CrtSetReportHook(DebugReportHook);
+
     // Update the title bar of the console window.
     SetConsoleTitleW(DistributionInfo::WindowTitle.c_str());
 


### PR DESCRIPTION
In Microsoft’s implementation of the C++ standard library, there are some useful debug assertions, mostly regarding memory and address safety. The default behaviour of these is to promp the user with the line where the assertion failed (not very useful as it is often deep inside the standard library, but it offers some clue) and stop execution until that prompt is attended to.

This is usefull when locally debugging but annoying in automated CI, as that prompt will wait until the tests time out and the process is killed.