### PR TITLE
Rewrite homepage in standard form

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -19,7 +19,11 @@ executables
 filesystem
 filesystems
 GPG
+GUI
+GUIs
 init
+IDE
+IDEs
 js
 Jupyter
 localhost
@@ -29,6 +33,7 @@ Numbat
 OpenGL
 OpenID
 OpenVINO
+performant
 PowerShell
 rootfs
 Rootfs
@@ -40,6 +45,7 @@ subprocess
 systemd
 ubuntu
 UbuntuPreview
+UP4W
 vGPU
 VMs
 webserver

--- a/docs/explanations/index.md
+++ b/docs/explanations/index.md
@@ -1,0 +1,9 @@
+(explanations)=
+
+# Explanations
+
+```{toctree}
+:titlesonly:
+
+up4w
+```

--- a/docs/explanations/up4w.md
+++ b/docs/explanations/up4w.md
@@ -1,0 +1,10 @@
+# Ubuntu Pro for WSL
+
+Ubuntu Pro for WSL is an automation tool that runs on Windows hosts to
+manage Ubuntu WSL instances, providing them with compliance by attaching them
+to an [Ubuntu Pro subscription](https://ubuntu.com/pro) and enrolling them into
+[Landscape](https://ubuntu.com/landscape). 
+
+Documentation for UP4W can currently be found at the following link:
+
+[Ubuntu Pro for WSL Documentation](https://canonical-ubuntu-pro-for-wsl.readthedocs-hosted.com/en/latest/) 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,34 @@ Linux, Windows and the browser.
 
 ## In this documentation
 
+````{grid} 1 1 2 2
+
+```{grid-item-card} [Tutorials](tutorials/index)
+
+**Start here** with hands-on tutorials for new users to learn Ubuntu WSL
+```
+
+```{grid-item-card} [How-to guides](guides/index)
+
+**Follow step-by-step** instructions for key operations and common tasks for Ubuntu WSL
+```
+
+````
+
+````{grid} 1 1 2 2
+:reverse:
+
+```{grid-item-card} [Reference](reference/index)
+
+**Read technical descriptions** of important factual information relating to Ubuntu WSL
+```
+
+```{grid-item-card} [Explanations](explanations/index)
+
+**Read explanatory notes** on important concepts
+```
+
+````
 
 
 ```{toctree}
@@ -34,4 +62,5 @@ self
 tutorials/index
 guides/index
 reference/index
+explanations/index
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,8 @@ Linux-native graphical applications.
 Ubuntu WSL can be used to build projects in a performant Linux environment
 without the overhead of traditional virtual machine or dual-boot setups.
 Organisations that manage a Microsoft infrastructure can empower developers who
-prefer a Linux-based workflow. With Ubuntu Pro for WSL, large fleets of Ubuntu
-WSL machines can also be administered with ease and security.
+prefer a Linux-based workflow. With [Ubuntu Pro for WSL](explanations/up4w), large
+fleets of Ubuntu WSL machines can also be administered with ease and security.
 
 Ubuntu WSL is for the programmer who wants a fully-featured Linux development
 environment but must use a Windows device, the system administrator who

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,29 @@
 # Ubuntu WSL
 
-This documentation refers to the Ubuntu distribution for WSL.
+Benefit from the unrivalled developer experience of Ubuntu without leaving
+Windows.
 
-## Windows Subsystem for Linux
+Windows Subsystem for Linux (WSL) lets developers run a GNU/Linux environment
+on Windows. The Ubuntu distribution for WSL is tightly integrated with the
+Windows OS, supporting remote development from popular IDEs, cross-OS file
+management and seamless local testing of web applications. Ubuntu WSL provides
+a high-quality command line interface that is also suitable for launching
+Linux-native graphical applications.
 
-Windows Subsystem for Linux (WSL) lets developers run a GNU/Linux environment -- including most command-line tools, utilities, and applications -- directly on Windows, unmodified, without the overhead of a traditional virtual machine or dual-boot setup. It is a Microsoft product, developed, maintained and documented by Microsoft. You can find their documentation [here](https://learn.microsoft.com/en-us/windows/wsl/).
+Ubuntu WSL can be used to build projects in a performant Linux environment
+without the overhead of traditional virtual machine or dual-boot setups.
+Organisations that manage a Microsoft infrastructure can empower developers who
+prefer a Linux-based workflow. With Ubuntu Pro for WSL, large fleets of Ubuntu
+WSL machines can also be administered with ease and security.
 
-WSL can be installed from the Microsoft Store.
+Ubuntu WSL is for the programmer who wants a fully-featured Linux development
+environment but must use a Windows device, the system administrator who
+requires a secure way of supporting Linux on hundreds of Windows machines, and
+the cross-platform app developer who needs to create projects that work on
+Linux, Windows and the browser.
 
-## Ubuntu and WSL
+## In this documentation
 
-While Microsoft provides the virtual machine, the kernel, and a few more utilities; Ubuntu provides the distribution that runs on top of them. 
-We develop multiple flavours of Ubuntu for WSL, which you can read more about [here](reference/distributions.md). These flavours materialise as applications on the Microsoft Store.
 
 
 ```{toctree}


### PR DESCRIPTION
This PR rewrites the Ubuntu WSL docs homepage to achieve the following goals:

- Impose standard homepage structure for Canonical docs
- Increase focus on Ubuntu WSL rather than (Microsoft) WSL
- Highlight material that is covered elsewhere in the docs
- Include reference to Ubuntu Pro for WSL (UP4W) and a short explanatory note for UP4W in the docs

For reference, this aims to satisfy some of the following features of a homepage:

  1. A single sentence that says what the product is, succinctly and memorably
  2. A paragraph that describe what the product does.
  3. A third paragraph explaining what need the product meets.
  4. A paragraph that describes whom the product is useful for.
  5. A grid of links to relevant Diataxis sections with short descriptions
  
 Nick Veitch (Canonical) provided feedback on a draft version of the homepage.

 UDENG-3267
