### PR TITLE
tests: fix version of the devel release

### DIFF
--- a/e2e/launchertester/test_cases.go
+++ b/e2e/launchertester/test_cases.go
@@ -50,7 +50,7 @@ func testCorrectReleaseRootfs(t *testing.T) { //nolint: thelper, this is a test
 		"Ubuntu-22.04":   "22.04",
 		"Ubuntu-20.04":   "20.04",
 		"Ubuntu-18.04":   "18.04",
-		"Ubuntu-Preview": "23.10",
+		"Ubuntu-Preview": "24.04",
 	}
 
 	expectedRelease, ok := distroNameToRelease[*distroName]


### PR DESCRIPTION
quick'n dirty fix to the version. Ideally we use something similar to distro-info but since it's running on Windows it is not so straightforward.