### PR TITLE
maint: disable automated build

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -18,8 +18,8 @@ on:
         description: 'Should we upload the appxbundle to the store'
         required: true
         default: 'yes'
-  schedule:
-    - cron: '0 10 * * *'
+  #schedule:
+  #  - cron: '0 10 * * *'
 concurrency: build-wsl
 
 env:


### PR DESCRIPTION
We are going to manually build special images of WSL, disable automated builds to be in control of what and when we deliver. This will be reenable gradually post 24.04 LTS release.