### PR TITLE
Fix help argument to not install the distro

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -12,6 +12,7 @@
 #define ARG_INSTALL_ROOT        L"--root"
 #define ARG_RUN                 L"run"
 #define ARG_RUN_C               L"-c"
+#define ARG_HELP                L"help"
 
 // Helper class for calling WSL Functions:
 // https://msdn.microsoft.com/en-us/library/windows/desktop/mt826874(v=vs.85).aspx
@@ -111,6 +112,12 @@ int wmain(int argc, wchar_t const *argv[])
     std::vector<std::wstring_view> arguments;
     for (int index = 1; index < argc; index += 1) {
         arguments.push_back(argv[index]);
+    }
+
+    // Deal with possible help flag.
+    if (!arguments.empty() && arguments.front() == ARG_HELP) {
+        Helpers::PrintMessage(MSG_USAGE);
+        return 0;
     }
 
     Oobe::Application<> app(arguments);

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -125,5 +125,5 @@ Usage:
               Sets the default user to <username>. This must be an existing user.
 
     help
-        Print usage information.
+        Print usage information and exit.
 .

--- a/e2e/go.work
+++ b/e2e/go.work
@@ -1,7 +1,7 @@
 go 1.21.4
 
 use (
-    ./constants
-    ./launchertester
-    ./ui-driver
+	./constants
+	./launchertester
+	./ui-driver
 )

--- a/e2e/launchertester/basic_setup_test.go
+++ b/e2e/launchertester/basic_setup_test.go
@@ -28,6 +28,7 @@ func TestBasicSetupGUI(t *testing.T) {
 		"CorrectUpgradePolicy":    testCorrectUpgradePolicy,
 		"UpgradePolicyIdempotent": testUpgradePolicyIdempotent,
 		"InteropIsEnabled":        testInteropIsEnabled,
+		"HelpFlag":                testHelpFlag,
 	}
 
 	for name, tc := range testCases {

--- a/e2e/launchertester/help_test.go
+++ b/e2e/launchertester/help_test.go
@@ -1,0 +1,20 @@
+package launchertester
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelpFlagNoInstall(t *testing.T) {
+	wslSetup(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	out, err := launcherCommand(ctx, "help").CombinedOutput()
+	require.NoErrorf(t, err, "Unexpected error using help message: %s", out)
+
+	require.Equal(t, "DistroNotFound", distroState(t), "Using command help should not install the distro")
+}

--- a/e2e/launchertester/test_cases.go
+++ b/e2e/launchertester/test_cases.go
@@ -216,3 +216,24 @@ func systemdIsExpected() bool {
 	}
 	return expectSystemd
 }
+
+func testHelpFlag(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), systemdBootTimeout)
+	defer cancel()
+
+	// usageFirstLine is the first line printed after '> laucher.exe --help'.
+	// The usage message is not localized so it's safe to assert on it.
+	const usageFirstLine = "Launches or configures a Linux distribution."
+
+	out, err := launcherCommand(ctx, "run", "help").CombinedOutput()
+	require.NoError(t, err, "could not run '%s run help': %v, %s", *launcherName, err, out)
+	require.NotContains(t, string(out), usageFirstLine, "help command should not have been picked up by the launcher")
+
+	out, err = launcherCommand(ctx, "-c", "help").CombinedOutput()
+	require.NoError(t, err, "could not run '%s -c help': %v, %s", *launcherName, err, out)
+	require.NotContains(t, string(out), usageFirstLine, "help command should not have been picked up by the launcher")
+
+	out, err = launcherCommand(ctx, "help").CombinedOutput()
+	require.NoError(t, err, "could not run '%s help': %v, %s", *launcherName, err, out)
+	require.Contains(t, string(out), usageFirstLine, "help command should have been picked up by the launcher")
+}


### PR DESCRIPTION
The way command line arguments are parsed is not ideal, but that is mostly inherited from upstream.

Command `launcher.exe help` should print the help and exit, however `help` is not a real command, so it defaults to the same behaviour as `launcher.exe made-up-command`. It first installs and then fails to launch.

I fix this by checking for `help` very early on.

UDENG-276