### PR TITLE
Download rootfses specific to appid livebuild rootfs

### DIFF
--- a/build-remote
+++ b/build-remote
@@ -204,7 +204,7 @@ def main():
                 shouldExit = True
             arch = os.path.basename(build.distro_arch_series_link)
             for f in build.getFileUrls():
-                if not f.endswith(".rootfs.tar.gz"):
+                if not f.endswith(".%s.rootfs.tar.gz" % selected_appID.lower()):
                     continue
                 rootfses.append("%s::%s" % (f, arch))
         if shouldExit:

--- a/build-remote
+++ b/build-remote
@@ -204,7 +204,7 @@ def main():
                 shouldExit = True
             arch = os.path.basename(build.distro_arch_series_link)
             for f in build.getFileUrls():
-                if not f.endswith(".%s.rootfs.tar.gz" % selected_appID.lower()):
+                if not f.endswith(f".{selected_appID.lower()}.rootfs.tar.gz"):
                     continue
                 rootfses.append("%s::%s" % (f, arch))
         if shouldExit:

--- a/wsl-builder/common/releasesinfo.go
+++ b/wsl-builder/common/releasesinfo.go
@@ -244,5 +244,6 @@ func (w *WslReleaseInfo) RootfsURL(arch string) string {
 		imageBaseName = fmt.Sprintf("ubuntu-%s-wsl", w.CodeName)
 	}
 
-	return fmt.Sprintf("https://cloud-images.ubuntu.com/%s/current/%s-%s-wsl.rootfs.tar.gz", codeNameSubUri, imageBaseName, arch)
+	return fmt.Sprintf("https://cloud-images.ubuntu.com/%s/current/%s-%s-wsl.%s.rootfs.tar.gz",
+		codeNameSubUri, imageBaseName, arch, strings.ToLower(w.AppID))
 }


### PR DESCRIPTION
We now have per appid livebuild produced rootfs. Adjust the paths to download them generically.