### PR TITLE
docs: Add check for vocab files to Vale config

### DIFF
--- a/docs/.sphinx/get_vale_conf.py
+++ b/docs/.sphinx/get_vale_conf.py
@@ -20,6 +20,19 @@ def main():
         file.write(download.text)
         file.close()
 
+    if os.path.exists(f"{DIR}/.sphinx/styles/config/vocabularies/Canonical"):
+        print("Vocab directory exists")
+    else:
+        os.makedirs(f"{DIR}/.sphinx/styles/config/vocabularies/Canonical")
+    
+    url = "https://api.github.com/repos/canonical/praecepta/contents/styles/config/vocabularies/Canonical"
+    r = requests.get(url)
+    for item in r.json():
+        download = requests.get(item["download_url"])
+        file = open(".sphinx/styles/config/vocabularies/Canonical/" + item["name"], "w")
+        file.write(download.text)
+        file.close()
+
     config = requests.get("https://raw.githubusercontent.com/canonical/praecepta/main/vale.ini")
     file = open(".sphinx/vale.ini", "w")
     file.write(config.text)


### PR DESCRIPTION
Updates the configuration settings for the [Vale](https://vale.sh/) linter, based on recent changes to the docs Starter Pack.

Vale can now be invoked successfully with `make vale`, which will generate errors, warnings and suggestions based on documentation style.

UDENG-3785