### PR TITLE
docs: update cloud-init tutorial to 24.04

### DIFF
--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -6,12 +6,6 @@ Ubuntu WSL users can now leverage it to perform an automatic setup to get a work
 
 > See more:  [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
 
-```{note}
-**Coming soon*:
-
-That feature is currently in development and will be available soon on the UbuntuPreview app first, then gradually released for the latest LTS applications.
-```
-
 ## What you will learn:
 
 - How to write cloud-config user data to a specific WSL instance.
@@ -21,7 +15,7 @@ That feature is currently in development and will be available soon on the Ubunt
 ## What you will need:
 
 - Windows 11 with WSL 2 already enabled
-- The latest UbuntuPreview application from Microsoft Store.
+- The latest Ubuntu-24.04 application from Microsoft Store.
 
 ## Write the cloud-config file
 
@@ -30,7 +24,7 @@ Locate your Windows user home directory. It typically is `C:\Users\<YOUR_USER_NA
 > You can be sure about that path by running `echo $env:USERPROFILE` in PowerShell.
 
 Inside your Windows user home directory, create a new folder named `.cloud-init` (notice the `.` à la Linux
-configuration directories), and inside the new directory, create an empty file named `Ubuntu-Preview.user-data`. That file name must
+configuration directories), and inside the new directory, create an empty file named `Ubuntu-24.04.user-data`. That file name must
 match the name of the distro instance that will be created in the next step.
 
 Open that file with your text editor of choice (`notepad.exe` is just fine) and paste in the following contents:
@@ -57,7 +51,7 @@ packages: [ginac-tools, octave]
 runcmd:
    - sudo git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
    - sudo apt-get install zip curl -y
-   - /opt/vcpkg/bootstrap-vcpkg.sh
+   - sudo /opt/vcpkg/bootstrap-vcpkg.sh
 ```
 
 Save it and close it.
@@ -69,18 +63,18 @@ Save it and close it.
 
 > See more: [WSL data source reference](https://cloudinit.readthedocs.io/en/latest/reference/datasources/wsl.html).
 
-## Register a new Ubuntu-Preview instance
+## Register a new Ubuntu-24.04 instance
 
 In PowerShell, run:
 
 ```powershell
-ubuntupreview.exe install --root
+ubuntu2404.exe install --root
 ```
 
 We skip the user creation since we expect cloud-init to do it.
 
-> If you want to be sure that there is now an Ubuntu-Preview instance, run `wsl -l -v`.
-> Notice that the application is named `UbuntuPreview` but the WSL instance created is named `Ubuntu-Preview`.
+> If you want to be sure that there is now an Ubuntu-24.04 instance, run `wsl -l -v`.
+> Notice that the application is named `ubuntu2404` but the WSL instance created is named `Ubuntu-24.04`.
 > See more about that naming convention in [our reference documentation](naming).
 
 ## Check that cloud-init is running
@@ -89,7 +83,7 @@ In PowerShell again run:
 
 
 ```powershell
-ubuntupreview run cloud-init status --wait
+ubuntu2404.exe run cloud-init status --wait
 ```
 
 That will wait until cloud-init completes configuring the new instance we just created. When done, you should see an
@@ -110,21 +104,28 @@ Restart the distro just to make sure the changes in `/etc/wsl.conf` made by clou
 below:
 
 ```powershell
-> wsl -t Ubuntu-Preview
+> wsl -t Ubuntu-24.04
 The operation completed successfully.
-> ubuntupreview
+> ubuntu2404.exe
 To run a command as administrator (user "root"), use "sudo <command>".
 See "man sudo_root" for details.
 
-Welcome to Ubuntu Noble Numbat (development branch) (GNU/Linux 5.15.137.3-microsoft-standard-WSL2 x86_64)
+Welcome to Ubuntu 24.04 LTS (GNU/Linux 5.15.146.1-microsoft-standard-WSL2 x86_64)
 
  * Documentation:  https://help.ubuntu.com
  * Management:     https://landscape.canonical.com
  * Support:        https://ubuntu.com/pro
 
+ System information as of mar. 07 mai 2024 16:26:17 CEST
+
+  System load:  0.23                Processes:             63
+  Usage of /:   0.2% of 1006.85GB   Users logged in:       0
+  Memory usage: 9%                  IPv4 address for eth0: 172.18.8.70
+  Swap usage:   0%
+
 
 This message is shown once a day. To disable it please create the
-/home/cn/.hushlogin file.
+/home/u/.hushlogin file.
 jdoe@mib:~$
 ```
 


### PR DESCRIPTION
Remove all the references to Ubuntu Preview now that Ubuntu 24.04 has been released.
Also fixed a small sudo missing from runcmd.