### PR TITLE
fix(actions/wsl-bash): Bash-WSL action: write temp script in the Windows filesystem

### DIFF
--- a/.github/actions/wsl-bash/action.yaml
+++ b/.github/actions/wsl-bash/action.yaml
@@ -21,28 +21,40 @@ runs:
       shell: powershell
       env:
         exec: ${{ inputs.exec }}
-        scriptDir: /tmp/github_${{github.run_number}}_${{github.run_attempt}}
+        scriptDir: C:\Temp\Ubuntu-WSL-actions\${{github.run_number}}_${{github.run_attempt}}
       run: |
         Write-Output '::group::Storage of script into WSL'
-        $dirWindows="\\wsl.localhost\${{ inputs.distro }}${{ env.scriptDir }}"
-
-        New-Item -Force -Path "${dirWindows}" -ItemType Directory | Out-Null
-        New-Item -Force -Path "${dirWindows}\script.sh" -ItemType File | Out-Null
+        
+        New-Item -Force -Path "${{ env.scriptDir }}" -ItemType Directory | Out-Null
 
         # The following function is used because:
         # - It does not write the BOM (0xff 0xfe at file start)
         # - It does not write \r at line ends
-        [IO.File]::WriteAllText( "${dirWindows}\script.sh" , "${env:exec}")
+        # - Overwrites a pre-existing file if there was one
+        [IO.File]::WriteAllText( "${{ env.scriptDir }}\script.sh" , "${env:exec}")
         $exit=$?
 
         Write-Output '::endgroup::'
         if ( "${exit}" -eq "$False" ) { Exit(1) }
-
     - name: Run linux script
       shell: powershell
       env:
-        scriptDir: /tmp/github_${{github.run_number}}_${{github.run_attempt}}
+        scriptDir: C:\Temp\Ubuntu-WSL-actions\${{github.run_number}}_${{github.run_attempt}}
         WSL_UTF8: "1"
       run: |
-          wsl.exe -d ${{ inputs.distro }} --cd '${{ inputs.working-dir }}' -- bash "${{ env.scriptDir }}/script.sh"
-          if ( ! $? ) { Exit(1) }
+        # Run script
+
+        # We use this --cd trick otherwise bash gets confused with the \ path separators
+        $linuxPath = wsl.exe -d "${{ inputs.distro }}" --cd "${{ env.scriptDir }}" -- wslpath -ua .
+
+        wsl.exe -d ${{ inputs.distro }} --cd '${{ inputs.working-dir }}' -- bash "$linuxPath/script.sh"
+        if ( ! $? ) { Exit(1) }
+    - name: Cleanup
+      if: always()
+      shell: powershell
+      env:
+        scriptDir: C:\Temp\Ubuntu-WSL-actions\${{github.run_number}}_${{github.run_attempt}}
+      run: |
+        if(Test-Path -Path "${{ env.scriptDir }}") {
+          Remove-Item -Recurse -Force -Path "${{ env.scriptDir }}"
+        }


### PR DESCRIPTION
The /tmp directory is, as expected, temporary. This is broken with regular WSL (files persist), which is something we were using in this action.

However, enabling systemd makes it so the contents of /tmp  are no longer persistent.

---

This is being tested here:
https://github.com/ubuntu/wsl-actions-example/pull/6 (cloud-init workflow)
