### PR TITLE
Skip update assets for other appx's

### DIFF
--- a/.github/workflows/detect-update-releases.yaml
+++ b/.github/workflows/detect-update-releases.yaml
@@ -10,6 +10,8 @@ on:
       - 'DistroLauncher-Appx/**'
       - '.github/workflows/detect-update-releases.yaml'
       - 'wsl-builder/**'
+  schedule:
+    - cron: '42 0 * * 6'
 
 jobs:
   update-releases:

--- a/wsl-builder/prepare-assets/assets.go
+++ b/wsl-builder/prepare-assets/assets.go
@@ -61,8 +61,11 @@ func updateAssets(csvPath string) error {
 		return err
 	}
 
-	// Update each application
+	// Update only the 'default' application
 	for _, r := range releasesInfo {
+		if r.AppID != "Ubuntu" {
+			continue
+		}
 		wslPath := filepath.Join(metaPath, r.AppID)
 		generatedPath := filepath.Join(wslPath, common.GeneratedDir)
 


### PR DESCRIPTION
Only update the default Ubuntu appx build files.
Now we can restore the cron job that detects and updates release assets.

---
UDENG-10634