### PR TITLE
feat: Update Windows Terminal profile fragment

### DIFF
--- a/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -18,11 +18,10 @@
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +29,50 @@
       {
         "name": "UbuntuDev.WslID.Dev-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "UbuntuDev.WslID.Dev-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }

--- a/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,9 +11,7 @@
         "colorScheme": "UbuntuDev.WslID.Dev-ColorScheme",
         "commandline": "UbuntuDev.LauncherName.Dev.exe",
         "tabTitle": "UbuntuDev.FullName.Dev",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store

--- a/meta/Ubuntu/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,18 +11,15 @@
         "colorScheme": "Ubuntu-ColorScheme",
         "commandline": "ubuntu.exe",
         "tabTitle": "Ubuntu",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +27,50 @@
       {
         "name": "Ubuntu-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "Ubuntu-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }

--- a/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu18.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,18 +11,15 @@
         "colorScheme": "Ubuntu-18.04-ColorScheme",
         "commandline": "ubuntu1804.exe",
         "tabTitle": "Ubuntu 18.04.6 LTS",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +27,50 @@
       {
         "name": "Ubuntu-18.04-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "Ubuntu-18.04-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }

--- a/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu20.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,18 +11,15 @@
         "colorScheme": "Ubuntu-20.04-ColorScheme",
         "commandline": "ubuntu2004.exe",
         "tabTitle": "Ubuntu 20.04.6 LTS",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +27,50 @@
       {
         "name": "Ubuntu-20.04-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "Ubuntu-20.04-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }

--- a/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu22.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,18 +11,15 @@
         "colorScheme": "Ubuntu-22.04-ColorScheme",
         "commandline": "ubuntu2204.exe",
         "tabTitle": "Ubuntu 22.04.5 LTS",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +27,50 @@
       {
         "name": "Ubuntu-22.04-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "Ubuntu-22.04-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }

--- a/meta/Ubuntu24.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu24.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,18 +11,15 @@
         "colorScheme": "Ubuntu-24.04-ColorScheme",
         "commandline": "ubuntu2404.exe",
         "tabTitle": "Ubuntu 24.04.4 LTS",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +27,50 @@
       {
         "name": "Ubuntu-24.04-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "Ubuntu-24.04-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }

--- a/meta/Ubuntu26.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/Ubuntu26.04LTS/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,18 +11,15 @@
         "colorScheme": "Ubuntu-26.04-ColorScheme",
         "commandline": "ubuntu2604.exe",
         "tabTitle": "Ubuntu 26.04.1 LTS",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +27,50 @@
       {
         "name": "Ubuntu-26.04-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "Ubuntu-26.04-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }

--- a/meta/UbuntuPreview/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
+++ b/meta/UbuntuPreview/generated/DistroLauncher-Appx/Terminal/Fragments/terminal.json
@@ -11,18 +11,15 @@
         "colorScheme": "Ubuntu-Preview-ColorScheme",
         "commandline": "ubuntupreview.exe",
         "tabTitle": "Ubuntu (Preview)",
-        // This would be the idea once https://github.com/microsoft/terminal/issues/10359 is fixed.
-        // "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
-        "icon": "https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png",
+        "icon": "ms-appx:///Assets/Square44x44Logo.targetsize-32.png",
         "cursorShape": "filledBox",
         "font": {
           // Not possible right now as we have multiple appx which could ship it and needs a store
           // permission: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-extensions#share-fonts-with-other-windows-applications
-          // Also, referencing it if it does not exist will show an error message when opening
-          // the profile.
-          //"face": "Ubuntu Mono",
+          // Also, referencing it if it does not exist will show an error message when opening the app.
+          //"face": "Ubuntu Sans Mono",
           "face": "Cascadia Mono",
-          "size": 13
+          "size": 12
         }
       }
     ],
@@ -30,26 +27,50 @@
       {
         "name": "Ubuntu-Preview-ColorScheme",
 
-        "background": "#300A24",
-        "black": "#171421",
-        "blue": "#0037DA",
-        "brightBlack": "#767676",
-        "brightBlue": "#08458F",
-        "brightCyan": "#2C9FB3",
-        "brightGreen": "#26A269",
-        "brightPurple": "#A347BA",
-        "brightRed": "#C01C28",
-        "brightWhite": "#F2F2F2",
-        "brightYellow": "#A2734C",
-        "cursorColor": "#FFFFFF",
-        "cyan": "#3A96DD",
-        "foreground": "#FFFFFF",
-        "green": "#26A269",
-        "purple": "#881798",
-        "red": "#C21A23",
-        "selectionBackground": "#FFFFFF",
-        "white": "#CCCCCC",
-        "yellow": "#A2734C"
+	"background": "#300A24",
+	"black": "#1B1B1B",
+	"blue": "#3667A6",
+	"brightBlack": "#838383",
+	"brightBlue": "#729FCF",
+	"brightCyan": "#34E2E2",
+	"brightGreen": "#8AE234",
+	"brightPurple": "#AD7FA8",
+	"brightRed": "#F93632",
+	"brightWhite": "#EEEEEC",
+	"brightYellow": "#FCE94F",
+	"cursorColor": "#FFFFFF",
+	"cyan": "#06989A",
+	"foreground": "#FFFFFF",
+	"green": "#4E9A06",
+	"purple": "#7F5985",
+	"red": "#CC1A12",
+	"selectionBackground": "#FFFFFF",
+	"white": "#D5D5D5",
+	"yellow": "#C4A000"
+      },
+      {
+        "name": "Ubuntu-Preview-Light-ColorScheme",
+
+	"background": "#F8F8F8",
+	"black": "#F2F2F2",
+	"blue": "#5B91D7",
+	"brightBlack": "#707070",
+	"brightBlue": "#395E86",
+	"brightCyan": "#064141",
+	"brightGreen": "#26420C",
+	"brightPurple": "#80577C",
+	"brightRed": "#CE191C",
+	"brightWhite": "#212121",
+	"brightYellow": "#80721B",
+	"cursorColor": "#121212",
+	"cyan": "#047B7D",
+	"foreground": "#121212",
+	"green": "#3F7E04",
+	"purple": "#A77DAD",
+	"red": "#F93B2E",
+	"selectionBackground": "#000000",
+	"white": "#1B1B1B",
+	"yellow": "#A88F00"
       }
     ]
   }


### PR DESCRIPTION
To get in sync with https://github.com/ubuntu/wsl-setup/pull/49, including a light theme.
We still cannot ship fonts in packaged apps, though.
Also in recent versions of the Windows Terminal the asset icon is not being loaded from the web.
But the issue mentioned in the comments is fixed since late 2025, so we can confidently point to the icon present in the package itself.

---

UDENG-10627