### PR TITLE
feat(wsl-checkout): Add support for checking out a private repository into WSL

### DIFF
--- a/.github/actions/wsl-checkout/action.yaml
+++ b/.github/actions/wsl-checkout/action.yaml
@@ -1,5 +1,5 @@
 name: Azure WSL repo clone
-description: 'Clones your repo into WSL.'
+description: "Clones your repo into WSL."
 
 inputs:
   distro:
@@ -13,9 +13,13 @@ inputs:
     description: Whether to fetch submodules or not
     required: false
     default: "false"
+  token:
+    description: GitHub access token used to fetch the repository. This is required for checking out private repositories. The token will persist in the git config of the checked out repository and is not cleaned up automatically.
+    required: false
+    default: ""
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Clone repo
       uses: ubuntu/WSL/.github/actions/wsl-bash@main
@@ -27,7 +31,12 @@ runs:
           export GIT_TERMINAL_PROMPT=0
 
           mkdir -p ${{ inputs.working-dir }}
-          git clone --quiet --depth 1 https://github.com/${{ github.repository }}.git ${{ inputs.working-dir }}
+
+          CLONE_URL="https://github.com/${{ github.repository }}.git"
+          if [ -n "${{ inputs.token }}" ] ; then
+              CLONE_URL="https://x-access-token:${{ inputs.token }}@github.com/${{ github.repository }}.git"
+          fi
+          git clone --quiet --depth 1 "$CLONE_URL" ${{ inputs.working-dir }}
 
           cd ${{ inputs.working-dir }}
           git fetch --quiet --depth 1 --no-tags --prune --update-head-ok origin +${{ github.sha }}:${{ github.ref }}


### PR DESCRIPTION
This PR adds support for checkout out a private repository into WSL by utilizing a GitHub token.

Note that the token persists in the git config even after the action completes. Since we aren't using a JavaScript action, we don't have the ability to cleanup the token in the git configuration at the end. Additionally, clearing the git configuration at the end of the main action would cause a change in behavior down the road between private and public repositories at best, and a breaking behavior change at worst. Thus, we only just warn the user in the description, and by default not use any token at all.

As a consequence, one should only be using this feature in tightly controlled environments such as self-hosted runners and should also use scoped permissions. Presently, the existing e2e tests only handle the non-token case for this reason.

Realistically, we should probably overhaul many of these actions to be more robust at some point.