### PR TITLE
Rework dotnet systemd tutorial

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,5 +1,6 @@
 AppxPackage
 awk
+backports
 BotFramework
 chatbot
 codebase

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -103,7 +103,7 @@ First, get the IP address of your machine by running `ipconfig` in a PowerShell 
 
 ![|624x357](assets/dotnet-systemd/ipconfig.png)
 
-Then select the setting icon in the corner of the Bot Framework Emulator and enter your IP under ‘localhost override'.
+Then select the setting icon in the bottom-left corner of the Bot Framework Emulator and enter your IP under ‘localhost override'.
 
 ![|624x411](assets/dotnet-systemd/emulator-settings.png)
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -128,11 +128,9 @@ Then install the .Net systemd extension with:
 
 > `sudo dotnet add package Microsoft.Extensions.Hosting.Systemd`
 
-Now we need to open our ‘echoes’ project in VS Code by running:
+We can open our project with VS Code by running this command in the 'echoes' directory:
 
 > `code .`
-
-From the ‘echoes’ directory.
 
 Navigate to ‘Program.cs’ and insert `.UseSystemd()` as a new line in the location shown in the screenshot.
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -30,7 +30,20 @@ Make sure to restart your distribution after you have made this change.
 
 ## Install .Net
 
-.Net has recently [been added to the Ubuntu repositories](https://ubuntu.com/blog/install-dotnet-on-ubuntu). This means you can now quickly install a bundle with both the SDK and runtime with a single command:
+```{note}
+In Ubuntu 24.04 LTS .Net 8 is available [in the Ubuntu repositories](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
+To install this version of .Net for your project you only need to run:
+
+> `sudo apt install dotnet8`
+
+In this tutorial we will be using .Net 6, which requires adding the backports archive.
+```
+
+To install .Net 6 on Ubuntu 24.04 LTS we will first add the backports archive for .Net with the following command:
+
+> `sudo add-apt-repository ppa:dotnet/backports`
+
+Now we can install a bundle with both the SDK and runtime for .Net 6:
 
 > `sudo apt install dotnet6`
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -143,14 +143,14 @@ Next we need to create a service file for your bot using your favourite editor, 
 
 > `sudo nano /etc/systemd/system/echoes.service`
 
-Then paste the below taking care to change the path of `WorkingDirectory` to the location of your project folder.
+Then paste the snippet below taking care to replace `<your-username>` with your username.
 
 ```
 [Unit]
 Description=The first ever WSL Ubuntu systemd .NET ChatBot Service
 
 [Service]
-WorkingDirectory=/home/local-optimum/demos/mybot/echoes
+WorkingDirectory=/home/<your-username>/mybot/echoes
 Environment=DOTNET_CLI_HOME=/temp
 ExecStart=dotnet run
 SyslogIdentifier=echoes

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -10,16 +10,17 @@ We will create the bot using .NET on Ubuntu WSL and it will be accessible from t
 ## Requirements
 
 * A PC running Windows 11
-* The latest version of the WSL Windows Store application
-* Ubuntu 22.04 LTS, Ubuntu 24.04 LTS or Ubuntu Preview installed
+* The latest version of WSL from the Microsoft Store
+* Ubuntu, Ubuntu 22.04 LTS or Ubuntu 24.04 LTS
+* Visual Studio Code (recommended)
 
-Systemd support is a new feature of WSL and only available on WSL version 0.67.6 or higher.
+Systemd support is required for this tutorial and is available on WSL version 0.67.6 or higher.
 
 In your PowerShell terminal, you can check your current WSL version by running:
 
 > `wsl --version`
 
-Inside WSL, you can check that systemd is enabled on your Ubuntu distribution by running:
+Inside WSL, you can check that systemd is enabled on your Ubuntu distribution with the following command:
 
 > `cat /etc/wsl.conf`
 
@@ -202,12 +203,13 @@ You now have a simple Echo Bot running as a systemd service on WSL that you can 
 
 If you would like to expand on this example try reviewing some of the more advanced [Bot Framework samples](https://github.com/Microsoft/BotBuilder-Samples/blob/main/README.md) on the Microsoft GitHub.
 
-To read more about how Ubuntu supports .NET developers, making it easier than ever to build multi-platform services and applications, read our [recent announcement](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
+To read more about how Ubuntu supports .NET developers, making it easier than ever to build multi-platform services and applications, read our [previous announcement](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
 
 ### Further Reading
 
 * [.NET on Ubuntu](https://ubuntu.com/blog/install-dotnet-on-ubuntu)
 * [Bot Framework samples](https://github.com/Microsoft/BotBuilder-Samples/blob/main/README.md)
+* [Working with Visual Studio Code on Ubuntu WSL](vscode.md)
 * [Enabling GPU acceleration on Ubuntu on WSL2 with the NVIDIA CUDA Platform](gpu-cuda.md)
 * [Windows and Ubuntu interoperability on WSL2](interop.md)
 * [Microsoft WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/)

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -34,21 +34,17 @@ Make sure to restart your distribution after you have made this change.
 
 ## Install .NET
 
+To install .NET 6 on Ubuntu 24.04 LTS we first need to add the backports archive for .NET.
+
 ```{note}
-In Ubuntu 24.04 LTS .NET 8 is available [in the Ubuntu repositories](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
-To install this version of .NET for your project you only need to run:
-
-> `sudo apt install dotnet8`
-
-In this tutorial we will be using .NET 6, which requires adding the backports archive for older .NET versions on Ubuntu 24.04 LTS.
-If you are using Ubuntu 22.04 LTS you can skip this step.
+If you are using Ubuntu 22.04 LTS you can skip the command for installing backports and install the .NET 6 bundle directly. 
 ```
 
-To install .NET 6 on Ubuntu 24.04 LTS we will first add the backports archive for .NET with the following command:
+Run this command to install backports, which includes .NET 6:
 
 > `sudo add-apt-repository ppa:dotnet/backports`
 
-Now we can install a bundle with both the SDK and runtime for .NET 6:
+To install a bundle with both the SDK and runtime for .NET 6 run:
 
 > `sudo apt install dotnet6`
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -117,7 +117,9 @@ http://localhost:3978/api/messages
 
 ![|624x411](assets/dotnet-systemd/open-a-bot.png)
 
-And click ‘Connect’ to connect to your Echo Bot running in WSL and start chatting!![|624x411](assets/dotnet-systemd/start-chatting.png)
+And click ‘Connect’ to connect to your Echo Bot running in WSL and start chatting!
+
+![|624x411](assets/dotnet-systemd/start-chatting.png)
 
 Congratulations, your Echo Chat Bot App is running on Ubuntu WSL as an App. Now it is time to make it run as a service.
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -1,9 +1,11 @@
 # Run a .Net Echo Bot as a systemd service on Ubuntu WSL
 *Authored by Oliver Smith ([oliver.smith@canonical.com](mailto:oliver.smith@canonical.com))*
 
-.Net is an open-source development platform from Microsoft that enables developers to build multi-platform applications from a single codebase.
+In this tutorial we will take advantage of WSL's systemd support to run a chatbot as a systemd service for easier deployment.
 
-In this tutorial we demonstrate how easy it is to start working with .Net on Ubuntu WSL by creating a simple chatbot accessible from your Windows host. We also take advantage of WSL's new systemd support to run our bot as a systemd service for easier deployment.
+We will create the bot using .Net on Ubuntu WSL and it will be accessible from the Windows host.
+
+.Net is an open-source development platform from Microsoft that enables developers to build multi-platform applications from a single codebase.
 
 ## Requirements
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -178,6 +178,7 @@ You should get the following output:
 Now start your service and then check its status again.
 
 > `sudo systemctl start echoes.service`
+
 > `sudo systemctl status echoes.service`
 
 If everything has been configured correctly you should get an output similar to the below.

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -1,11 +1,11 @@
-# Run a .Net Echo Bot as a systemd service on Ubuntu WSL
+# Run a .NET Echo Bot as a systemd service on Ubuntu WSL
 *Authored by Oliver Smith ([oliver.smith@canonical.com](mailto:oliver.smith@canonical.com))*
 
 In this tutorial we will take advantage of WSL's systemd support to run a chatbot as a systemd service for easier deployment.
 
-We will create the bot using .Net on Ubuntu WSL and it will be accessible from the Windows host.
+We will create the bot using .NET on Ubuntu WSL and it will be accessible from the Windows host.
 
-.Net is an open-source development platform from Microsoft that enables developers to build multi-platform applications from a single codebase.
+.NET is an open-source development platform from Microsoft that enables developers to build multi-platform applications from a single codebase.
 
 ## Requirements
 
@@ -19,7 +19,10 @@ In your PowerShell terminal, you can check your current WSL version by running:
 
 > `wsl --version`
 
-Inside WSL, you can check that systemd is enabled on your Ubuntu distribution by running `cat /etc/wsl.conf`.
+Inside WSL, you can check that systemd is enabled on your Ubuntu distribution by running:
+
+> `cat /etc/wsl.conf`
+
 If enabled the output will be:
 
 > `[boot]`  
@@ -28,23 +31,23 @@ If enabled the output will be:
 If set to `false` open the file with `sudo nano /etc/wsl.conf`, set to `true` and save.
 Make sure to restart your distribution after you have made this change.
 
-## Install .Net
+## Install .NET
 
 ```{note}
-In Ubuntu 24.04 LTS .Net 8 is available [in the Ubuntu repositories](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
-To install this version of .Net for your project you only need to run:
+In Ubuntu 24.04 LTS .NET 8 is available [in the Ubuntu repositories](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
+To install this version of .NET for your project you only need to run:
 
 > `sudo apt install dotnet8`
 
-In this tutorial we will be using .Net 6, which requires adding the backports archive for older .Net versions on Ubuntu 24.04 LTS.
+In this tutorial we will be using .NET 6, which requires adding the backports archive for older .NET versions on Ubuntu 24.04 LTS.
 If you are using Ubuntu 22.04 LTS you can skip this step.
 ```
 
-To install .Net 6 on Ubuntu 24.04 LTS we will first add the backports archive for .Net with the following command:
+To install .NET 6 on Ubuntu 24.04 LTS we will first add the backports archive for .NET with the following command:
 
 > `sudo add-apt-repository ppa:dotnet/backports`
 
-Now we can install a bundle with both the SDK and runtime for .Net 6:
+Now we can install a bundle with both the SDK and runtime for .NET 6:
 
 > `sudo apt install dotnet6`
 
@@ -127,7 +130,7 @@ Congratulations, your Echo Chat Bot App is running on Ubuntu WSL as an App. Now 
 
 Return to your running WSL distro and end the app with `Ctrl+C`.
 
-Then install the .Net systemd extension with:
+Then install the .NET systemd extension with:
 
 > `sudo dotnet add package Microsoft.Extensions.Hosting.Systemd`
 
@@ -199,11 +202,11 @@ You now have a simple Echo Bot running as a systemd service on WSL that you can 
 
 If you would like to expand on this example try reviewing some of the more advanced [Bot Framework samples](https://github.com/Microsoft/BotBuilder-Samples/blob/main/README.md) on the Microsoft GitHub.
 
-To read more about how Ubuntu supports .Net developers, making it easier than ever to build multi-platform services and applications, read our [recent announcement](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
+To read more about how Ubuntu supports .NET developers, making it easier than ever to build multi-platform services and applications, read our [recent announcement](https://ubuntu.com/blog/install-dotnet-on-ubuntu).
 
 ### Further Reading
 
-* [.Net on Ubuntu](https://ubuntu.com/blog/install-dotnet-on-ubuntu)
+* [.NET on Ubuntu](https://ubuntu.com/blog/install-dotnet-on-ubuntu)
 * [Bot Framework samples](https://github.com/Microsoft/BotBuilder-Samples/blob/main/README.md)
 * [Enabling GPU acceleration on Ubuntu on WSL2 with the NVIDIA CUDA Platform](gpu-cuda.md)
 * [Windows and Ubuntu interoperability on WSL2](interop.md)

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -61,11 +61,11 @@ Once inside we can install the EchoBot C# template by running:
 
 > `dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot`
 
-We can verify the template has been installed correctly by running:
+We can then verify the template has been installed correctly:
 
 > `dotnet new --list`
 
-And looking for the `Bot Framework Echo Bot` template in the list.
+You should be able to find the `Bot Framework Echo Bot` template in the list.
 
 ![|624x153](assets/dotnet-systemd/templates.png)
 
@@ -73,11 +73,11 @@ Create a new Echo Bot project, with `echoes` as the name for our bot, using the 
 
 > `dotnet new echobot -n echoes`
 
-Once this has completed we can navigate into the new directory that has been created.
+After this has completed we can navigate into the new directory that has been created.
 
 > `cd ~/mybot/echoes`
 
-Once inside, the project should be ready to run. Test it with:
+From inside this directory the project should be ready to run. Test it with:
 
 > `sudo dotnet run`
 
@@ -139,7 +139,7 @@ Navigate to ‘Program.cs’ and insert `.UseSystemd()` as a new line in the loc
 
 ![|624x381](assets/dotnet-systemd/program-cs.png)
 
-Save and close the project in VS code and return to your WSL terminal.
+Save and close the project in VS Code and return to your WSL terminal.
 
 Next we need to create a service file for your bot using your favourite editor, for example.
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -13,7 +13,7 @@ We will create the bot using .Net on Ubuntu WSL and it will be accessible from t
 * The latest version of the WSL Windows Store application
 * Ubuntu, Ubuntu 22.04 LTS or Ubuntu Preview installed
 
-Systemd support is a new feature of WSL and only available on WSL version XX or higher.
+Systemd support is a new feature of WSL and only available on WSL version 0.67.6 or higher.
 
 You can check your current WSL version by running:
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -107,7 +107,7 @@ Then select the setting icon in the bottom-left corner of the Bot Framework Emul
 
 ![|624x411](assets/dotnet-systemd/emulator-settings.png)
 
-Click save and navigate back to the Welcome tab.
+Click 'Save' and navigate back to the Welcome tab.
 
 Click ‘Open Bot’ and under ‘Bot URL’ input:
 ```

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -69,7 +69,7 @@ And looking for the `Bot Framework Echo Bot` template in the list.
 
 ![|624x153](assets/dotnet-systemd/templates.png)
 
-Create a new Echo Bot project using the following command. We use `echoes` as the name for our bot.
+Create a new Echo Bot project, with `echoes` as the name for our bot, using the following command:
 
 > `dotnet new echobot -n echoes`
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -110,7 +110,8 @@ Then select the setting icon in the bottom-left corner of the Bot Framework Emul
 Click 'Save' and navigate back to the Welcome tab.
 
 Click ‘Open Bot’ and under ‘Bot URL’ input:
-```
+
+```text
 http://localhost:3978/api/messages
 ```
 
@@ -144,7 +145,7 @@ Next we need to create a service file for your bot using your favourite editor, 
 
 Then paste the snippet below taking care to replace `<your-username>` with your username.
 
-```
+```text
 [Unit]
 Description=The first ever WSL Ubuntu systemd .NET ChatBot Service
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -17,7 +17,7 @@ Systemd support is a new feature of WSL and only available on WSL version 0.67.6
 
 You can check your current WSL version by running:
 
-> `> wsl --version`
+> `wsl --version`
 
 In your PowerShell terminal.
 
@@ -32,29 +32,29 @@ Make sure to restart your distribution after you have made this change.
 
 .Net has recently [been added to the Ubuntu repositories](https://ubuntu.com/blog/install-dotnet-on-ubuntu). This means you can now quickly install a bundle with both the SDK and runtime with a single command:
 
->`$ sudo apt install dotnet6`
+> `sudo apt install dotnet6`
 
 Run `dotnet --version` to confirm that the package was installed successfully.
 
 It is recommended to create a new directory for this project, do so now and navigate to it before proceeding:
 
->`$ sudo mkdir ~/mybot`  
->`$ cd mybot`
+> `sudo mkdir ~/mybot`  
+> `cd mybot`
 
 ## Install and run the Bot Framework EchoBot template
 
 Create a new directory for the project and navigate to it before proceeding:
 
->`$ sudo mkdir ~/mybot`  
->`$ cd mybot`
+> `sudo mkdir ~/mybot`  
+> `cd mybot`
 
 Once inside we can install the EchoBot C# template by running:
 
->`$ dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot`
+> `dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot`
 
 We can verify the template has been installed correctly by running:
 
->`$ dotnet new --list`
+> `dotnet new --list`
 
 And looking for the `Bot Framework Echo Bot` template in the list.
 
@@ -62,15 +62,15 @@ And looking for the `Bot Framework Echo Bot` template in the list.
 
 Create a new Echo Bot project using the following command. We use `echoes` as the name for our bot.
 
->`$ dotnet new echobot -n echoes`
+> `dotnet new echobot -n echoes`
 
 Once this has completed we can navigate into the new directory that has been created.
 
->`$ cd ~/mybot/echoes`
+> `cd ~/mybot/echoes`
 
 Once inside, the project should be ready to run. Test it with:
 
->`$ sudo dotnet run`
+> `sudo dotnet run`
 
 If everything was set up correctly you should see a similar output to the one below:
 
@@ -117,11 +117,11 @@ Return to your running WSL distro and end the app with `Ctrl+C`.
 
 Then install the .Net systemd extension with:
 
->`$ sudo dotnet add package Microsoft.Extensions.Hosting.Systemd`
+> `sudo dotnet add package Microsoft.Extensions.Hosting.Systemd`
 
 Now we need to open our ‘echoes’ project in VS Code by running:
 
->`$ code .`
+> `code .`
 
 From the ‘echoes’ directory.
 
@@ -133,7 +133,7 @@ Save and close the project in VS code and return to your WSL terminal.
 
 Next we need to create a service file for your bot using your favourite editor, for example.
 
->`$ sudo nano /etc/systemd/system/echoes.service`
+> `sudo nano /etc/systemd/system/echoes.service`
 
 Then paste the below taking care to change the path of `WorkingDirectory` to the location of your project folder.
 
@@ -155,11 +155,11 @@ WantedBy=multi-user.target
 
 Save your file and reload your services with:
 
->`$ sudo systemctl daemon-reload`
+> `sudo systemctl daemon-reload`
 
 To reload the services. You can check if your service is ready by running:
 
->`$ systemctl status echoes.service`
+> `systemctl status echoes.service`
 
 You should get the following output:
 
@@ -167,8 +167,8 @@ You should get the following output:
 
 Now start your service and then check its status again.
 
->`$ sudo systemctl start echoes.service`
->`$ sudo systemctl status echoes.service`
+> `sudo systemctl start echoes.service`
+> `sudo systemctl status echoes.service`
 
 If everything has been configured correctly you should get an output similar to the below.
 
@@ -180,7 +180,7 @@ Return to your Windows host and reconnect to your Bot Emulator using the same in
 
 You can stop your bot from running at any time with the command:
 
->`$ sudo systemctl stop echoes.service`
+> `sudo systemctl stop echoes.service`
 
 ## Tutorial complete!
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -11,7 +11,7 @@ We will create the bot using .Net on Ubuntu WSL and it will be accessible from t
 
 * A PC running Windows 11
 * The latest version of the WSL Windows Store application
-* Ubuntu, Ubuntu 22.04 LTS or Ubuntu Preview installed
+* Ubuntu 24.04 LTS or Ubuntu Preview installed
 
 Systemd support is a new feature of WSL and only available on WSL version 0.67.6 or higher.
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -49,11 +49,6 @@ Now we can install a bundle with both the SDK and runtime for .Net 6:
 
 Run `dotnet --version` to confirm that the package was installed successfully.
 
-It is recommended to create a new directory for this project, do so now and navigate to it before proceeding:
-
-> `sudo mkdir ~/mybot`  
-> `cd mybot`
-
 ## Install and run the Bot Framework EchoBot template
 
 Create a new directory for the project and navigate to it before proceeding:

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -133,7 +133,7 @@ Now we need to open our ‘echoes’ project in VS Code by running:
 
 From the ‘echoes’ directory.
 
-Navigate to ‘Program.cs’ and insert `.UserSystemd()` as a new line in the location shown in the screenshot.
+Navigate to ‘Program.cs’ and insert `.UseSystemd()` as a new line in the location shown in the screenshot.
 
 ![|624x381](assets/dotnet-systemd/program-cs.png)
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -11,7 +11,7 @@ We will create the bot using .Net on Ubuntu WSL and it will be accessible from t
 
 * A PC running Windows 11
 * The latest version of the WSL Windows Store application
-* Ubuntu 24.04 LTS or Ubuntu Preview installed
+* Ubuntu 22.04 LTS, Ubuntu 24.04 LTS or Ubuntu Preview installed
 
 Systemd support is a new feature of WSL and only available on WSL version 0.67.6 or higher.
 
@@ -36,7 +36,8 @@ To install this version of .Net for your project you only need to run:
 
 > `sudo apt install dotnet8`
 
-In this tutorial we will be using .Net 6, which requires adding the backports archive.
+In this tutorial we will be using .Net 6, which requires adding the backports archive for older .Net versions on Ubuntu 24.04 LTS.
+If you are using Ubuntu 22.04 LTS you can skip this step.
 ```
 
 To install .Net 6 on Ubuntu 24.04 LTS we will first add the backports archive for .Net with the following command:

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -28,7 +28,7 @@ If enabled the output will be:
 > `[boot]`  
 > `systemd=true`
 
-If set to `false` open the file with `sudo nano /etc/wsl.conf`, set to `true` and save.
+If systemd is set to `false` then open the file with `sudo nano /etc/wsl.conf`, set it to `true` and save.
 Make sure to restart your distribution after you have made this change.
 
 ## Install .NET

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -53,7 +53,7 @@ Run `dotnet --version` to confirm that the package was installed successfully.
 
 Create a new directory for the project and navigate to it before proceeding:
 
-> `sudo mkdir ~/mybot`  
+> `mkdir ~/mybot`  
 > `cd mybot`
 
 Once inside we can install the EchoBot C# template by running:

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -15,17 +15,17 @@ We will create the bot using .Net on Ubuntu WSL and it will be accessible from t
 
 Systemd support is a new feature of WSL and only available on WSL version 0.67.6 or higher.
 
-You can check your current WSL version by running:
+In your PowerShell terminal, you can check your current WSL version by running:
 
 > `wsl --version`
 
-In your PowerShell terminal.
-
-To enable systemd on your Ubuntu distribution you need to add the following content to `/etc/wsl.conf`​:
+Inside WSL, you can check that systemd is enabled on your Ubuntu distribution by running `cat /etc/wsl.conf`.
+If enabled the output will be:
 
 > `[boot]`  
 > `systemd=true`
 
+If set to `false` open the file with `sudo nano /etc/wsl.conf`, set to `true` and save.
 Make sure to restart your distribution after you have made this change.
 
 ## Install .Net


### PR DESCRIPTION
The dotnet-systemd tutorial had some issues that could block a user from completing its steps.

Some of the major ones included:

- Using the latest LTS (24.04) .NET 6 could not be installed using the command indicated in the tutorial
- Instructions for setting paths in the config for the systemd service were not sufficiently clear and deviated slightly from the main text
- Distinct CLI commands were erroneously concatenated on a single line
- There was a typo in a method call that the user needed to insert in a file to run the systemd service successfully
- A placeholder referred to a minimum WSL version necessary to leverage systemd but no version was cited

In addition to these changes, a number of minor improvements were made,
primarily relating to clarification of text and removing duplication.

UDENG-2981