### PR TITLE
feat(docs): Tutorial for auto setup with cloud-init

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -105,3 +105,4 @@ Escandell
 edu
 gomez
 escandell
+powershell

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -117,6 +117,7 @@ redirects = {}
 
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
+    'https://askubuntu.com',
     ]
 
 # Pages on which to ignore anchors

--- a/docs/reference/distributions.md
+++ b/docs/reference/distributions.md
@@ -6,6 +6,7 @@ Each of these flavours corresponds to a different application on the Microsoft S
 - [Ubuntu 18.04.6 LTS](https://apps.microsoft.com/detail/9PNKSF5ZN4SW?hl=en-us&gl=US), [Ubuntu 20.04.6 LTS](https://apps.microsoft.com/detail/9MTTCL66CPXJ?hl=en-us&gl=US), and [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) are the LTS versions of Ubuntu and receive updates for five years. Upgrades to future LTS releases will not be proposed.
 - [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu previewing new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
 
+(naming)=
 ## Naming
 
 Due to different limitations in different contexts, these applications will have different names in different contexts. Here is a table matching them.

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -3,8 +3,12 @@
 
 Cloud-init is an industry-standard multi-distribution method for cross-platform cloud instance initialisation.
 Ubuntu WSL users can now leverage it to perform an automatic setup to get a working instance with minimal touch.
-That feature is currently experimental and, thus only available on the UbuntuPreview app. Soon that will be available for
-the latest LTS application as well.
+
+```{note}
+**Coming soon*:
+
+That feature is currently in development and will be available soon on the UbuntuPreview app first, then gradually released for the latest LTS applications.
+```
 
 ## What you will learn:
 

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -2,14 +2,14 @@
 *Authored by Carlos Nihelton ([carlos.santanadeoliveira@canonical.com](mailto:carlos.santanadeoliveira@canonical.com))*
 
 Cloud-init is an industry-standard multi-distribution method for cross-platform cloud instance initialisation.
-Ubuntu WSL users can now leverage it to perform automatic setup to get a working instance with minimal touch.
-That feature is currently experimental, thus only available on the UbuntuPreview app. Soon that will be available for
+Ubuntu WSL users can now leverage it to perform an automatic setup to get a working instance with minimal touch.
+That feature is currently experimental and, thus only available on the UbuntuPreview app. Soon that will be available for
 the latest LTS application as well.
 
 ## What you will learn:
 
 - How to write cloud-config user data to a specific WSL instance.
-- How to automatically setup a WSL instance with cloud-init.
+- How to automatically set up a WSL instance with cloud-init.
 - How to verify that cloud-init succeeded with the configuration supplied.
 
 ## What you will need:
@@ -24,8 +24,8 @@ Locate your Windows user home directory. It typically is `C:\Users\<YOUR_USER_NA
 > You can be sure about that path by running `echo $env:USERPROFILE` in PowerShell.
 
 Inside your Windows user home directory, create a new folder named `.cloud-init` (notice the `.` à la Linux
-configuration directories), and inside it create a new empty file named `Ubuntu-Preview.user-data`. That file name must
-match the name of the distro instance that will create in the next step.
+configuration directories), and inside the new directory, create an empty file named `Ubuntu-Preview.user-data`. That file name must
+match the name of the distro instance that will be created in the next step.
 
 Open that file with your text editor of choice (`notepad.exe` is just fine) and paste in the following contents:
 
@@ -44,7 +44,7 @@ write_files:
   append: true
   content: |
     [user]
-    default=u
+    default=jdoe
 
 packages: [ginac-tools, octave]
 
@@ -66,7 +66,8 @@ In PowerShell, run:
 ```powershell
 ubuntupreview.exe install --root
 ```
-We skip the user creation, since we expect cloud-init to do it.
+
+We skip the user creation since we expect cloud-init to do it.
 
 > If you want to be sure that there is now an Ubuntu-Preview instance, run `wsl -l -v`.
 > Notice that the application is named `UbuntuPreview` but the WSL instance created is named `Ubuntu-Preview`.
@@ -155,7 +156,7 @@ LC_ALL=
 
 ```
 
-4. The packages were installed and their commands are available
+4. The packages were installed and the commands they provide are available
 
 ```sh
 u@mib:~$ apt list --installed | egrep 'ginac|octave'
@@ -181,13 +182,14 @@ See LICENSE.txt for license information.
 
 ## Enjoy!
 
-That’s all folks! In this tutorial, we’ve shown you how to use cloud-init to automatically setup Ubuntu on WSL 2 with minimal touch.
+That’s all folks! In this tutorial, we’ve shown you how to use cloud-init to automatically set up Ubuntu on WSL 2 with minimal touch.
 
-This workflow can be used to ensure a baseline for your next project that relies on Ubuntu WSL, ready for work.
+This workflow will guarantee a solid foundation for your next Ubuntu WSL project.
 
 We hope you enjoy using Ubuntu inside WSL!
 
 ### Further Reading
 
-To know more about cloud-init support for WSL checkout the [WSL data source reference in cloud-init's docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
+To know more about cloud-init support for WSL check out the [WSL data source reference in cloud-init's docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
 To learn more about cloud-init in general visit [cloud-init's official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
+

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -119,14 +119,14 @@ u@mib:~$
 
 Once logged in the new distro instance's shell, verify that:
 
-1. The default user match what was configured in the user data file (in our case `u`).
+1. The default user matches what was configured in the user data file (in our case `u`).
 
 ```sh
 u@mib:~$ whoami
 u
 ```
 
-2. The cloud-config user data supplied was approved by cloud-init validation.
+2. The supplied cloud-config user data was approved by cloud-init validation.
 
 ```sh
 u@mib:~$ sudo cloud-init schema --system
@@ -183,11 +183,11 @@ See LICENSE.txt for license information.
 
 That’s all folks! In this tutorial, we’ve shown you how to use cloud-init to automatically setup Ubuntu on WSL 2 with minimal touch.
 
-That workflow can be used to ensure a baseline for your next project that rely on Ubuntu WSL, ready for work.
+This workflow can be used to ensure a baseline for your next project that relies on Ubuntu WSL, ready for work.
 
 We hope you enjoy using Ubuntu inside WSL!
 
 ### Further Reading
 
 To know more about cloud-init support for WSL checkout the [WSL data source reference in cloud-init's docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
-To learn more about cloud-init in general visit [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
+To learn more about cloud-init in general visit [cloud-init's official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -70,6 +70,7 @@ We skip the user creation, since we expect cloud-init to do it.
 
 > If you want to be sure that there is now an Ubuntu-Preview instance, run `wsl -l -v`.
 > Notice that the application is named `UbuntuPreview` but the WSL instance created is named `Ubuntu-Preview`.
+> See more about that naming convention in [our reference documentation](../reference/distributions.md#naming).
 
 ## Check that cloud-init is running
 

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -71,7 +71,7 @@ We skip the user creation since we expect cloud-init to do it.
 
 > If you want to be sure that there is now an Ubuntu-Preview instance, run `wsl -l -v`.
 > Notice that the application is named `UbuntuPreview` but the WSL instance created is named `Ubuntu-Preview`.
-> See more about that naming convention in [our reference documentation](../reference/distributions.md#naming).
+> See more about that naming convention in [our reference documentation](naming).
 
 ## Check that cloud-init is running
 

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -189,5 +189,5 @@ We hope you enjoy using Ubuntu inside WSL!
 
 ### Further Reading
 
-To know more about cloud-init support for WSL checkout the [WSL data source reference in cloud-int docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
+To know more about cloud-init support for WSL checkout the [WSL data source reference in cloud-init's docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
 To learn more about cloud-init in general visit [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -33,8 +33,8 @@ Open that file with your text editor of choice (`notepad.exe` is just fine) and 
 #cloud-config
 locale: pt_BR
 users:
-- name: u
-  gecos: Ubuntu
+- name: jdoe
+  gecos: John Doe
   groups: [adm,dialout,cdrom,floppy,sudo,audio,dip,video,plugdev,netdev]
   sudo: ALL=(ALL) NOPASSWD:ALL
   shell: /bin/bash

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -190,6 +190,6 @@ We hope you enjoy using Ubuntu inside WSL!
 
 ### Further Reading
 
-To know more about cloud-init support for WSL check out the [WSL data source reference in cloud-init's docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
-To learn more about cloud-init in general visit [cloud-init's official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
+To know more about cloud-init support for WSL check out the [WSL data source reference in cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
+To learn more about cloud-init in general visit [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
 

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -1,0 +1,192 @@
+# Automatic setup with cloud-init
+*Authored by Carlos Nihelton ([carlos.santanadeoliveira@canonical.com](mailto:carlos.santanadeoliveira@canonical.com))*
+
+Cloud-init is an industry-standard multi-distribution method for cross-platform cloud instance initialisation.
+Ubuntu WSL users can now leverage it to perform automatic setup to get a working instance with minimal touch.
+That feature is currently experimental, thus only available on the UbuntuPreview app. Soon that will be available for
+the latest LTS application as well.
+
+## What you will learn:
+
+- How to write cloud-config user data to a specific WSL instance.
+- How to automatically setup a WSL instance with cloud-init.
+- How to verify that cloud-init succeeded with the configuration supplied.
+
+## What you will need:
+
+- Windows 11 with WSL 2 already enabled
+- The latest UbuntuPreview application from Microsoft Store.
+
+## Write the cloud-config file
+
+Locate your Windows user home directory. It typically is `C:\Users\<YOUR_USER_NAME>`.
+
+> You can be sure about that path by running `echo $env:USERPROFILE` in powershell.
+
+Inside your Windows user home directory, create a new folder named `.cloud-init` (notice the `.` alla Linux
+configuration directories), and inside it create a new empty file named `Ubuntu-Preview.user-data`. That file name must
+match the name of the distro instance that will create in the next step.
+
+Open that file with your text editor of choice (`notepad.exe` is just fine) and paste in the following contents:
+
+```yaml
+#cloud-config
+locale: pt_BR
+users:
+- name: u
+  gecos: Ubuntu
+  groups: [adm,dialout,cdrom,floppy,sudo,audio,dip,video,plugdev,netdev]
+  sudo: ALL=(ALL) NOPASSWD:ALL
+  shell: /bin/bash
+
+write_files:
+- path: /etc/wsl.conf
+  append: true
+  content: |
+    [user]
+    default=u
+
+packages: [ginac-tools, octave]
+
+runcmd:
+   - git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
+   - /opt/vcpkg/bootstrap-vcpkg.sh
+```
+
+Save it and close it.
+
+> That example will create a user named `u` and set it as default via `/etc/wsl.conf`, install the packages
+> `ginac-tools` and `octave` and install `vcpkg` from the git repository, since there is no deb or snap of that
+> application (hence the reason for being included in this tutorial - it requires an unusual setup).
+
+## Register a new Ubuntu-Preview instance
+
+In Powershell, run:
+
+```powershell
+ubuntupreview.exe install --root
+```
+We skip the user creation, since we expect cloud-init to do it.
+
+> If you want to be sure that there is now an Ubuntu-Preview instance, run `wsl -l -v`.
+> Notice that the application is named `UbuntuPreview` but the WSL instance created is named `Ubuntu-Preview`.
+
+## Check that cloud-init is running
+
+In Powershell again run:
+
+
+```powershell
+ubuntupreview run cloud-init status --wait
+```
+
+That will wait until cloud-init completes configuring the new instance we just created. When done, you should see an
+output similar to the following:
+
+```powershell
+..............................................................................
+..............................................................................
+..............................................................................
+...................
+status: done
+```
+
+
+## Verify that it worked
+
+Restart the distro just to make sure the changes in `/etc/wsl.conf` made by cloud-init will take effect, as listed
+below:
+
+```powershell
+> wsl -t Ubuntu-Preview
+The operation completed successfully.
+> ubuntupreview
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
+
+Welcome to Ubuntu Noble Numbat (development branch) (GNU/Linux 5.15.137.3-microsoft-standard-WSL2 x86_64)
+
+ * Documentation:  https://help.ubuntu.com
+ * Management:     https://landscape.canonical.com
+ * Support:        https://ubuntu.com/pro
+
+
+This message is shown once a day. To disable it please create the
+/home/cn/.hushlogin file.
+u@mib:~$
+```
+
+Once logged in the new distro instance's shell, verify that:
+
+1. The default user match what was configured in the user data file (in our case `u`).
+
+```sh
+u@mib:~$ whoami
+u
+```
+
+2. The cloud-config user data supplied was approved by cloud-init validation.
+
+```sh
+u@mib:~$ sudo cloud-init schema --system
+Valid schema user-data
+```
+
+3. The locale is set
+
+```sh
+u@mib:~$ locale
+LANG=pt_BR
+LANGUAGE=
+LC_CTYPE="pt_BR"
+LC_NUMERIC="pt_BR"
+LC_TIME="pt_BR"
+LC_COLLATE="pt_BR"
+LC_MONETARY="pt_BR"
+LC_MESSAGES="pt_BR"
+LC_PAPER="pt_BR"
+LC_NAME="pt_BR"
+LC_ADDRESS="pt_BR"
+LC_TELEPHONE="pt_BR"
+LC_MEASUREMENT="pt_BR"
+LC_IDENTIFICATION="pt_BR"
+LC_ALL=
+
+```
+
+4. The packages were installed and their commands are available
+
+```sh
+u@mib:~$ apt list --installed | egrep 'ginac|octave'
+
+WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+
+ginac-tools/noble,now 1.8.7-1 amd64 [installed]
+libginac11/noble,now 1.8.7-1 amd64 [installed,automatic]
+octave-common/noble,now 8.4.0-1 all [installed,automatic]
+octave-doc/noble,now 8.4.0-1 all [installed,automatic]
+octave/noble,now 8.4.0-1 amd64 [installed]
+```
+
+5. Verify that the commands requested were also run. In this case we set up `vcpkg` from git, as recommended by its
+   documentation (there is no deb or snap available for that program).
+
+```sh
+u@mib:~$ /opt/vcpkg/vcpkg version
+vcpkg package management program version 2024-01-11-710a3116bbd615864eef5f9010af178034cb9b44
+
+See LICENSE.txt for license information.
+```
+
+## Enjoy!
+
+That’s all folks! In this tutorial, we’ve shown you how to use cloud-init to automatically setup Ubuntu on WSL 2 with minimal touch.
+
+That workflow can be used to ensure a baseline for your next project that rely on Ubuntu WSL, ready for work.
+
+We hope you enjoy using Ubuntu inside WSL!
+
+### Further Reading
+
+To know more about cloud-init support for WSL checkout the [WSL Datasource reference in cloud-int docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
+To learn more about cloud-init in general visit [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -4,6 +4,8 @@
 Cloud-init is an industry-standard multi-distribution method for cross-platform cloud instance initialisation.
 Ubuntu WSL users can now leverage it to perform an automatic setup to get a working instance with minimal touch.
 
+> See more:  [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
+
 ```{note}
 **Coming soon*:
 
@@ -62,6 +64,9 @@ Save it and close it.
 > That example will create a user named `jdoe` and set it as default via `/etc/wsl.conf`, install the packages
 > `ginac-tools` and `octave` and install `vcpkg` from the git repository, since there is no deb or snap of that
 > application (hence the reason for being included in this tutorial - it requires an unusual setup).
+
+
+> See more: [WSL data source reference](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
 
 ## Register a new Ubuntu-Preview instance
 
@@ -191,9 +196,4 @@ That’s all folks! In this tutorial, we’ve shown you how to use cloud-init to
 This workflow will guarantee a solid foundation for your next Ubuntu WSL project.
 
 We hope you enjoy using Ubuntu inside WSL!
-
-### Further Reading
-
-To know more about cloud-init support for WSL check out the [WSL data source reference in cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
-To learn more about cloud-init in general visit [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
 

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -55,7 +55,7 @@ runcmd:
 
 Save it and close it.
 
-> That example will create a user named `u` and set it as default via `/etc/wsl.conf`, install the packages
+> That example will create a user named `jdoe` and set it as default via `/etc/wsl.conf`, install the packages
 > `ginac-tools` and `octave` and install `vcpkg` from the git repository, since there is no deb or snap of that
 > application (hence the reason for being included in this tutorial - it requires an unusual setup).
 
@@ -115,29 +115,29 @@ Welcome to Ubuntu Noble Numbat (development branch) (GNU/Linux 5.15.137.3-micros
 
 This message is shown once a day. To disable it please create the
 /home/cn/.hushlogin file.
-u@mib:~$
+jdoe@mib:~$
 ```
 
 Once logged in the new distro instance's shell, verify that:
 
-1. The default user matches what was configured in the user data file (in our case `u`).
+1. The default user matches what was configured in the user data file (in our case `jdoe`).
 
 ```sh
-u@mib:~$ whoami
-u
+jdoe@mib:~$ whoami
+jdoe
 ```
 
 2. The supplied cloud-config user data was approved by cloud-init validation.
 
 ```sh
-u@mib:~$ sudo cloud-init schema --system
+jdoe@mib:~$ sudo cloud-init schema --system
 Valid schema user-data
 ```
 
 3. The locale is set
 
 ```sh
-u@mib:~$ locale
+jdoe@mib:~$ locale
 LANG=pt_BR
 LANGUAGE=
 LC_CTYPE="pt_BR"
@@ -159,7 +159,7 @@ LC_ALL=
 4. The packages were installed and the commands they provide are available
 
 ```sh
-u@mib:~$ apt list --installed | egrep 'ginac|octave'
+jdoe@mib:~$ apt list --installed | egrep 'ginac|octave'
 
 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
 
@@ -174,7 +174,7 @@ octave/noble,now 8.4.0-1 amd64 [installed]
    documentation (there is no deb or snap available for that program).
 
 ```sh
-u@mib:~$ /opt/vcpkg/vcpkg version
+jdoe@mib:~$ /opt/vcpkg/vcpkg version
 vcpkg package management program version 2024-01-11-710a3116bbd615864eef5f9010af178034cb9b44
 
 See LICENSE.txt for license information.

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -21,9 +21,9 @@ the latest LTS application as well.
 
 Locate your Windows user home directory. It typically is `C:\Users\<YOUR_USER_NAME>`.
 
-> You can be sure about that path by running `echo $env:USERPROFILE` in powershell.
+> You can be sure about that path by running `echo $env:USERPROFILE` in PowerShell.
 
-Inside your Windows user home directory, create a new folder named `.cloud-init` (notice the `.` alla Linux
+Inside your Windows user home directory, create a new folder named `.cloud-init` (notice the `.` à la Linux
 configuration directories), and inside it create a new empty file named `Ubuntu-Preview.user-data`. That file name must
 match the name of the distro instance that will create in the next step.
 
@@ -61,7 +61,7 @@ Save it and close it.
 
 ## Register a new Ubuntu-Preview instance
 
-In Powershell, run:
+In PowerShell, run:
 
 ```powershell
 ubuntupreview.exe install --root
@@ -73,7 +73,7 @@ We skip the user creation, since we expect cloud-init to do it.
 
 ## Check that cloud-init is running
 
-In Powershell again run:
+In PowerShell again run:
 
 
 ```powershell
@@ -188,5 +188,5 @@ We hope you enjoy using Ubuntu inside WSL!
 
 ### Further Reading
 
-To know more about cloud-init support for WSL checkout the [WSL Datasource reference in cloud-int docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
+To know more about cloud-init support for WSL checkout the [WSL data source reference in cloud-int docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
 To learn more about cloud-init in general visit [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -10,4 +10,5 @@ interop
 dotnet-systemd
 gpu-cuda
 data-science-and-engineering
+cloud-init
 ```


### PR DESCRIPTION
This PR adds a tutorial for auto setup an UbuntuPreview instance with cloud-init.

It assumes things that are not yet true, so we should not merge it right away:

1. WSL datasource in cloud-init (and its reference documentation) is merged. Not yet, see PR https://github.com/canonical/cloud-init/pull/4786
2. UbuntuPreview app comes with cloud-init by default - not yet seeded
3. Subiquty is removed - also not yet.

Once allfacts above are true, this tutorial will be valid.

Yet, assuming one can prepare an Ubuntu WSL image (doesn't have to be Noble BTW) with cloud-init seeded and modified to add the WSL datasource above mentioned, the subsequent steps are valid and can be followed to setup an instance with minimal touch.

I'm doing exactly that all the time for a few days for testing (and because I managed to break my main WSL instance :) )

Closes UDENG-1995 .