### PR TITLE
docs: Improve code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,69 @@ Doing these checks locally is good practice. You are less likely to run into
 failed CI checks after your PR is submitted and the reviewer of your PR can
 more quickly focus on the contribution you have made.
 
+### Note on using code blocks
+
+In the Ubuntu WSL docs, code blocks are used to document:
+
+- Ubuntu terminal commands
+- PowerShell terminal commands
+- Terminal outputs
+- Code and config files
+
+We follow specific conventions when including code blocks so that they
+are readable and functional.
+
+#### Include prompts when documenting terminal commands
+
+It is common that Ubuntu and PowerShell terminal commands are included in the same page.
+We use prompts to ensure that the reader can distinguish between them.
+
+Here are some examples:
+
+- PowerShell prompt symbol: `>`
+- PowerShell prompt symbol with path: `C:\Users\myuser>`
+- PowerShell prompt symbol with path and PowerShell prefix: `PS C:\Users\myuser>`
+- Ubuntu prompt symbol: `$`
+- Ubuntu prompt symbol with user and host: `user@host:~$`
+
+Whether to include the path or user@host depends on whether it is useful in the context
+of the documentation being written.
+For example, if demonstrating the use of multiple WSL instances, including the user and host
+can make it easier to tell the instances apart.
+
+#### Exclude prompts from clipboard when using copy button
+
+The WSL docs automatically strips prompts when a user clicks the **copy** button on a code block.
+This is to prevent errors when a reader pastes the full content of a copy block into their terminal.
+
+We use a solution based on regular expressions, which identifies the first instance of a prompt symbol followed by whitespace on a particular line before removing the text before that symbol.
+
+There may be edge-cases when this creates problems; for example, you should include whitespace after a prompt but if you don't it may not be removed during copying.
+
+Always test code blocks when you include them to ensure that the correct text is captured during the copy operation.
+If you encounter a problem or edge-case contact the maintainers or file an issue.
+
+#### Separate input from output and remove copy button from output blocks
+
+Terminal commands are separated from the output that they generate.
+Explanatory text can be included to explain to the reader what is being presented:
+
+- "Run the following command..."
+- "This will generate the following output..."
+
+Copy buttons are not included in output blocks.
+This is to prevent an output being confused for an input.
+There are also few reasons why someone would copy an output from documentation.
+
+To exclude a copy button from an output block the `no-copy` CSS class must be included
+within the code block:
+
+```text
+:class: no-copy
+```
+
+Note: a code-block must be labelled with the [code-block directive](https://mystmd.org/guide/directives#directive-code) for this to work.
+
 ## Getting Help
 
 Join us in the [Ubuntu Community](https://discourse.ubuntu.com/c/wsl/27) and post your question there with a descriptive tag.

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -224,3 +224,7 @@ rst_prolog = '''
 .. role:: center
    :class: align-center
 '''
+
+# Define a selector that only adds copy buttons to code blocks without the class `no-copy`
+copybutton_selector = "div:not(.no-copy) > div.highlight > pre"
+

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -229,5 +229,5 @@ rst_prolog = '''
 copybutton_selector = "div:not(.no-copy) > div.highlight > pre"
 
 # Define prompts to be excluded from copying when a copy button is used 
-copybutton_prompt_text = r"^.*?[\$>#]\s+"
+copybutton_prompt_text = r"^.*?[\$>]\s+"
 copybutton_prompt_is_regexp = True

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -228,3 +228,6 @@ rst_prolog = '''
 # Define a selector that only adds copy buttons to code blocks without the class `no-copy`
 copybutton_selector = "div:not(.no-copy) > div.highlight > pre"
 
+# Define prompts to be excluded from copying when a copy button is used 
+copybutton_prompt_text = r"^.*?[\$>#]\s+"
+copybutton_prompt_is_regexp = True

--- a/docs/guides/install-ubuntu-wsl2.md
+++ b/docs/guides/install-ubuntu-wsl2.md
@@ -15,7 +15,7 @@
 
 You can install WSL from the command line. Open a PowerShell prompt as an Administrator (we recommend using [Windows Terminal](https://github.com/microsoft/terminal?tab=readme-ov-file#installing-and-running-windows-terminal)) and run:
 
-```text
+```{code-block} text
 wsl --install
 ```
 
@@ -42,7 +42,8 @@ Ubuntu will then be installed on your machine. Once installed, you can either la
 It is possible to install the same Ubuntu versions available on the Microsoft Store directly from the command line.
 In a PowerShell terminal, you can run `wsl --list --online` to see an output with all available distros and versions:
 
-```text
+```{code-block} text
+:class: no-copy
 The following is a list of valid distributions that can be installed.
 The default distribution is denoted by '*'.
 Install using 'wsl --install -d <Distro>'.
@@ -63,20 +64,22 @@ Your list may be different once new distributions become available.
 
 You can install a version using a NAME from the output:
 
-```text
+```{code-block} text
 wsl --install -d Ubuntu-24.04
 ```
 
 You'll see an indicator of the installation progress in the terminal:
 
-```text
+```{code-block} text
+:class: no-copy
 Installing: Ubuntu 24.04 LTS
 [==========================72,0%==========                 ]
 ```
 
 Use `wsl -l -v` to see all your currently installed distros and the version of WSL they are using:
 
-```text
+```{code-block} text
+:class: no-copy
   NAME            STATE           VERSION
   Ubuntu-20.04    Stopped         2
 * Ubuntu-24.04    Stopped         2
@@ -86,13 +89,13 @@ Use `wsl -l -v` to see all your currently installed distros and the version of W
 
 Open a PowerShell terminal and type:
 
-```text
+```{code-block} text
 winget show --name Ubuntu --source msstore
 ```
 
 You'll see a list of available distros and their Ids. Choose the one you prefer and install it. For instance, for `Ubuntu 24.04 LTS`:
 
-```text
+```{code-block} text
 winget install --Id "9NZ3KLHXDJP5" --source msstore
 ```
 
@@ -100,7 +103,7 @@ You'll be prompted to accept the source and package agreements before installing
 
 Check out [the documentation](../reference/distributions.md) to see which executable matches your application and run it.
 
-```text
+```{code-block} text
 ubuntu.exe
 ```
 
@@ -112,10 +115,11 @@ Once it has finished its initial setup, you will be prompted to create a usernam
 
 Finally, it’s always good practice to install the latest updates with the following commands, entering your password when prompted:
 
-```text
+```{code-block} text
 sudo apt update
 sudo apt full-upgrade -y
 ```
+
 ## Enjoy Ubuntu on WSL
 
 In this guide, we’ve shown you how to install Ubuntu WSL on Windows 10 or 11.

--- a/docs/guides/install-ubuntu-wsl2.md
+++ b/docs/guides/install-ubuntu-wsl2.md
@@ -16,7 +16,7 @@
 You can install WSL from the command line. Open a PowerShell prompt as an Administrator (we recommend using [Windows Terminal](https://github.com/microsoft/terminal?tab=readme-ov-file#installing-and-running-windows-terminal)) and run:
 
 ```{code-block} text
-wsl --install
+> wsl --install
 ```
 
 This command will enable the features necessary to run WSL and also install the default Ubuntu distribution of Linux available in the Microsoft Store. It is recommended to reboot your machine after this initial installation to complete the setup. You can also install WSL from the Microsoft Store.
@@ -65,7 +65,7 @@ Your list may be different once new distributions become available.
 You can install a version using a NAME from the output:
 
 ```{code-block} text
-wsl --install -d Ubuntu-24.04
+> wsl --install -d Ubuntu-24.04
 ```
 
 You'll see an indicator of the installation progress in the terminal:
@@ -90,13 +90,13 @@ Use `wsl -l -v` to see all your currently installed distros and the version of W
 Open a PowerShell terminal and type:
 
 ```{code-block} text
-winget show --name Ubuntu --source msstore
+> winget show --name Ubuntu --source msstore
 ```
 
 You'll see a list of available distros and their Ids. Choose the one you prefer and install it. For instance, for `Ubuntu 24.04 LTS`:
 
 ```{code-block} text
-winget install --Id "9NZ3KLHXDJP5" --source msstore
+> winget install --Id "9NZ3KLHXDJP5" --source msstore
 ```
 
 You'll be prompted to accept the source and package agreements before installing. You need to accept them in order to proceed.
@@ -104,7 +104,7 @@ You'll be prompted to accept the source and package agreements before installing
 Check out [the documentation](../reference/distributions.md) to see which executable matches your application and run it.
 
 ```{code-block} text
-ubuntu.exe
+> ubuntu.exe
 ```
 
 ## Configure Ubuntu
@@ -116,8 +116,8 @@ Once it has finished its initial setup, you will be prompted to create a usernam
 Finally, it’s always good practice to install the latest updates with the following commands, entering your password when prompted:
 
 ```{code-block} text
-sudo apt update
-sudo apt full-upgrade -y
+$ sudo apt update
+$ sudo apt full-upgrade -y
 ```
 
 ## Enjoy Ubuntu on WSL

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -6,18 +6,18 @@ Ubuntu WSL users can now leverage it to perform an automatic setup to get a work
 
 > See more:  [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
 
-The latest release of Ubuntu (Noble Numbat 24.04 LTS) comes with cloud-init already preinstalled, so you'll need that specific application to follow this tutorial. Ubuntu 24.04 LTS can be installed from [this link to the Microsoft Store](https://www.microsoft.com/store/productId/9NZ3KLHXDJP5?ocid=pdpshare). A previous version of this tutorial used Ubuntu-Preview, because that comes with the latest in-development features. You can still use it to follow the instructions below, if you prefer.
+The latest release of Ubuntu (Noble Numbat 24.04 LTS) comes with cloud-init already preinstalled, so you'll need that specific application to follow this tutorial. Ubuntu 24.04 LTS can be installed from [this link to the Microsoft Store](https://www.microsoft.com/store/productId/9NZ3KLHXDJP5?ocid=pdpshare). A previous version of this tutorial used Ubuntu Preview, because that comes with the latest in-development features. You can still use it to follow the instructions below, if you prefer.
 
-## What you will learn:
+## What you will learn
 
 - How to write cloud-config user data to a specific WSL instance.
 - How to automatically set up a WSL instance with cloud-init.
 - How to verify that cloud-init succeeded with the configuration supplied.
 
-## What you will need:
+## What you will need
 
 - Windows 11 with WSL 2 already enabled
-- The latest Ubuntu24.04LTS application from Microsoft Store.
+- The latest Ubuntu 24.04 LTS application from the Microsoft Store
 
 ## Write the cloud-config file
 
@@ -102,8 +102,10 @@ status: done
 
 ## Verify that it worked
 
-Restart the distro just to make sure the changes in `/etc/wsl.conf` made by cloud-init will take effect, as listed
-below:
+Restart the distro just to confirm that the changes in `/etc/wsl.conf` made by cloud-init will take effect.
+
+Terminate the running instance:
+
 
 ```powershell
 > wsl -t Ubuntu-24.04
@@ -124,7 +126,7 @@ This message is shown once a day. To disable it please create the
 jdoe@mib:~$
 ```
 
-Once logged in the new distro instance's shell, verify that:
+Once logged into the new distro instance's shell, verify that:
 
 1. The default user matches what was configured in the user data file (in our case `jdoe`).
 
@@ -162,7 +164,7 @@ LC_ALL=
 
 ```
 
-4. The packages were installed and the commands they provide are available
+4. The packages were installed and the commands they provide are available.
 
 ```sh
 jdoe@mib:~$ apt list --installed | egrep 'ginac|octave'
@@ -176,7 +178,7 @@ octave-doc/noble,now 8.4.0-1 all [installed,automatic]
 octave/noble,now 8.4.0-1 amd64 [installed]
 ```
 
-5. Verify that the commands requested were also run. In this case we set up `vcpkg` from git, as recommended by its
+5. Lastly, verify that the commands requested were also run. In this case we set up `vcpkg` from git, as recommended by its
    documentation (there is no deb or snap available for that program).
 
 ```sh

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -70,7 +70,7 @@ Save it and close it.
 In PowerShell, run:
 
 ```{code-block} text
-ubuntu2404.exe install --root
+> ubuntu2404.exe install --root
 ```
 
 We skip the user creation since we expect cloud-init to do it.
@@ -83,9 +83,8 @@ We skip the user creation since we expect cloud-init to do it.
 
 In PowerShell again run:
 
-
 ```{code-block} text
-ubuntu2404.exe run cloud-init status --wait
+> ubuntu2404.exe run cloud-init status --wait
 ```
 
 That will wait until cloud-init completes configuring the new instance we just created. When done, you should see an
@@ -107,7 +106,7 @@ Restart the distro just to confirm that the changes in `/etc/wsl.conf` made by c
 Terminate the running instance:
 
 ```{code-block} text
-wsl -t Ubuntu-24.04
+> wsl -t Ubuntu-24.04
 ```
 
 This should output a message confirming that the instance has stopped:
@@ -120,7 +119,7 @@ The operation completed successfully.
 Now start the instance again:
 
 ```{code-block} text
-ubuntu2404.exe
+> ubuntu2404.exe
 ```
 
 You should see the standard welcome text:
@@ -243,9 +242,9 @@ This workflow will guarantee a solid foundation for your next Ubuntu WSL project
 As a side note, users installing the distro with the `wsl --install` online command must take a few steps to ensure cloud-init has time to do its job. First, make sure to install with the `--no-launch` flag, then use the distro launcher to install without creating a user (if you expect cloud-init to do it for you as described in this tutorial) and finally watch cloud-init do its job. The commands are outlined below:
 
 ```text
-wsl --install --no-launch -d Ubuntu-24.04
-ubuntu2404.exe install --root
-ubuntu2404.exe run cloud-init status --wait
+> wsl --install --no-launch -d Ubuntu-24.04
+> ubuntu2404.exe install --root
+> ubuntu2404.exe run cloud-init status --wait
 ```
 
 We hope you enjoy using Ubuntu inside WSL!

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -31,7 +31,7 @@ match the name of the distro instance that will be created in the next step.
 
 Open that file with your text editor of choice (`notepad.exe` is just fine) and paste in the following contents:
 
-```yaml
+```{code-block} yaml
 #cloud-config
 locale: pt_BR
 users:
@@ -69,7 +69,7 @@ Save it and close it.
 
 In PowerShell, run:
 
-```powershell
+```{code-block} text
 ubuntu2404.exe install --root
 ```
 
@@ -84,14 +84,15 @@ We skip the user creation since we expect cloud-init to do it.
 In PowerShell again run:
 
 
-```powershell
+```{code-block} text
 ubuntu2404.exe run cloud-init status --wait
 ```
 
 That will wait until cloud-init completes configuring the new instance we just created. When done, you should see an
 output similar to the following:
 
-```powershell
+```{code-block} text
+:class: no-copy
 ..............................................................................
 ..............................................................................
 ..............................................................................
@@ -99,18 +100,33 @@ output similar to the following:
 status: done
 ```
 
-
 ## Verify that it worked
 
 Restart the distro just to confirm that the changes in `/etc/wsl.conf` made by cloud-init will take effect.
 
 Terminate the running instance:
 
+```{code-block} text
+wsl -t Ubuntu-24.04
+```
 
-```powershell
-> wsl -t Ubuntu-24.04
+This should output a message confirming that the instance has stopped:
+
+```{code-block} text
+:class: no-copy
 The operation completed successfully.
-> ubuntu2404.exe
+```
+
+Now start the instance again:
+
+```{code-block} text
+ubuntu2404.exe
+```
+
+You should see the standard welcome text:
+
+```{code-block} text
+:class: no-copy
 To run a command as administrator (user "root"), use "sudo <command>".
 See "man sudo_root" for details.
 
@@ -130,22 +146,40 @@ Once logged into the new distro instance's shell, verify that:
 
 1. The default user matches what was configured in the user data file (in our case `jdoe`).
 
-```sh
+```{code-block} text
 jdoe@mib:~$ whoami
+```
+
+This should be verified with the output message:
+
+```{code-block} text
+:class: no-copy
 jdoe
 ```
 
 2. The supplied cloud-config user data was approved by cloud-init validation.
 
-```sh
+```{code-block} text
 jdoe@mib:~$ sudo cloud-init schema --system
+```
+
+Verified with the output:
+
+```{code-block} text
+:class: no-copy
 Valid schema user-data
 ```
 
 3. The locale is set
 
-```sh
+```{code-block} text
 jdoe@mib:~$ locale
+```
+
+Verified with:
+
+```{code-block} text
+:class: no-copy
 LANG=pt_BR
 LANGUAGE=
 LC_CTYPE="pt_BR"
@@ -166,8 +200,14 @@ LC_ALL=
 
 4. The packages were installed and the commands they provide are available.
 
-```sh
+```{code-block} text
 jdoe@mib:~$ apt list --installed | egrep 'ginac|octave'
+```
+
+Verified:
+
+```{code-block} text
+:class: no-copy
 
 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
 
@@ -181,8 +221,14 @@ octave/noble,now 8.4.0-1 amd64 [installed]
 5. Lastly, verify that the commands requested were also run. In this case we set up `vcpkg` from git, as recommended by its
    documentation (there is no deb or snap available for that program).
 
-```sh
+```{code-block} text
 jdoe@mib:~$ /opt/vcpkg/vcpkg version
+```
+
+This should also be verified with:
+
+```{code-block} text
+:class: no-copy
 vcpkg package management program version 2024-01-11-710a3116bbd615864eef5f9010af178034cb9b44
 
 See LICENSE.txt for license information.
@@ -196,7 +242,7 @@ This workflow will guarantee a solid foundation for your next Ubuntu WSL project
 
 As a side note, users installing the distro with the `wsl --install` online command must take a few steps to ensure cloud-init has time to do its job. First, make sure to install with the `--no-launch` flag, then use the distro launcher to install without creating a user (if you expect cloud-init to do it for you as described in this tutorial) and finally watch cloud-init do its job. The commands are outlined below:
 
-```powershell
+```text
 wsl --install --no-launch -d Ubuntu-24.04
 ubuntu2404.exe install --root
 ubuntu2404.exe run cloud-init status --wait

--- a/docs/tutorials/cloud-init.md
+++ b/docs/tutorials/cloud-init.md
@@ -6,7 +6,7 @@ Ubuntu WSL users can now leverage it to perform an automatic setup to get a work
 
 > See more:  [cloud-init official documentation](https://cloudinit.readthedocs.io/en/latest/index.html).
 
-The latest release of Ubuntu (Noble Numbat 24.04 LTS) comes with cloud-init already preinstalled, so you'll need that specific application to follow this tutorial. Ubuntu 24.04 LTS can be installed from [this link to the Microsoft Store](https://www.microsoft.com/store/productId/9NZ3KLHXDJP5?ocid=pdpshare). A previous version of this tutorial used Ubuntu Preview, because that comes with the latest in-development features. You can still use it to follow the instructions below, if you prefer.
+The latest release of Ubuntu (Noble Numbat 24.04 LTS) comes with cloud-init already preinstalled, so you'll need that specific application to follow this tutorial. Ubuntu 24.04 LTS can be installed from [this link to the Microsoft Store](https://www.microsoft.com/store/productId/9NZ3KLHXDJP5?ocid=pdpshare). A previous version of this tutorial used Ubuntu (Preview), because that comes with the latest in-development features. You can still use it to follow the instructions below, if you prefer.
 
 ## What you will learn
 

--- a/docs/tutorials/data-science-and-engineering.md
+++ b/docs/tutorials/data-science-and-engineering.md
@@ -11,17 +11,17 @@ First, you'll need to set up Ubuntu on WSL, see [here](../guides/install-ubuntu-
 
 We will use it to calculate and draw a beautiful Julia fractal. The goal here is to use Octave to demonstrate how WSLg works, not to go through the theory of fractals. 
 
-First thing is to install the software like we did for x11-apps, from the terminal prompt run:
+From an Ubuntu WSL terminal prompt run:
 
 ```{code-block} text
-sudo apt update
-sudo apt install -y octave
+$ sudo apt update
+$ sudo apt install -y octave
 ```
 
 Then start the application:
 
 ```{code-block} text
-octave --gui &
+$ octave --gui &
 ```
 
 Do not forget the ampersand `&` at the end of the line, so the application is started in the background and we can continue using the same terminal window.

--- a/docs/tutorials/data-science-and-engineering.md
+++ b/docs/tutorials/data-science-and-engineering.md
@@ -13,13 +13,14 @@ We will use it to calculate and draw a beautiful Julia fractal. The goal here is
 
 First thing is to install the software like we did for x11-apps, from the terminal prompt run:
 
-```
+```{code-block} text
 sudo apt update
 sudo apt install -y octave
 ```
 
 Then start the application:
-```
+
+```{code-block} text
 octave --gui &
 ```
 
@@ -29,7 +30,7 @@ Do not forget the ampersand `&` at the end of the line, so the application is st
 
 In Octave, click on the `New script` icon to open a new editor window and copy/paste the following code:
 
-```octave
+```{code-block} octave
 #{
 Inspired by the work of Bruno Girin ([Geek Thoughts: Fractals with Octave: Classic Mandelbrot and Julia](http://brunogirin.blogspot.com/2008/12/fractals-with-octave-classic-mandelbrot.html))
 Calculate a Julia set
@@ -60,7 +61,8 @@ end
 This code is the function that will calculate the Julia set. Save it to a file named `julia.m`. Since it is a function definition, the name of the file must match the name of the function.
 
 Open a second editor window with the New Script button and copy and paste the following code:
-```octave
+
+```{code-block} octave
 Jc1=julia(-1.6+1.2i, 1.6-1.2i, 640, 128, -0.75+0.2i);
 imagesc(Jc1)
 axis off

--- a/docs/tutorials/data-science-and-engineering.md
+++ b/docs/tutorials/data-science-and-engineering.md
@@ -71,7 +71,7 @@ This code calls the function defined in `julia.m`. You can later change the para
 
 Save it to a file named `juliatest.m`.
 
-And finally, press the button `Save File and Run`.
+And finally, press the button **Save File and Run**.
 
 ![|570x225](assets/data-science-engineering/save-file.png)
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -103,13 +103,13 @@ First, get the IP address of your machine by running `ipconfig` in a PowerShell 
 
 ![|624x357](assets/dotnet-systemd/ipconfig.png)
 
-Then select the setting icon in the bottom-left corner of the Bot Framework Emulator and enter your IP under ‘localhost override'.
+Then select the settings icon in the bottom-left corner of the Bot Framework Emulator and enter your IP under ‘localhost override'.
 
 ![|624x411](assets/dotnet-systemd/emulator-settings.png)
 
-Click 'Save' and navigate back to the Welcome tab.
+Click **Save** and navigate back to the Welcome tab.
 
-Click ‘Open Bot’ and under ‘Bot URL’ input:
+Click **Open Bot** and under ‘Bot URL’ input:
 
 ```text
 http://localhost:3978/api/messages
@@ -117,7 +117,7 @@ http://localhost:3978/api/messages
 
 ![|624x411](assets/dotnet-systemd/open-a-bot.png)
 
-And click ‘Connect’ to connect to your Echo Bot running in WSL and start chatting!
+And click **Connect** to connect to your Echo Bot running in WSL and start chatting!
 
 ![|624x411](assets/dotnet-systemd/start-chatting.png)
 
@@ -160,8 +160,6 @@ SyslogIdentifier=echoes
 [Install]
 WantedBy=multi-user.target
 ```
-
-![|624x401](assets/dotnet-systemd/nano-service-file.png)
 
 Save your file and reload your services with:
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -18,16 +18,23 @@ Systemd support is required for this tutorial and is available on WSL version 0.
 
 In your PowerShell terminal, you can check your current WSL version by running:
 
-> `wsl --version`
+```{code-block} text
+wsl --version
+```
 
 Inside WSL, you can check that systemd is enabled on your Ubuntu distribution with the following command:
 
-> `cat /etc/wsl.conf`
+```{code-block} text
+cat /etc/wsl.conf
+```
 
 If enabled the output will be:
 
-> `[boot]`  
-> `systemd=true`
+```{code-block} text
+:class: no-copy
+[boot]
+systemd=true
+```
 
 If systemd is set to `false` then open the file with `sudo nano /etc/wsl.conf`, set it to `true` and save.
 Make sure to restart your distribution after you have made this change.
@@ -42,11 +49,15 @@ If you are using Ubuntu 22.04 LTS you can skip the command for installing backpo
 
 Run this command to install backports, which includes .NET 6:
 
-> `sudo add-apt-repository ppa:dotnet/backports`
+```{code-block} text
+sudo add-apt-repository ppa:dotnet/backports
+```
 
 To install a bundle with both the SDK and runtime for .NET 6 run:
 
-> `sudo apt install dotnet6`
+```{code-block} text
+sudo apt install dotnet6
+```
 
 Run `dotnet --version` to confirm that the package was installed successfully.
 
@@ -54,16 +65,22 @@ Run `dotnet --version` to confirm that the package was installed successfully.
 
 Create a new directory for the project and navigate to it before proceeding:
 
-> `mkdir ~/mybot`  
-> `cd mybot`
+```{code-block} text
+mkdir ~/mybot
+cd mybot
+```
 
 Once inside we can install the EchoBot C# template by running:
 
-> `dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot`
+```{code-block} text
+dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot
+```
 
 We can then verify the template has been installed correctly:
 
-> `dotnet new --list`
+```{code-block} text
+dotnet new --list
+```
 
 You should be able to find the `Bot Framework Echo Bot` template in the list.
 
@@ -71,15 +88,21 @@ You should be able to find the `Bot Framework Echo Bot` template in the list.
 
 Create a new Echo Bot project, with `echoes` as the name for our bot, using the following command:
 
-> `dotnet new echobot -n echoes`
+```{code-block} text
+dotnet new echobot -n echoes
+```
 
 After this has completed we can navigate into the new directory that has been created.
 
-> `cd ~/mybot/echoes`
+```{code-block} text
+cd ~/mybot/echoes
+```
 
 From inside this directory the project should be ready to run. Test it with:
 
-> `sudo dotnet run`
+```{code-block} text
+sudo dotnet run
+```
 
 If everything was set up correctly you should see a similar output to the one below:
 
@@ -129,11 +152,15 @@ Return to your running WSL distro and end the app with `Ctrl+C`.
 
 Then install the .NET systemd extension with:
 
-> `sudo dotnet add package Microsoft.Extensions.Hosting.Systemd`
+```{code-block} text
+sudo dotnet add package Microsoft.Extensions.Hosting.Systemd
+```
 
 We can open our project with VS Code by running this command in the 'echoes' directory:
 
-> `code .`
+```{code-block} text
+code .
+```
 
 Navigate to ‘Program.cs’ and insert `.UseSystemd()` as a new line in the location shown in the screenshot.
 
@@ -143,11 +170,13 @@ Save and close the project in VS Code and return to your WSL terminal.
 
 Next we need to create a service file for your bot using your favourite editor, for example.
 
-> `sudo nano /etc/systemd/system/echoes.service`
+```{code-block} text
+sudo nano /etc/systemd/system/echoes.service
+```
 
 Then paste the snippet below taking care to replace `<your-username>` with your username.
 
-```text
+```{code-block} text
 [Unit]
 Description=The first ever WSL Ubuntu systemd .NET ChatBot Service
 
@@ -163,21 +192,31 @@ WantedBy=multi-user.target
 
 Save your file and reload your services with:
 
-> `sudo systemctl daemon-reload`
+```{code-block} text
+sudo systemctl daemon-reload
+```
 
 To reload the services. You can check if your service is ready by running:
 
-> `systemctl status echoes.service`
+```{code-block} text
+systemctl status echoes.service
+```
 
 You should get the following output:
 
 ![|624x77](assets/dotnet-systemd/systemctl-status-inactive.png)
 
-Now start your service and then check its status again.
+Now start your service:
 
-> `sudo systemctl start echoes.service`
+```{code-block} text
+sudo systemctl start echoes.service
+```
 
-> `sudo systemctl status echoes.service`
+Then check its status again:
+
+```{code-block} text
+sudo systemctl status echoes.service
+```
 
 If everything has been configured correctly you should get an output similar to the below.
 
@@ -189,7 +228,9 @@ Return to your Windows host and reconnect to your Bot Emulator using the same in
 
 You can stop your bot from running at any time with the command:
 
-> `sudo systemctl stop echoes.service`
+```{code-block} text
+sudo systemctl stop echoes.service
+```
 
 ## Tutorial complete!
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -19,13 +19,13 @@ Systemd support is required for this tutorial and is available on WSL version 0.
 In your PowerShell terminal, you can check your current WSL version by running:
 
 ```{code-block} text
-wsl --version
+> wsl --version
 ```
 
 Inside WSL, you can check that systemd is enabled on your Ubuntu distribution with the following command:
 
 ```{code-block} text
-cat /etc/wsl.conf
+$ cat /etc/wsl.conf
 ```
 
 If enabled the output will be:
@@ -50,13 +50,13 @@ If you are using Ubuntu 22.04 LTS you can skip the command for installing backpo
 Run this command to install backports, which includes .NET 6:
 
 ```{code-block} text
-sudo add-apt-repository ppa:dotnet/backports
+$ sudo add-apt-repository ppa:dotnet/backports
 ```
 
 To install a bundle with both the SDK and runtime for .NET 6 run:
 
 ```{code-block} text
-sudo apt install dotnet6
+$ sudo apt install dotnet6
 ```
 
 Run `dotnet --version` to confirm that the package was installed successfully.
@@ -66,20 +66,20 @@ Run `dotnet --version` to confirm that the package was installed successfully.
 Create a new directory for the project and navigate to it before proceeding:
 
 ```{code-block} text
-mkdir ~/mybot
-cd mybot
+$ mkdir ~/mybot
+$ cd mybot
 ```
 
 Once inside we can install the EchoBot C# template by running:
 
 ```{code-block} text
-dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot
+$ dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot
 ```
 
 We can then verify the template has been installed correctly:
 
 ```{code-block} text
-dotnet new --list
+$ dotnet new --list
 ```
 
 You should be able to find the `Bot Framework Echo Bot` template in the list.
@@ -89,19 +89,19 @@ You should be able to find the `Bot Framework Echo Bot` template in the list.
 Create a new Echo Bot project, with `echoes` as the name for our bot, using the following command:
 
 ```{code-block} text
-dotnet new echobot -n echoes
+$ dotnet new echobot -n echoes
 ```
 
 After this has completed we can navigate into the new directory that has been created.
 
 ```{code-block} text
-cd ~/mybot/echoes
+$ cd ~/mybot/echoes
 ```
 
 From inside this directory the project should be ready to run. Test it with:
 
 ```{code-block} text
-sudo dotnet run
+$ sudo dotnet run
 ```
 
 If everything was set up correctly you should see a similar output to the one below:
@@ -153,13 +153,13 @@ Return to your running WSL distro and end the app with `Ctrl+C`.
 Then install the .NET systemd extension with:
 
 ```{code-block} text
-sudo dotnet add package Microsoft.Extensions.Hosting.Systemd
+$ sudo dotnet add package Microsoft.Extensions.Hosting.Systemd
 ```
 
 We can open our project with VS Code by running this command in the 'echoes' directory:
 
 ```{code-block} text
-code .
+$ code .
 ```
 
 Navigate to ‘Program.cs’ and insert `.UseSystemd()` as a new line in the location shown in the screenshot.
@@ -171,7 +171,7 @@ Save and close the project in VS Code and return to your WSL terminal.
 Next we need to create a service file for your bot using your favourite editor, for example.
 
 ```{code-block} text
-sudo nano /etc/systemd/system/echoes.service
+$ sudo nano /etc/systemd/system/echoes.service
 ```
 
 Then paste the snippet below taking care to replace `<your-username>` with your username.
@@ -193,13 +193,13 @@ WantedBy=multi-user.target
 Save your file and reload your services with:
 
 ```{code-block} text
-sudo systemctl daemon-reload
+$ sudo systemctl daemon-reload
 ```
 
 To reload the services. You can check if your service is ready by running:
 
 ```{code-block} text
-systemctl status echoes.service
+$ systemctl status echoes.service
 ```
 
 You should get the following output:
@@ -209,13 +209,13 @@ You should get the following output:
 Now start your service:
 
 ```{code-block} text
-sudo systemctl start echoes.service
+$ sudo systemctl start echoes.service
 ```
 
 Then check its status again:
 
 ```{code-block} text
-sudo systemctl status echoes.service
+$ sudo systemctl status echoes.service
 ```
 
 If everything has been configured correctly you should get an output similar to the below.
@@ -229,7 +229,7 @@ Return to your Windows host and reconnect to your Bot Emulator using the same in
 You can stop your bot from running at any time with the command:
 
 ```{code-block} text
-sudo systemctl stop echoes.service
+$ sudo systemctl stop echoes.service
 ```
 
 ## Tutorial complete!

--- a/docs/tutorials/gpu-cuda.md
+++ b/docs/tutorials/gpu-cuda.md
@@ -74,23 +74,23 @@ This step ends with a screen similar to the image below.
 The following commands will install the WSL-specific CUDA toolkit version 11.6 on Ubuntu 22.04 AMD64 architecture. Be aware that older versions of CUDA (<=10) don’t support WSL 2. Also notice that attempting to install the CUDA toolkit packages straight from the Ubuntu repository (`cuda`, `cuda-11-0`, or `cuda-drivers`) will attempt to install the Linux NVIDIA graphics driver, which is not what you want on WSL 2. So, first remove the old GPG key:
 
 ```{code-block} text
-sudo apt-key del 7fa2af80
+$ sudo apt-key del 7fa2af80
 ```
 
 Then setup the appropriate package for Ubuntu WSL with the following commands:
 
 ```{code-block} text
-wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin
+$ wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin
 
-sudo mv cuda-wsl-ubuntu.pin /etc/apt/preferences.d/cuda-repository-pin-600
+$ sudo mv cuda-wsl-ubuntu.pin /etc/apt/preferences.d/cuda-repository-pin-600
 
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/3bf863cc.pub
+$ sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/3bf863cc.pub
 
-sudo add-apt-repository 'deb https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/ /'
+$ sudo add-apt-repository 'deb https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/ /'
 
-sudo apt-get update
+$ sudo apt-get update
 
-sudo apt-get -y install cuda
+$ sudo apt-get -y install cuda
 ```
 
 Once complete, you should see a series of outputs that end in `done.`:
@@ -106,15 +106,15 @@ NVIDIA provides an open source repository on GitHub with samples for CUDA Develo
 Let’s say you have a `~/Dev/` directory where you usually put your working projects. Navigate inside the directory and `git clone` the [cuda-samples repository](https://github.com/nvidia/cuda-samples):
 
 ```{code-block} text
-cd ~/Dev
-git clone https://github.com/nvidia/cuda-samples
+$ cd ~/Dev
+$ git clone https://github.com/nvidia/cuda-samples
 ```
 
 To build the application, go to the cloned repository directory and run `make`:
 
 ```{code-block} text
-cd ~/Dev/cuda-samples/Samples/1_Utilities/deviceQuery
-make
+$ cd ~/Dev/cuda-samples/Samples/1_Utilities/deviceQuery
+$ make
 ```
 
 A successful build will look like the screenshot below.
@@ -124,7 +124,7 @@ A successful build will look like the screenshot below.
 Once complete, run the application with:
 
 ```{code-block} text
-./deviceQuery
+$ ./deviceQuery
 ```
 
 You should see a similar output to the following detailing the functionality of your CUDA setup (the exact results depend on your hardware setup):

--- a/docs/tutorials/gpu-cuda.md
+++ b/docs/tutorials/gpu-cuda.md
@@ -3,13 +3,13 @@
 
 While WSL's default setup allows you to develop cross-platform applications without leaving Windows, enabling GPU acceleration inside WSL provides users with direct access to the hardware. This provides support for GPU-accelerated AI/ML training and the ability to develop and test applications built on top of technologies, such as OpenVINO, OpenGL, and CUDA that target Ubuntu while staying on Windows.
 
-## What you will learn:
+## What you will learn
 
 * How to install a Windows graphical device driver compatible with WSL2
 * How to install the NVIDIA CUDA toolkit for WSL 2 on Ubuntu
 * How to compile and run a sample CUDA application on Ubuntu on WSL2
 
-## What you will need:
+## What you will need
 
 * A Windows 10 version 21H2 or newer physical machine equipped with an NVIDIA graphics card and administrative permission to be able to install device drivers
 * Ubuntu on WSL2 previously installed
@@ -75,7 +75,7 @@ The following commands will install the WSL-specific CUDA toolkit version 11.6 o
 
 > `sudo apt-key del 7fa2af80`
 
-Then setup the appropriate package for Ubuntu WSL:
+Then setup the appropriate package for Ubuntu WSL with the following commands:
 
 > `wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin`
 
@@ -111,11 +111,13 @@ To build the application, go to the cloned repository directory and type `make`:
 
 > `make`
 
-A successful build will look like the screenshot below. Once complete, run the application:
+A successful build will look like the screenshot below.
 
 ![|624x135](assets/gpu-cuda/make.png)
 
 > `./deviceQuery`
+Once complete, run the application with:
+
 
 You should see a similar output to the following detailing the functionality of your CUDA setup (the exact results depend on your hardware setup):
 

--- a/docs/tutorials/gpu-cuda.md
+++ b/docs/tutorials/gpu-cuda.md
@@ -73,21 +73,25 @@ This step ends with a screen similar to the image below.
 
 The following commands will install the WSL-specific CUDA toolkit version 11.6 on Ubuntu 22.04 AMD64 architecture. Be aware that older versions of CUDA (<=10) don’t support WSL 2. Also notice that attempting to install the CUDA toolkit packages straight from the Ubuntu repository (`cuda`, `cuda-11-0`, or `cuda-drivers`) will attempt to install the Linux NVIDIA graphics driver, which is not what you want on WSL 2. So, first remove the old GPG key:
 
-> `sudo apt-key del 7fa2af80`
+```{code-block} text
+sudo apt-key del 7fa2af80
+```
 
 Then setup the appropriate package for Ubuntu WSL with the following commands:
 
-> `wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin`
+```{code-block} text
+wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin
 
-> `sudo mv cuda-wsl-ubuntu.pin /etc/apt/preferences.d/cuda-repository-pin-600`
+sudo mv cuda-wsl-ubuntu.pin /etc/apt/preferences.d/cuda-repository-pin-600
 
-> `sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/3bf863cc.pub`
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/3bf863cc.pub
 
-> `sudo add-apt-repository 'deb https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/ /'`
+sudo add-apt-repository 'deb https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/ /'
 
-> `sudo apt-get update`
+sudo apt-get update
 
-> `sudo apt-get -y install cuda`
+sudo apt-get -y install cuda
+```
 
 Once complete, you should see a series of outputs that end in `done.`:
 
@@ -101,23 +105,27 @@ NVIDIA provides an open source repository on GitHub with samples for CUDA Develo
 
 Let’s say you have a `~/Dev/` directory where you usually put your working projects. Navigate inside the directory and `git clone` the [cuda-samples repository](https://github.com/nvidia/cuda-samples):
 
-> `cd ~/Dev`
+```{code-block} text
+cd ~/Dev
+git clone https://github.com/nvidia/cuda-samples
+```
 
-> `git clone https://github.com/nvidia/cuda-samples`
+To build the application, go to the cloned repository directory and run `make`:
 
-To build the application, go to the cloned repository directory and type `make`:
-
-> `cd ~/Dev/cuda-samples/Samples/1_Utilities/deviceQuery`
-
-> `make`
+```{code-block} text
+cd ~/Dev/cuda-samples/Samples/1_Utilities/deviceQuery
+make
+```
 
 A successful build will look like the screenshot below.
 
 ![|624x135](assets/gpu-cuda/make.png)
 
-> `./deviceQuery`
 Once complete, run the application with:
 
+```{code-block} text
+./deviceQuery
+```
 
 You should see a similar output to the following detailing the functionality of your CUDA setup (the exact results depend on your hardware setup):
 

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -40,13 +40,13 @@ Note: in this tutorial, we consider that interoperability is turned on in WSL.co
 
 Let’s install [Jupyter notebook](https://jupyter.org/), a web-based interactive computing platform where we will generate some statistics.
 
-1. Start our WSL instance, on a terminal, using Ubuntu:
+1. In PowerShell, start an Ubuntu WSL instance:
 
 ```{code-block} text
-$ ubuntu.exe
+> ubuntu.exe
 ```
 
-2. Install the python package manager [pip](https://pypi.org/project/pip/):
+2. Now in the instance, install the python package manager [pip](https://pypi.org/project/pip/):
 
 ```{code-block} text
 $ sudo apt update

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -7,14 +7,14 @@ Interoperability is the ability to transparently execute commands and applicatio
 
 We’ll illustrate all these notions by generating data from your Ubuntu WSL instance using your Windows user profile directory, perform some transformations via PowerShell scripts, and finally, visualise those on Windows. We are going to cross the chasm between the two worlds not just once, but many times, seamlessly!
 
-## What you will learn:
+## What you will learn
 
 * How to access a service provided by a web server running on your Ubuntu WSL instance from Windows.
 * Share environment variables between Windows and Ubuntu, back and forth.
 * Access files across filesystems, and discover where they are located on both sides.
 * Run Windows commands (command line and graphical) from your WSL instance and chain them.
 
-## What you will need:
+## What you will need
 
 * Know how to use command line tools on Windows or Linux.
 * A PC with Windows 10 or 11.
@@ -93,7 +93,7 @@ Let’s try this right away: from Windows, launch a web browser and enter the `U
 
 ![|624x347](assets/interop/jupyter.png)
 
-And it works! You can thus easily expose and share any services that are using network ports between your Windows machine and WSL instances!
+It works! You can thus easily expose and share any services that are using network ports between your Windows machine and WSL instances!
 
 >ⓘ **Note:** you need to keep this command line Window opened to have your Jupyter instance running. If you close it, the service will shut down and you won’t have access to it anymore. Other command-line operations in the same WSL instance should be done on another terminal.
 
@@ -128,9 +128,9 @@ ls: cannot access 'C:\Users\myuser': No such file or directory
 
 Indeed, `C:\Users\myuser` is not a compatible Linux-path where the Windows file system is located under WSL.
 
-But we haven’t done all that for nothing! `WSLENV` variable declaration can be suffixed with `/p`, which then translates any paths between Windows and your Linux instance.
+Yet we haven’t done all that for nothing! `WSLENV` variable declaration can be suffixed with `/p`, which then translates any paths between Windows and your Linux instance.
 
-Let’s try again:
+Let’s try again. Run `exit` to shutdown Ubuntu, then in PowerShell set `WSLENV` again using the `/p` suffix then start Ubuntu:
 
 ```
 $ exit
@@ -147,7 +147,7 @@ Desktop
 […]
 ```
 
-And here we go! We now know where our user profile data is accessible on WSL thanks to environment variables sharing. But more generally, environment variables could be used in your scripts, or any services in your WSL instance, where parameters are controlled from Windows.
+There we go! We now know where our user profile data is accessible on WSL thanks to environment variables sharing. More generally, environment variables could be used in your scripts, or any services in your WSL instance, where parameters are controlled from Windows.
 
 Going further:
 
@@ -162,13 +162,13 @@ After this little detour into the command line world to discover which path to u
 
 We are going to create a `stats-raw.csv` file, containing statistics about our user profile directory.
 
-Some preliminary warnings: accessing Windows filesystem from Ubuntu is using the [9P protocol](https://en.wikipedia.org/wiki/9P_(protocol)), which might mean slower access and indexing of files than native performance. So that this section doesn’t take too long to complete, we are advising you to choose a subdirectory or your Windows user profile directory, with fewer files and directories to run over. We will call it here `/mnt/c/Users/mysuser/path/my/subdirectory`.
+Some preliminary warnings: accessing Windows filesystem from Ubuntu is using the [9P protocol](https://en.wikipedia.org/wiki/9P_(protocol)), which might mean slower access and indexing of files than native performance. So that this section doesn’t take too long to complete, we are advising you to choose a subdirectory or your Windows user profile directory, with fewer files and directories to run over. Here, we will be calling this `/mnt/c/Users/mysuser/path/my/subdirectory`.
 
-From the Jupyter main screen, create a new notebook to start developing an interactive Python solution. You can do this by clicking on the `New` button, and then clicking on the `Python 3` option, as we can see below.
+From the main screen of Jupyter, create a new notebook to start developing an interactive Python solution. You can do this by clicking on the **New** button, and then clicking on the **Python 3** option, as we can see below.
 
 ![Jupyter Notebook: A Beginner's Tutorial|624x251](assets/interop/jupyter-python.jpg)
 
-Copy this to the first cell, adapting the input directory:
+Copy this to the first cell, taking care to edit the input directory:
 
 ```python
 import os
@@ -202,7 +202,7 @@ Let’s execute it by clicking on the “Run” button in the web interface.
 
 ![|624x469](assets/interop/jupyter-script.png)
 
-Note that while the entry is running, you will have a `In [*]` with the star marker. This will be replaced by `In [1]:` when completed. Once done and the results are printed, let’s ensure that the CSV file is present on disk using an Ubuntu terminal:
+Note that while the entry is running, you will have a `In [*]` with the star marker. This will be replaced by `In [1]:` when completed. Once this is completed and the results have been printed, let’s ensure that the CSV file is present on disk using an Ubuntu terminal:
 
 ```
 $ cat stats-raw.csv
@@ -232,13 +232,13 @@ image/vnd.microsoft.icon,91
 
 ## Accessing Ubuntu files from Windows
 
-So, we now have a stat file on Ubuntu, which is the result of computation on files stored on the Windows partition. We now want to analyse this file using Windows tools, but first, can we access it from Windows?
+So, we now have a stat file on Ubuntu, which is the result of computation on files stored on the Windows partition. We now want to analyse this file using Windows tools, but can we access it from Windows?
 
 Of course, interoperability goes both ways, and we already know exactly how to discover where those are available on Windows: introducing sharing environment variable round 2!
 
 ### Start PowerShell from Ubuntu and share the HOME directory
 
-Similarly to `USERPROFILE`, we want, this time, to share the user `HOME` variable with Windows, and let interoperability translate it to a Windows-compatible path. Let’s do this right away from an Ubuntu terminal:
+Similarly to `USERPROFILE`, we want, this time, to share the user `HOME` variable with Windows, and let interoperability translate it to a Windows-compatible path. In an Ubuntu terminal set the environment variable, making sure to use the `/p` suffix then open a Windows command prompt:
 
 ```
 $ export WSLENV=HOME/p
@@ -248,7 +248,8 @@ HOME=\\wsl.localhost\Ubuntu\home\u
 C:\Windows> exit
 ```
 
-First, we are able to export the `HOME` variable to subprocess, telling us that we want to translate the path back to Windows compatible paths by appending `/p` as we previously saw. But this is not all: we are running `cmd.exe` from an Ubuntu terminal (which is itself running inside a PowerShell terminal), and get the corresponding Windows path! Even if that sounds a little bit like inception, using this feature is just seamless: you are launching any process, Linux or Windows, from your Ubuntu terminal. Inputs and outputs are connected and this complex machinery works flawlessly!
+
+First, we are able to export the `HOME` variable to subprocess, telling us that we want to translate the path back to Windows compatible paths by appending `/p` as we previously saw. But this is not all: we are running `cmd.exe` from an Ubuntu terminal (which is itself running inside a PowerShell terminal), and get the corresponding Windows path! Even if that sounds a little bit like the movie Inception, using this feature is just seamless: you are launching any process, Linux or Windows, from your Ubuntu terminal. Inputs and outputs are connected and this complex machinery works flawlessly!
 
 ### Accessing Linux files from Windows
 
@@ -258,7 +259,7 @@ Open Windows Explorer and navigate to that path to confirm they are visible ther
 
 Let’s now create a PowerShell script, from Windows, on this Ubuntu filesystem and save it there:
 
-You can open any editor, from notepad to a full-fledged IDE. Create a file named `filter-less-than-five.ps1` under `\\wsl.localhost\Ubuntu\home\<youruser>` (with the following content:
+You can open any editor, from Notepad to a full-fledged IDE. Create a file named `filter-less-than-five.ps1` under `\\wsl.localhost\Ubuntu\home\<youruser>` (with the following content:
 
 ```powershell
 $csvImport = $input | ConvertFrom-CSV
@@ -276,9 +277,9 @@ Foreach ($csvImportedItem in $csvImport){
 $csvArray | convertTo-CSV -NoTypeInformation
 ```
 
-This script will take a CSV-formatted content as input, filter any item which has less than 5 occurrences and will export it to the standard output as another CVS-formatted content.
+This script will take a CSV-formatted content as input, filter any item which has less than 5 occurrences and will then export it to the standard output as another CSV-formatted content.
 
-After saving, let’s check it’s available on the WSL side:
+After saving, let’s check that it’s available on the WSL side:
 
 ```
 $ cat filter-less-than-five.ps1
@@ -290,7 +291,7 @@ This PowerShell script, written from Windows on your Linux instance will be quit
 
 ## Execute and connect Linux and Windows executables.
 
-This is all very impressive, we have been able to share network, environment variables, paths, and files, and execute processes interchangeably between Ubuntu and Windows. Let’s go one step further by chaining all of this together in a single, but effective line:
+This is all very impressive, we have been able to share network, environment variables, paths and files, as well execute processes interchangeably between Ubuntu and Windows. Let’s go one step further by chaining all of this together in a single, but effective line:
 
 ```
 $ cat stats-raw.csv | powershell.exe -ExecutionPolicy Bypass -File $HOME/filter-less-than-five.ps1 | tee stats.csv
@@ -321,7 +322,7 @@ This simple command exercises many concepts of interoperability we saw in previo
 
 This deep integration for back-and-forth access between systems allows users to create awesome pipelines, taking the best tool that is available, independent of their host operating system. To make that easy, WSL transparently converts any paths and does the heavy lifting for you so that you don’t need to do the manual conversion!
 
-And finally, we can even run the default associated GUI Windows application associated with those files, from Ubuntu:
+Finally, we can even run the default associated GUI Windows application associated with those files, from Ubuntu:
 
 ```
 $ explorer.exe stats.csv
@@ -329,7 +330,7 @@ $ explorer.exe stats.csv
 
 Note: You can’t deny it’s really amazing to be able to execute explorer.exe from Ubuntu. :)
 
-This will open LibreOffice, Microsoft Excel, or any other tool you may have associated with CSV files. From there, you will be able to draw beautiful charts, make further analyses, and so on. But that’s another story…
+This will open LibreOffice, Microsoft Excel, or any other tool you may have associated with CSV files. From there, you will be able to draw beautiful charts and do data analysis, but that’s another story…
 
 ![|624x389](assets/interop/spreadsheet.png)
 
@@ -337,8 +338,8 @@ This will open LibreOffice, Microsoft Excel, or any other tool you may have asso
 
 That’s all folks! In this tutorial, we’ve shown you many aspects of interoperability on WSL. To sum it up, we can:
 
-* **Run Ubuntu commands from a Windows PowerShell prompt** such as cut, grep, or awk
-* **Run Windows commands from an Ubuntu Terminal** such as explorer.exe or notepad.exe
+* **Run Ubuntu commands from a Windows PowerShell prompt** such as cut, grep, or awk.
+* **Run Windows commands from an Ubuntu Terminal** such as explorer.exe, notepad.exe and many others.
 * **Share network ports** between Ubuntu and Windows systems.
 * **Share environment variables** between Ubuntu and Windows systems.
 * **Open files** on the `Windows` file system from `Ubuntu`.

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -42,29 +42,36 @@ Let’s install [Jupyter notebook](https://jupyter.org/), a web-based interactiv
 
 1. Start our WSL instance, on a terminal, using Ubuntu:
 
-> $ ubuntu.exe
+```{code-block} text
+$ ubuntu.exe
+```
 
 2. Install the python package manager [pip](https://pypi.org/project/pip/):
 
-```
-
+```{code-block} text
 $ sudo apt update
-
 $ sudo apt install python3-pip
-
 ```
 
 3. Get Jupyter notebook installed via pip:
 
-> $ pip install notebook
+```{code-block} text
+$ pip install notebook
+```
 
 ### Executing Jupyter notebook.
 
 Finally, let’s start Jupyter, by adding it to the user PATH first:
 
-```
+```{code-block} text
 $ export PATH=$PATH:~/.local/bin
 $ jupyter notebook --no-browser
+```
+
+This should generate output like the following:
+
+```{code-block} text
+:class: no-copy
 [I 10:52:23.760 NotebookApp] Writing notebook server cookie secret to /home/u/.local/share/jupyter/runtime/notebook_cookie_secret
 [I 10:52:24.205 NotebookApp] Serving notebooks from local directory: /home/u
 [I 10:52:24.205 NotebookApp] Jupyter Notebook 6.4.10 is running at:
@@ -103,17 +110,34 @@ Our next step is to be able to generate some statistics on our Windows user pers
 
 On another terminal, under PowerShell, let’s first check our Windows user profile directory:
 
-```
+```{code-block} text
 PS C:\Users\myuser> echo $env:USERPROFILE
+```
+
+The path will be outputted:
+
+```{code-block} text
+:class: no-copy
 C:\Users\myuser
 ```
 
 Let’s share it with Ubuntu by setting `WSLENV`:
 
-```
+```{code-block} text
 PS C:\Users\myuser> $env:WSLENV="USERPROFILE"
 PS C:\Users\myuser> ubuntu.exe
+```
+
+The last command will start ubuntu where we can test that the variable has been shared:
+
+```{code-block} text
 $ echo $USERPROFILE
+```
+
+Running this command will again show the path:
+
+```{code-block} text
+:class: no-copy
 C:\Users\myuser
 ```
 
@@ -121,8 +145,14 @@ Awesome! Setting `WSLENV="ENVVAR1:ENVVAR2:…"` allows us to share multiple envi
 
 However, you may notice that the environment variable value was shared as is, which is fine in most cases but not for path-related content. Let’s check:
 
-```
+```{code-block} text
 $ ls 'C:\Users\myuser'
+```
+
+This will fail to list any files and output the following message:
+
+```{code-block} text
+:class: no-copy
 ls: cannot access 'C:\Users\myuser': No such file or directory
 ```
 
@@ -132,13 +162,35 @@ Yet we haven’t done all that for nothing! `WSLENV` variable declaration can be
 
 Let’s try again. Run `exit` to shutdown Ubuntu, then in PowerShell set `WSLENV` again using the `/p` suffix then start Ubuntu:
 
-```
-$ exit
+```{code-block} text
+
 PS C:\Users\myuser> $env:WSLENV="USERPROFILE/p"
 PS C:\Users\myuser> ubuntu.exe
+```
+
+Now in Ubuntu test the environmental variable like before:
+
+```{code-block} text
 $ echo $USERPROFILE
+```
+
+The output should show that the path has been translated:
+
+```{code-block} text
+:class: no-copy
 /mnt/c/Users/myuser
+```
+
+Now let's check the Windows files with the Linux `ls` command:
+
+```{code-block} text
 $ ls /mnt/c/Users/myuser
+```
+
+This should now list the files in the directory as expected:
+
+```{code-block} text
+:class: no-copy
 AppData
 'Application Data'
 Contacts
@@ -204,8 +256,14 @@ Let’s execute it by clicking on the “Run” button in the web interface.
 
 Note that while the entry is running, you will have a `In [*]` with the star marker. This will be replaced by `In [1]:` when completed. Once this is completed and the results have been printed, let’s ensure that the CSV file is present on disk using an Ubuntu terminal:
 
-```
+```{code-block} text
 $ cat stats-raw.csv
+```
+
+The output should look like this:
+
+```{code-block} text
+:class: no-copy
 mime_type,count
 text/plain,468
 chemical/x-cerius,3
@@ -240,12 +298,22 @@ Of course, interoperability goes both ways, and we already know exactly how to d
 
 Similarly to `USERPROFILE`, we want, this time, to share the user `HOME` variable with Windows, and let interoperability translate it to a Windows-compatible path. In an Ubuntu terminal set the environment variable, making sure to use the `/p` suffix then open a Windows command prompt:
 
-```
+```{code-block} text
 $ export WSLENV=HOME/p
 $ cmd.exe
+```
+
+We can check if the path has been translated with:
+
+```{code-block} text
 C:\Windows> set HOME
+```
+
+The following output confirms a Windows-compatible path:
+
+```{code-block} text
+:class: no-copy
 HOME=\\wsl.localhost\Ubuntu\home\u
-C:\Windows> exit
 ```
 
 
@@ -261,7 +329,7 @@ Let’s now create a PowerShell script, from Windows, on this Ubuntu filesystem 
 
 You can open any editor, from Notepad to a full-fledged IDE. Create a file named `filter-less-than-five.ps1` under `\\wsl.localhost\Ubuntu\home\<youruser>` (with the following content:
 
-```powershell
+```{code-block} powershell
 $csvImport = $input | ConvertFrom-CSV
 
 # Create Array for Exporting out data
@@ -281,7 +349,7 @@ This script will take a CSV-formatted content as input, filter any item which ha
 
 After saving, let’s check that it’s available on the WSL side:
 
-```
+```{code-block} text
 $ cat filter-less-than-five.ps1
 ```
 
@@ -293,8 +361,14 @@ This PowerShell script, written from Windows on your Linux instance will be quit
 
 This is all very impressive, we have been able to share network, environment variables, paths and files, as well execute processes interchangeably between Ubuntu and Windows. Let’s go one step further by chaining all of this together in a single, but effective line:
 
-```
+```{code-block} text
 $ cat stats-raw.csv | powershell.exe -ExecutionPolicy Bypass -File $HOME/filter-less-than-five.ps1 | tee stats.csv
+```
+
+This yields the output:
+
+```{code-block} text
+:class: no-copy
 "mime_type","count"
 "text/plain","468"
 "application/x-pkcs12","5"
@@ -324,7 +398,7 @@ This deep integration for back-and-forth access between systems allows users to 
 
 Finally, we can even run the default associated GUI Windows application associated with those files, from Ubuntu:
 
-```
+```{code-block} text
 $ explorer.exe stats.csv
 ```
 

--- a/docs/tutorials/vscode.md
+++ b/docs/tutorials/vscode.md
@@ -58,13 +58,13 @@ Once installed we can test it out by creating an example local web server with N
 Open your WSL Ubuntu terminal and ensure everything is up to date by typing:
 
 ```{code-block} text
-sudo apt update
+$ sudo apt update
 ```
 
 Then:
 
 ```{code-block} text
-sudo apt upgrade
+$ sudo apt upgrade
 ```
 
 Entering your password and pressing `Y` when prompted.
@@ -72,8 +72,8 @@ Entering your password and pressing `Y` when prompted.
 Next, install Node.js and npm:
 
 ```{code-block} text
-sudo apt-get install nodejs
-sudo apt install npm
+$ sudo apt-get install nodejs
+$ sudo apt install npm
 ```
 
 Press `Y` when prompted.
@@ -81,19 +81,19 @@ Press `Y` when prompted.
 Now, create a new folder for our server.
 
 ```{code-block} text
-mkdir serverexample/
+$ mkdir serverexample/
 ```
 
 Then navigate into it:
 
 ```{code-block} text
-cd serverexample/
+$ cd serverexample/
 ```
 
 Now, open up your folder in Visual Studio Code, you can do this by typing:
 
 ```{code-block} text
-code .
+$ code .
 ```
 
 The first time you do this, it will trigger a download for the necessary dependencies:
@@ -134,13 +134,13 @@ Add the following text, then save and close:
 Now return to your Ubuntu terminal (or use the Visual Studio Code terminal window) and type the following to install a server defined by the above specifications detailed in `package.json`:
 
 ```{code-block} text
-npm install
+$ npm install
 ```
 
 Finally, type the following to launch the web server:
 
 ```{code-block} text
-npm start
+$ npm start
 ```
 
 You can now navigate to `localhost:10001` in your native Windows web browser by using `CTRL+LeftClick` on the terminal links.

--- a/docs/tutorials/vscode.md
+++ b/docs/tutorials/vscode.md
@@ -11,7 +11,7 @@ The easiest way to access your Ubuntu development environment in WSL is by using
 ## What you will need:
 
 * A PC with Windows 10 or 11
-* (Optional) This tutorial uses [Windows Terminal Preview](https://www.microsoft.com/en-us/p/windows-terminal-preview/9n8g5rfz9xk3?activetab=pivot:overviewtab), which you can get from the Windows app store
+* (Optional) This tutorial uses [Windows Terminal Preview](https://www.microsoft.com/en-us/p/windows-terminal-preview/9n8g5rfz9xk3?activetab=pivot:overviewtab), which you can get from the Microsoft Store
 
 ## Install Ubuntu on WSL2
 
@@ -27,9 +27,9 @@ Once you have completed the relevant tutorial, the following steps will work on 
 
 One of the advantages of WSL is that it can interact with the native Windows version of Visual Studio Code using its remote development extension.
 
-To install Visual Studio Code visit the Microsoft Store and search for `Visual Studio Code`.
+To install Visual Studio Code visit the Microsoft Store and search for Visual Studio Code.
 
-Then click `Install`.
+Then click **Install**.
 
 ![|624x483](assets/vscode/msstore.png)
 
@@ -37,7 +37,7 @@ Alternatively, you can install Visual Studio Code from the web link [here](https
 
 ![|624x353](assets/vscode/download-vs-code.png)
 
-During installation, under the `Additional Tasks` step, ensure the `Add to PATH` option is checked.
+During installation, under the 'Additional Tasks' step, ensure the `Add to PATH` option is checked.
 
 ![|624x492](assets/vscode/aditional-tasks.png)
 
@@ -59,7 +59,7 @@ Open your WSL Ubuntu terminal and ensure everything is up to date by typing:
 
 ` sudo apt update`
 
-And then
+Then:
 
 `sudo apt upgrade`
 
@@ -115,7 +115,7 @@ In Visual Studio Code, create a new file called `package.json` and add the follo
 
 Save the file and then, in the same folder, create a new one called `index.html`
 
-Add the following text, and then save and close:
+Add the following text, then save and close:
 
 `<h1>Hello World</h1>`
 
@@ -127,7 +127,7 @@ Finally, type the following to launch the web server:
 
 `npm start`
 
-You can now navigate to `localhost:10001` in your native Windows web browser by using `CTRL+Left Click` on the terminal links.
+You can now navigate to `localhost:10001` in your native Windows web browser by using `CTRL+LeftClick` on the terminal links.
 
 ![|624x351](assets/vscode/hello-world.png)
 
@@ -137,7 +137,7 @@ By using Ubuntu on WSL you’re able to take advantage of the latest Node.js pac
 
 ## Enjoy Ubuntu on WSL!
 
-That’s all folks! In this tutorial, we’ve shown you how to connect the Windows version of Visual Studio Code to your Ubuntu on WSL filesystem and launch a basic Node.js webserver.
+In this tutorial, we’ve shown you how to connect the Windows version of Visual Studio Code to your Ubuntu on WSL filesystem and launch a basic Node.js webserver.
 
 We hope you enjoy using Ubuntu inside WSL. Don’t forget to check out our other tutorials for tips on how to optimise your WSL setup for Data Science.
 

--- a/docs/tutorials/vscode.md
+++ b/docs/tutorials/vscode.md
@@ -57,33 +57,44 @@ Once installed we can test it out by creating an example local web server with N
 
 Open your WSL Ubuntu terminal and ensure everything is up to date by typing:
 
-` sudo apt update`
+```{code-block} text
+sudo apt update
+```
 
 Then:
 
-`sudo apt upgrade`
+```{code-block} text
+sudo apt upgrade
+```
 
 Entering your password and pressing `Y` when prompted.
 
 Next, install Node.js and npm:
 
-    sudo apt-get install nodejs
-
-    sudo apt install npm
+```{code-block} text
+sudo apt-get install nodejs
+sudo apt install npm
+```
 
 Press `Y` when prompted.
 
 Now, create a new folder for our server.
 
-`mkdir serverexample/`
+```{code-block} text
+mkdir serverexample/
+```
 
 Then navigate into it:
 
-`cd serverexample/`
+```{code-block} text
+cd serverexample/
+```
 
 Now, open up your folder in Visual Studio Code, you can do this by typing:
 
-`code .`
+```{code-block} text
+code .
+```
 
 The first time you do this, it will trigger a download for the necessary dependencies:
 
@@ -95,8 +106,7 @@ Once complete, your native version of Visual Studio Code will open the folder.
 
 In Visual Studio Code, create a new file called `package.json` and add the following text ([original example](https://learn.microsoft.com/en-gb/archive/blogs/cdndevs/visual-studio-code-and-local-web-server#3-add-a-packagejson-file-to-the-project-folder))
 
-```json
-
+```{code-block} json
 {
     "name": "Demo",
     "version": "1.0.0",
@@ -117,15 +127,21 @@ Save the file and then, in the same folder, create a new one called `index.html`
 
 Add the following text, then save and close:
 
-`<h1>Hello World</h1>`
+```{code-block} html
+<h1>Hello World</h1>
+```
 
 Now return to your Ubuntu terminal (or use the Visual Studio Code terminal window) and type the following to install a server defined by the above specifications detailed in `package.json`:
 
-`npm install`
+```{code-block} text
+npm install
+```
 
 Finally, type the following to launch the web server:
 
-`npm start`
+```{code-block} text
+npm start
+```
 
 You can now navigate to `localhost:10001` in your native Windows web browser by using `CTRL+LeftClick` on the terminal links.
 


### PR DESCRIPTION
This PR improves the consistency and functionality of code blocks in the docs.

The main changes are:

- Addition of a CSS selector that allows copy buttons to be deactivated in code-blocks. This is especially useful for code blocks that contain output.

A code block with the regular behaviour is written:

\```{code-block) text
PS C:\Users\myuser> echo $env:USERPROFILE
\```

Result (note the button on cursor hover): 

![codeblock-regular-behaviour](https://github.com/ubuntu/WSL/assets/66971213/6eed284a-c5ee-4bc2-8985-bb59cabf0b40)

If we do not want the copy button, we write:

\```{code-block) text
:class: no-copy
C:\Users\myuser
\```

Result (note the lack of button on cursor hover):

![output-no-copybtn](https://github.com/ubuntu/WSL/assets/66971213/ae4cffe7-16a0-4e9a-9bde-aca0e240475a)

- Addition of regex-based solution to prevent copy/pasting of command prompts. This ensures that the prompt and any text preceding the prompt is not copied when a user clicks the copy button. This is done automatically for any code block marked with the {code-block} directive.

The example below shows two lines with complex prompts and a symbol sometimes used as a prompt ($) in the commands (top). After the copy button is clicked, only the relevant information is pasted into the text editor (bottom). This means that users can more easily and quickly copy commands from the docs:

![prompt-paste-nocopy](https://github.com/ubuntu/WSL/assets/66971213/e0ccfcd5-dd85-4107-ac0c-d32f7d15ab72)

Other minor changes:

- Explicit use of code block directive in markup.
- Replacement of blockquotes and other unconventional methods of code markup.
- Where possible, separation of input and output, using text to explain which is which.
- Prefer no syntax highlighting for terminal commands.
- Delete any image that duplicates content in code blocks.
- Some minor fixes to style and wording.

UDENG-3441