### PR TITLE
fix(e2e): Remove testCorrectReleaseRootfs test case

### DIFF
--- a/e2e/launchertester/basic_setup_test.go
+++ b/e2e/launchertester/basic_setup_test.go
@@ -23,7 +23,6 @@ func TestBasicSetupGUI(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"UserNotRoot":             testUserNotRoot,
 		"LanguagePacksMarked":     testLanguagePacksMarked,
-		"CorrectReleaseRootfs":    testCorrectReleaseRootfs,
 		"SystemdEnabled":          testSystemdEnabled,
 		"SystemdUnits":            testSystemdUnits,
 		"CorrectUpgradePolicy":    testCorrectUpgradePolicy,
@@ -51,7 +50,6 @@ func TestBasicSetupFallbackUI(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		// Skipping testUserNotRoot because we installed as --root
 		"LanguagePacksMarked":     testLanguagePacksMarked,
-		"CorrectReleaseRootfs":    testCorrectReleaseRootfs,
 		"SystemdEnabled":          testSystemdEnabled,
 		"SystemdUnits":            testSystemdUnits,
 		"CorrectUpgradePolicy":    testCorrectUpgradePolicy,

--- a/e2e/launchertester/default_experience_test.go
+++ b/e2e/launchertester/default_experience_test.go
@@ -56,7 +56,6 @@ func TestDefaultExperience(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"UserNotRoot":             testUserNotRoot,
 		"LanguagePacksMarked":     testLanguagePacksMarked,
-		"CorrectReleaseRootfs":    testCorrectReleaseRootfs,
 		"SystemdEnabled":          testSystemdEnabled,
 		"SystemdUnits":            testSystemdUnits,
 		"CorrectUpgradePolicy":    testCorrectUpgradePolicy,
@@ -103,9 +102,9 @@ func waitStateTransition(t *testing.T, fromState string, toState string) {
 // waitForInstaller waits until the subiquity server log indicates that the installation
 // has finsihed.
 // Considerations:
-// - The server may still run for a small amount of time after the log
-//   says it has finished. Experimentally, it seems to be less than a second.
-// - The State of the distro must be either Running or Stopped when called (i.e. installation must have been started).
+//   - The server may still run for a small amount of time after the log
+//     says it has finished. Experimentally, it seems to be less than a second.
+//   - The State of the distro must be either Running or Stopped when called (i.e. installation must have been started).
 func waitForInstaller(t *testing.T) {
 	t.Helper()
 

--- a/e2e/launchertester/test_cases.go
+++ b/e2e/launchertester/test_cases.go
@@ -40,39 +40,6 @@ func testLanguagePacksMarked(t *testing.T) { //nolint: thelper, this is a test
 	require.NotEmpty(t, string(out), "At least one language pack should have been installed or marked for installation, but apt-mark command output is empty.")
 }
 
-// Proper release. Ensures the right tarball was used as rootfs.
-func testCorrectReleaseRootfs(t *testing.T) { //nolint: thelper, this is a test
-	t.Parallel()
-	var expectedRelease string
-
-	distroNameToRelease := map[string]string{
-		"Ubuntu":         "22.04",
-		"Ubuntu-22.04":   "22.04",
-		"Ubuntu-20.04":   "20.04",
-		"Ubuntu-18.04":   "18.04",
-		"Ubuntu-Preview": "24.04",
-	}
-
-	expectedRelease, ok := distroNameToRelease[*distroName]
-	if !ok {
-		expectedRelease = distroNameToRelease["Ubuntu-Preview"]
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), systemdBootTimeout)
-	defer cancel()
-
-	out, err := wslCommand(ctx, "lsb_release", "-r").CombinedOutput()
-	require.NoErrorf(t, err, "Unexpected failure executing lsb_release: %s", out)
-
-	// Example 'out': "Release:        22.04"
-	k, v, found := strings.Cut(string(out), ":")
-	require.True(t, found, "Failed to parse '<key>: <value>' from input %q", out)
-	require.Equal(t, k, "Release", "Failed to parse 'Release: <value>' from input %q", out)
-	release := strings.TrimSpace(v)
-
-	require.Equal(t, expectedRelease, release, "Mismatching releases")
-}
-
 // testSystemdEnabled ensures systemd was enabled.
 func testSystemdEnabled(t *testing.T) { //nolint: thelper, this is a test
 	if !systemdIsExpected() {


### PR DESCRIPTION
We deemed that manually updating this every now and then is not worth the effort.

---

UDENG-1816