### PR TITLE
fix: No candidate default user is "normal"

### DIFF
--- a/DistroLauncher/Ubuntu/InitTasks.cpp
+++ b/DistroLauncher/Ubuntu/InitTasks.cpp
@@ -139,7 +139,6 @@ bool enforceDefaultUser(WslApiLoader& api) try {
     return setDefaultUserViaWslApi(api, found->uid);
   }
 
-  _putws(L"ERROR: no candidate default user was found\n");
   return false;
 } catch (const std::exception& err) {
   _putws(L"ERROR: Unexpected failure when enforcing the default user: ");


### PR DESCRIPTION
No reason for printing an error message.
That's too dramatic for an unsurprising situation.