### PR TITLE
tests: dynamically build the list of supported WSL releases

### DIFF
--- a/e2e/launchertester/test_cases.go
+++ b/e2e/launchertester/test_cases.go
@@ -45,13 +45,8 @@ func testCorrectReleaseRootfs(t *testing.T) { //nolint: thelper, this is a test
 	t.Parallel()
 	var expectedRelease string
 
-	distroNameToRelease := map[string]string{
-		"Ubuntu":         "22.04",
-		"Ubuntu-22.04":   "22.04",
-		"Ubuntu-20.04":   "20.04",
-		"Ubuntu-18.04":   "18.04",
-		"Ubuntu-Preview": "23.10",
-	}
+	distroNameToRelease, e := getDistroReleases()
+	require.NoError(t, e, "failed to initialize the list of distro")
 
 	expectedRelease, ok := distroNameToRelease[*distroName]
 	if !ok {


### PR DESCRIPTION
To reduce the burden of updating the list of supported releases every six months, we now use distro-info to dynamically build the list of releases. That is all the ESM supported LTS releases and the current development release.