### PR TITLE
e2e: add smoke test for running snaps

### DIFF
--- a/e2e/launchertester/basic_setup_test.go
+++ b/e2e/launchertester/basic_setup_test.go
@@ -32,6 +32,7 @@ func TestBasicSetup(t *testing.T) {
 		"UpgradePolicyIdempotent": testUpgradePolicyIdempotent,
 		"InteropIsEnabled":        testInteropIsEnabled,
 		"HelpFlag":                testHelpFlag,
+		"SnapdWorks":              testSnapdWorks,
 	}
 
 	for name, tc := range testCases {

--- a/e2e/launchertester/test_cases.go
+++ b/e2e/launchertester/test_cases.go
@@ -150,6 +150,19 @@ func testInteropIsEnabled(t *testing.T) { //nolint: thelper, this is a test
 	require.Equal(t, "Hello, world!\r\n", string(got), "Unexpected output from powershell")
 }
 
+func testSnapdWorks(t *testing.T) { //nolint: thelper, this is a test
+	ctx, cancel := context.WithTimeout(context.Background(), systemdBootTimeout)
+	defer cancel()
+
+	installOut, err := launcherCommand(ctx, "run", "snap", "install", "hello").CombinedOutput()
+	require.NoError(t, err, "Failed to execute snap install hello: %s", installOut)
+
+	runOut, err := launcherCommand(ctx, "run", "snap", "run", "hello").CombinedOutput()
+	require.NoError(t, err, "Failed to execute snap run hello: %s", runOut)
+
+	require.Equal(t, string(runOut), "Hello, World!", "Unexpected output from hello snap")
+}
+
 func testHelpFlag(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), systemdBootTimeout)
 	defer cancel()


### PR DESCRIPTION
As a part of cross-distro effort, we are trying to make sure that snapd works well in WSL environments. We now have WSL-specific release tests that check new snapd releases in Ubuntu 22.04 and Ubuntu 24.04 as running inside WSL. We want to complement this with a small smoke test that ensures subsequent WSL releases do not regress running snapd.

The test itself installs the hello snap from the store and runs it.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-24157