### PR TITLE
Update cloud-init.md

### DIFF
--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -55,7 +55,8 @@ write_files:
 packages: [ginac-tools, octave]
 
 runcmd:
-   - git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
+   - sudo git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
+   - sudo apt-get install zip curl -y
    - /opt/vcpkg/bootstrap-vcpkg.sh
 ```
 


### PR DESCRIPTION
Neither Ubuntu 24.04 nor Ubuntu-Preview comes with zip, tar, curl or unzip installed.

This guide is for Ubuntu. The script is not in sync with the guide.

Either merge this to guide or add note in the guide that the commands wont run from cloud-init