### PR TITLE
docs: Add alt text for images

### DIFF
--- a/docs/guides/install-ubuntu-wsl2.md
+++ b/docs/guides/install-ubuntu-wsl2.md
@@ -31,11 +31,11 @@ There are multiple ways of installing distros on WSL, here we show three: Micros
 
 Find the distribution you prefer on the Microsoft Store and then click **Get**. 
 
-![|624x489](assets/install-ubuntu-wsl2/choose-distribution.png)
+![Installation page for Ubuntu 24.04 LTS in the Microsoft store.](assets/install-ubuntu-wsl2/choose-distribution.png)
 
 Ubuntu will then be installed on your machine. Once installed, you can either launch the application directly from the Microsoft Store or search for Ubuntu in your Windows search bar.
 
-![|624x580](assets/install-ubuntu-wsl2/search-ubuntu-windows.png)
+![Search results for Ubuntu 24.04 LTS in Windows search bar.](assets/install-ubuntu-wsl2/search-ubuntu-windows.png)
 
 ### Method 2: WSL commands
 

--- a/docs/tutorials/data-science-and-engineering.md
+++ b/docs/tutorials/data-science-and-engineering.md
@@ -26,7 +26,7 @@ $ octave --gui &
 
 Do not forget the ampersand `&` at the end of the line, so the application is started in the background and we can continue using the same terminal window.
 
-![|624x373](assets/data-science-engineering/octave.png)
+![Octave graphical interface running after the "octave" command was run with the gui flag in WSL.](assets/data-science-engineering/octave.png)
 
 In Octave, click on the `New script` icon to open a new editor window and copy/paste the following code:
 
@@ -75,11 +75,11 @@ Save it to a file named `juliatest.m`.
 
 And finally, press the button **Save File and Run**.
 
-![|570x225](assets/data-science-engineering/save-file.png)
+![Octave graphical interface showing the "Save and Run button" for the julia test file.](assets/data-science-engineering/save-file.png)
 
 After a few seconds, depending on your hardware and the parameters, a Julia fractal is displayed.
 
-![|579x540](assets/data-science-engineering/julia-fractal.png)
+![Visualisation of a julia fractal.](assets/data-science-engineering/julia-fractal.png)
 
 Like Octave, this window is displayed using WSLg completely transparently to the user.
 

--- a/docs/tutorials/dotnet-systemd.md
+++ b/docs/tutorials/dotnet-systemd.md
@@ -84,7 +84,7 @@ $ dotnet new --list
 
 You should be able to find the `Bot Framework Echo Bot` template in the list.
 
-![|624x153](assets/dotnet-systemd/templates.png)
+![Selecting "Bot Framework Echo Bot" from Dotnet templates in a terminal.](assets/dotnet-systemd/templates.png)
 
 Create a new Echo Bot project, with `echoes` as the name for our bot, using the following command:
 
@@ -106,11 +106,11 @@ $ sudo dotnet run
 
 If everything was set up correctly you should see a similar output to the one below:
 
-![|624x357](assets/dotnet-systemd/welcome-to-dotnet.png)
+![Bash snippets confirming that Echo bot was installed and set up correctly.](assets/dotnet-systemd/welcome-to-dotnet.png)
 
 Leave the EchoBot App running in WSL for now. Open a new browser window on your Windows host and navigate to `localhost:3978` where you should see the following window:
 
-![|624x347](assets/dotnet-systemd/your-bot-is-ready.png)
+![Windows desktop showing the Echo bot app running in a browser on local host.](assets/dotnet-systemd/your-bot-is-ready.png)
 
 Leave everything running as we move to the next step.
 
