### PR TITLE
ci: retry rootfs download if it fails

### DIFF
--- a/.github/actions/download-rootfs/action.yaml
+++ b/.github/actions/download-rootfs/action.yaml
@@ -77,6 +77,9 @@ runs:
 
           $url = $data[1]
 
+          # Make sure there is no previous leftover
+          Remove-Item -Force "$file.tmp" 2>&1 | Out-Null
+
           Write-Output "::group::Downloading ${name}"
           Write-Output "Downloading from ${url}"
           pwsh.exe -Command Invoke-WebRequest -Uri "$url" -OutFile "${file}.tmp" -Resume -MaximumRetryCount 5 -RetryIntervalSec 2

--- a/.github/actions/download-rootfs/action.yaml
+++ b/.github/actions/download-rootfs/action.yaml
@@ -73,7 +73,7 @@ runs:
 
           Write-Output "::group::Downloading ${name}"
           Write-Output "Downloading from ${url}"
-          Invoke-WebRequest -Uri "$url" -OutFile "${file}.tmp"
+          Invoke-WebRequest -Uri "$url" -OutFile "${file}.tmp" -Resume -MaximumRetryCount 5 -RetryIntervalSec 2
           if ( ! $? ) {
             $allSuccess = $false
             Write-Output "Error: Failed download"

--- a/.github/actions/download-rootfs/action.yaml
+++ b/.github/actions/download-rootfs/action.yaml
@@ -55,8 +55,6 @@ runs:
     - name: Download Ubuntu rootfs
       shell: powershell
       run: |
-        # Ensure we are using the right version of Powershell
-        $PsVersion
         # Download rootfs
         .\release-info.exe "${{ inputs.path }}\ubuntu-releases.csv" ${{ inputs.distros }} --rootfs amd64 --short 1> "${{ inputs.path }}\wsl-releases.csv"
         if ( "${LastExitCode}" -ne "0" ) {
@@ -78,7 +76,9 @@ runs:
           $url = $data[1]
 
           # Make sure there is no previous leftover
-          Remove-Item -Force "$file.tmp" 2>&1 | Out-Null
+          if (Test-Path $file) {
+            Remove-Item -Force "$file.tmp" 2>&1 | Out-Null
+          }
 
           Write-Output "::group::Downloading ${name}"
           Write-Output "Downloading from ${url}"

--- a/.github/actions/download-rootfs/action.yaml
+++ b/.github/actions/download-rootfs/action.yaml
@@ -30,11 +30,11 @@ runs:
     - name: Prepare environment
       shell: powershell
       run: |
+        # Prepare environment
+
         # Install PowerShell
-        $PsVersion
         winget install --id Microsoft.Powershell --silent --accept-package-agreements --accept-source-agreements --source winget
 
-        # Prepare environment
         Write-Output "::group::Build wsl release info generator"
         go build .\wsl-builder\release-info\
         if ( "${LastExitCode}" -ne "0" ) {

--- a/.github/actions/download-rootfs/action.yaml
+++ b/.github/actions/download-rootfs/action.yaml
@@ -30,6 +30,10 @@ runs:
     - name: Prepare environment
       shell: powershell
       run: |
+        # Install PowerShell
+        $PsVersion
+        winget install --id Microsoft.Powershell --silent --accept-package-agreements --accept-source-agreements --source winget
+
         # Prepare environment
         Write-Output "::group::Build wsl release info generator"
         go build .\wsl-builder\release-info\
@@ -51,6 +55,8 @@ runs:
     - name: Download Ubuntu rootfs
       shell: powershell
       run: |
+        # Ensure we are using the right version of Powershell
+        $PsVersion
         # Download rootfs
         .\release-info.exe "${{ inputs.path }}\ubuntu-releases.csv" ${{ inputs.distros }} --rootfs amd64 --short 1> "${{ inputs.path }}\wsl-releases.csv"
         if ( "${LastExitCode}" -ne "0" ) {

--- a/.github/actions/download-rootfs/action.yaml
+++ b/.github/actions/download-rootfs/action.yaml
@@ -76,7 +76,7 @@ runs:
           $url = $data[1]
 
           # Make sure there is no previous leftover
-          if (Test-Path $file) {
+          if (Test-Path "$file.tmp") {
             Remove-Item -Force "$file.tmp" 2>&1 | Out-Null
           }
 

--- a/.github/actions/download-rootfs/action.yaml
+++ b/.github/actions/download-rootfs/action.yaml
@@ -79,7 +79,7 @@ runs:
 
           Write-Output "::group::Downloading ${name}"
           Write-Output "Downloading from ${url}"
-          Invoke-WebRequest -Uri "$url" -OutFile "${file}.tmp" -Resume -MaximumRetryCount 5 -RetryIntervalSec 2
+          pwsh.exe -Command Invoke-WebRequest -Uri "$url" -OutFile "${file}.tmp" -Resume -MaximumRetryCount 5 -RetryIntervalSec 2
           if ( ! $? ) {
             $allSuccess = $false
             Write-Output "Error: Failed download"

--- a/.github/workflows/update-rootfs-cache.yaml
+++ b/.github/workflows/update-rootfs-cache.yaml
@@ -11,7 +11,7 @@ on:
      paths:
       # We run it when changing one if its dependencies
       - .github/workflows/update-rootfs-cache.yaml
-      - .github/actions/download-rootfs.yaml
+      - .github/actions/download-rootfs/action.yaml
 
 env:
   az_name: wsl-ci


### PR DESCRIPTION
Since Powershell 6+ invoke-Webrequest has a retry option. Use this option in case of failure together with the resume option.
Besides, the path to action.yaml was wrong.

UDENG-1813