### PR TITLE
maint: allow download from cloud image and reenable automated build

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -18,8 +18,8 @@ on:
         description: 'Should we upload the appxbundle to the store'
         required: true
         default: 'yes'
-  #schedule:
-  #  - cron: '0 10 * * *'
+  schedule:
+    - cron: '0 10 * * *'
 
 env:
   goversion: '1.21.4'


### PR DESCRIPTION
* Adapt RootfsURL to current cloud-images
   Adapt it to our current cloud-images copy work, which strips the "ubuntu" prefix and replace it with "wsl" when the appid is empty.
   Support older versions too.
* Reenable automated build cron job

UDENG-2573