### PR TITLE
docs: Remove autoinstall doc

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -134,8 +134,9 @@ slug = ""
 # (see https://docs.readthedocs.io/en/stable/guides/redirects.html).
 # NOTE: If this variable is not defined, set to None, or the dictionary is empty,
 # the sphinx_reredirects extension will be disabled.
-redirects = {}
-
+redirects = {
+   'guides/autoinstall': '../../tutorials/cloud-init',
+}
 ############################################################
 ### Link checker exceptions
 ############################################################

--- a/docs/guides/autoinstall.md
+++ b/docs/guides/autoinstall.md
@@ -1,8 +1,0 @@
-# Using the Auto-installation feature
-
-```{warning}
-This feature has been deprecated and is no longer supported. Stay tuned for upcoming support for Cloud-init.
-```
-```{note}
-See more: [Cloud init | Home](https://cloud-init.io/)
-```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,7 +6,6 @@
 :titlesonly:
 
 install-ubuntu-wsl2
-autoinstall
 run-workflows-azure
 contributing
 ```


### PR DESCRIPTION
This removes documentation of the autoinstall feature (deprecated) and redirects the old url for autoinstall to the cloud-init doc. Follow up to discussion in #500 .