### PR TITLE
maint(ci): Disable scheduled workflow runs

### DIFF
--- a/.github/workflows/build-wsl.yaml
+++ b/.github/workflows/build-wsl.yaml
@@ -18,8 +18,6 @@ on:
         description: 'Should we upload the appxbundle to the store'
         required: true
         default: 'yes'
-  schedule:
-    - cron: '0 10 * * *'
 
 env:
   goversion: '1.21.4'

--- a/.github/workflows/detect-update-releases.yaml
+++ b/.github/workflows/detect-update-releases.yaml
@@ -10,8 +10,6 @@ on:
       - 'DistroLauncher-Appx/**'
       - '.github/workflows/detect-update-releases.yaml'
       - 'wsl-builder/**'
-  schedule:
-    - cron: '42 0 * * 6'
 
 env:
   goversion: '1.21.4'


### PR DESCRIPTION
As we're focused on the tar-based format, there are issues with the scheduled jobs we cannot address now.
Let's disable them for good.