@@ -120,15 +120,15 @@ Download the Bot Emulator from the official [Microsoft GitHub](https://github.co
 
 Running it will present you with the following screen, but before you can connect to your bot you need to change a few settings.
 
-![|624x411](assets/dotnet-systemd/bot-framework-emulator.png)
+![Bot Framework Emulator homepage.](assets/dotnet-systemd/bot-framework-emulator.png)
 
 First, get the IP address of your machine by running `ipconfig` in a PowerShell terminal.
 
-![|624x357](assets/dotnet-systemd/ipconfig.png)
+![Output of the "ipconfig" command showing network adapter details, including IPv4 addresses for Wi-Fi and WSL.](assets/dotnet-systemd/ipconfig.png)
 
 Then select the settings icon in the bottom-left corner of the Bot Framework Emulator and enter your IP under ‘localhost override'.
 
-![|624x411](assets/dotnet-systemd/emulator-settings.png)
+![Bot Emulator settings page.](assets/dotnet-systemd/emulator-settings.png)
 
 Click **Save** and navigate back to the Welcome tab.
 
@@ -138,11 +138,11 @@ Click **Open Bot** and under ‘Bot URL’ input:
 http://localhost:3978/api/messages
 ```
 
-![|624x411](assets/dotnet-systemd/open-a-bot.png)
+!["Open a bot" dialog.](assets/dotnet-systemd/open-a-bot.png)
 
 And click **Connect** to connect to your Echo Bot running in WSL and start chatting!
 
-![|624x411](assets/dotnet-systemd/start-chatting.png)
+![Live chat with Echo bot.](assets/dotnet-systemd/start-chatting.png)
 
 Congratulations, your Echo Chat Bot App is running on Ubuntu WSL as an App. Now it is time to make it run as a service.
 
@@ -164,7 +164,7 @@ $ code .
 
 Navigate to ‘Program.cs’ and insert `.UseSystemd()` as a new line in the location shown in the screenshot.
 
-![|624x381](assets/dotnet-systemd/program-cs.png)
+![The method for using systemd being added to line 21 of the file.](assets/dotnet-systemd/program-cs.png)
 
 Save and close the project in VS Code and return to your WSL terminal.
 
@@ -204,7 +204,7 @@ $ systemctl status echoes.service
 
 You should get the following output:
 
-![|624x77](assets/dotnet-systemd/systemctl-status-inactive.png)
+![Results of running "systemctl status echoes.service" in the terminal.](assets/dotnet-systemd/systemctl-status-inactive.png)
 
 Now start your service:
 
@@ -220,11 +220,11 @@ $ sudo systemctl status echoes.service
 
 If everything has been configured correctly you should get an output similar to the below.
 
-![|624x401](assets/dotnet-systemd/systemctl-status-running.png)
+![Results of running "sudo systemctl" in the terminal.](assets/dotnet-systemd/systemctl-status-running.png)
 
 Return to your Windows host and reconnect to your Bot Emulator using the same information as before and confirm that your bot is running, but this time as a systemd service!
 
-![|624x411](assets/dotnet-systemd/start-chatting-service.png)
+![Live chat with Echo bot.](assets/dotnet-systemd/start-chatting-service.png)
 
 You can stop your bot from running at any time with the command:
 

--- a/docs/tutorials/gpu-cuda.md
+++ b/docs/tutorials/gpu-cuda.md
@@ -35,37 +35,37 @@ Make sure the following prerequisites are met before moving forward:
 
 Please refer to the official [WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps) for up-to-date links matching your specific GPU vendor. You can find these in `Install support for Linux GUI apps > Prerequisites` . For this example, we will download the `NVIDIA GPU Driver for WSL`.
 
-![|624x283](assets/gpu-cuda/install-drivers.png)
+![Install support for Linux GUI apps page on Microsoft WSL documentation.](assets/gpu-cuda/install-drivers.png)
 
 > ⓘ **Note:** This is the only device driver you’ll need to install. Do not install any display driver on Ubuntu.
 
 Once downloaded, double-click on the executable file and click `Yes` to allow the program to make changes to your computer.
 
-![|624x136](assets/gpu-cuda/downloads-folder.png)
+![Windows file explorer showing the downloaded NVIDIA GPU driver for WSL.](assets/gpu-cuda/downloads-folder.png)
 
-![|358x312](assets/gpu-cuda/nvidia-allow-changes.png)
+![Windows Package Installer confirmation page for NVIDIA Package Launcher.](assets/gpu-cuda/nvidia-allow-changes.png)
 
 Confirm the default directory and allow the self-extraction process to proceed.
 
-![|369x175](assets/gpu-cuda/default-dir.png)
+![Default directory confirmation page for NVIDIA Display Driver.](assets/gpu-cuda/default-dir.png)
 
-![|368x168](assets/gpu-cuda/please-wait-install.png)
+![NVIDIA Display Driver installation progress screen.](assets/gpu-cuda/please-wait-install.png)
 
 A splash screen appears with the driver version number and quickly turns into the main installer window. Read and accept the license terms to continue.
 
-![|541x276](assets/gpu-cuda/splash-screen.png)
+![NVIDIA Graphics Driver startup page.](assets/gpu-cuda/splash-screen.png)
 
-![|542x412](assets/gpu-cuda/license.png)
+![NVIDIA software license agreement.](assets/gpu-cuda/license.png)
 
 Confirm the wizard defaults by clicking `Next` and wait until the end of the installation. You might be prompted to restart your computer.
 
-![|536x397](assets/gpu-cuda/installation-options.png)
+![NVIDIA Graphics Driver installation options with "Express" checked.](assets/gpu-cuda/installation-options.png)
 
-![|542x404](assets/gpu-cuda/installing.png)
+![NVIDIA Virtual Host controller installation progress.](assets/gpu-cuda/installing.png)
 
 This step ends with a screen similar to the image below.
 
-![|544x406](assets/gpu-cuda/install-finished.png)
+![NVIDIA Graphics Driver installation success page.](assets/gpu-cuda/install-finished.png)
 
 ## Install NVIDIA CUDA on Ubuntu
 
@@ -95,7 +95,7 @@ $ sudo apt-get -y install cuda
 
 Once complete, you should see a series of outputs that end in `done.`:
 
-![|544x559](assets/gpu-cuda/done-done.png)
+![Terminal output showing successful installation of NVIDIA CUDA toolkit on Ubuntu.](assets/gpu-cuda/done-done.png)
 
 Congratulations! You should have a working installation of CUDA by now. Let’s test it in the next step.
 
@@ -119,7 +119,7 @@ $ make
 
 A successful build will look like the screenshot below.
 
-![|624x135](assets/gpu-cuda/make.png)
+![Terminal output showing the successful compilation of a CUDA sample application.](assets/gpu-cuda/make.png)
 
 Once complete, run the application with:
 
@@ -129,7 +129,7 @@ $ ./deviceQuery
 
 You should see a similar output to the following detailing the functionality of your CUDA setup (the exact results depend on your hardware setup):
 
-![|548x599](assets/gpu-cuda/device-query.png)
+![Terminal output showing the results of running the device query sample application.](assets/gpu-cuda/device-query.png)
 
 ## Enjoy Ubuntu on WSL!
 

--- a/docs/tutorials/interop.md
+++ b/docs/tutorials/interop.md
@@ -98,7 +98,7 @@ However, this tutorial is not about running Linux GUI applications from WSL (whi
 
 Let’s try this right away: from Windows, launch a web browser and enter the `URL printed above` with the corresponding token, for example: `http://localhost:8888/?token=1d80ee69da6238f22bb683a4acd00025d32d15dde91cbdf4`.
 
-![|624x347](assets/interop/jupyter.png)
+![Jupyter Notebook running in a web browser on local host, showing an empty notebook list.](assets/interop/jupyter.png)
 
 It works! You can thus easily expose and share any services that are using network ports between your Windows machine and WSL instances!
 
@@ -218,7 +218,7 @@ Some preliminary warnings: accessing Windows filesystem from Ubuntu is using the
 
 From the main screen of Jupyter, create a new notebook to start developing an interactive Python solution. You can do this by clicking on the **New** button, and then clicking on the **Python 3** option, as we can see below.
 
-![Jupyter Notebook: A Beginner's Tutorial|624x251](assets/interop/jupyter-python.jpg)
+![Jupyter interface showing the creation of a new Python 3 notebook. The "New" button is clicked, revealing a dropdown menu with "Python 3" highlighted.](assets/interop/jupyter-python.jpg)
 
 Copy this to the first cell, taking care to edit the input directory:
 
@@ -252,7 +252,7 @@ This script will enumerate all files under `/mnt/c/Users/mysuser/path/my/subdire
 
 Let’s execute it by clicking on the “Run” button in the web interface.
 
-![|624x469](assets/interop/jupyter-script.png)
+![Python script in a Jupyter notebook.](assets/interop/jupyter-script.png)
 
 Note that while the entry is running, you will have a `In [*]` with the star marker. This will be replaced by `In [1]:` when completed. Once this is completed and the results have been printed, let’s ensure that the CSV file is present on disk using an Ubuntu terminal:
 
@@ -323,7 +323,7 @@ First, we are able to export the `HOME` variable to subprocess, telling us that 
 
 Open Windows Explorer and navigate to that path to confirm they are visible there:
 
-![|624x352](assets/interop/ubuntu-home.png)
+![Screenshot of Windows file explorer containing the stats-raw csv file.](assets/interop/ubuntu-home.png)
 
 Let’s now create a PowerShell script, from Windows, on this Ubuntu filesystem and save it there:
 
@@ -406,7 +406,7 @@ Note: You can’t deny it’s really amazing to be able to execute explorer.exe 
 
 This will open LibreOffice, Microsoft Excel, or any other tool you may have associated with CSV files. From there, you will be able to draw beautiful charts and do data analysis, but that’s another story…
 
-![|624x389](assets/interop/spreadsheet.png)
+![Windows desktop showing the PowerShell terminal and data visualizations for file statistics in LibreOffice Calc.](assets/interop/spreadsheet.png)
 
 ## Enjoy Ubuntu on WSL!
 

--- a/docs/tutorials/vscode.md
+++ b/docs/tutorials/vscode.md
@@ -31,15 +31,15 @@ To install Visual Studio Code visit the Microsoft Store and search for Visual St
 
 Then click **Install**.
 
-![|624x483](assets/vscode/msstore.png)
+![Installation page for Visual Studio Code on the Microsoft Store.](assets/vscode/msstore.png)
 
 Alternatively, you can install Visual Studio Code from the web link [here](https://code.visualstudio.com/Download).
 
-![|624x353](assets/vscode/download-vs-code.png)
+![Visual Studio Code download page showing download options for Windows, Linux, and Mac.](assets/vscode/download-vs-code.png)
 
 During installation, under the 'Additional Tasks' step, ensure the `Add to PATH` option is checked.
 
-![|624x492](assets/vscode/aditional-tasks.png)
+![Visual Studio Code's "Additional Tasks" setup dialog with the "Add to Path" and "Register Code as an editor for supported file types" options checked.](assets/vscode/aditional-tasks.png)
 
 Once the installation is complete, open Visual Studio Code.
 
@@ -49,7 +49,7 @@ Navigate to the `Extensions` menu in the sidebar and search for `Remote Developm
 
 This is an extension pack that allows you to open any folder in a container, remote machine, or in WSL. Alternatively, you can just install `Remote - WSL`.
 
-![|624x469](assets/vscode/remote-extension.png)
+![Installation page for the Remote Development Visual Studio Code extension.](assets/vscode/remote-extension.png)
 
 Once installed we can test it out by creating an example local web server with Node.js
 
@@ -98,7 +98,7 @@ $ code .
 
 The first time you do this, it will trigger a download for the necessary dependencies:
 
-![|624x321](assets/vscode/downloading-vscode-server.png)
+![Bash snippet showing the installation of Visual Studio Code Server's required dependencies.](assets/vscode/downloading-vscode-server.png)
 
 Once complete, your native version of Visual Studio Code will open the folder.
 
@@ -145,7 +145,7 @@ $ npm start
 
 You can now navigate to `localhost:10001` in your native Windows web browser by using `CTRL+LeftClick` on the terminal links.
 
-![|624x351](assets/vscode/hello-world.png)
+![Windows desktop showing a web server being run from a terminal with "npm start", A Visual Studio Code project with a "hello world" html file, and a web browser showing the "hello world" page being served on local host.](assets/vscode/hello-world.png)
 
 That’s it!
 


### PR DESCRIPTION
Images previously had no alt text, which is an accessibility issue.
This adds alt text to all images in the documentation.

Special thanks to @davidekete for collaborating with the Ubuntu WSL team through the Canonical Documentation Academy and writing appropriate and effective alt the text for the images.

[See the original Open Documentation Academy PR here.](https://github.com/canonical/open-documentation-academy/pull/124)

UDENG-3784